### PR TITLE
Scaffold vp-dev framework + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm run typecheck
+
+      - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@ dist/
 *.log
 .DS_Store
 
-state/
-agents/
-logs/
+/state/
+/agents/
+/logs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+dist/
+*.log
+.DS_Store
+
+state/
+agents/
+logs/

--- a/bin/vp-dev.ts
+++ b/bin/vp-dev.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+import { buildCli } from "../src/cli.js";
+
+const program = buildCli();
+program.parseAsync(process.argv).catch((err) => {
+  console.error(err instanceof Error ? err.stack ?? err.message : String(err));
+  process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1368 @@
+{
+  "name": "vaultpilot-development-agents",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vaultpilot-development-agents",
+      "version": "0.1.0",
+      "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.2.123",
+        "commander": "^12.1.0",
+        "zod": "^4.0.0"
+      },
+      "bin": {
+        "vp-dev": "dist/bin/vp-dev.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.14.0",
+        "typescript": "^5.5.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.2.123",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.123.tgz",
+      "integrity": "sha512-a4TysYoR9DBdkM9Uwh4J5ub7TwKmRPe5hFiWh4En+IKC+qkk5UFkxFM22c//cZjYZKynHX0ah2t6LUqb+najYA==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.81.0",
+        "@modelcontextprotocol/sdk": "^1.29.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.123",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.123",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.123",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.123",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.123",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.123",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.123",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.123"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.2.123",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.123.tgz",
+      "integrity": "sha512-tYAXCjlXZQklsUs0J//gip3fZQRzhlH5OCgvNXV70qe7A1iiwHqO2KPGvEHV1L+deEKQoMZmTaCOrQpN6zju3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.2.123",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.123.tgz",
+      "integrity": "sha512-AcUC6sTon6z6HculP87KsAOeTMRLBwpovdhcXUTjXUpo/8nplJ7lBEzWjZCHt8FF1KuN/WBy1Z4bDg/59TQDmA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.2.123",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.123.tgz",
+      "integrity": "sha512-7+GnbcF3/aZ8RJ1WmU/ogtPsOpknBAoUPer90MvZuFYBLPT9iI/U7f24gjrOHuYdcbDA5n7jFlhcfIO26F5DJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.2.123",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.123.tgz",
+      "integrity": "sha512-bYgRiaf2q+yVbGAoUluuhqrEW1zexL34+3HDmK9DneKXa2K2EJpw4M6Sq4XoBD/JezGaemoAP78Xv/M/QUS1OQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.2.123",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.123.tgz",
+      "integrity": "sha512-Xi+Rwk8uP5vWEnawJOlsk179fr0ATLl5J90MlbLj+puKaX5svEq8ljS+P3zq6zHTJeKh9GKLzPf7bc5YJKwcew==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.2.123",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.123.tgz",
+      "integrity": "sha512-IX95lFKhmmndY/YPfWPsVV+C3rLYJmuuq5wCS53p6jYIkCMxH1iGfhBGF1EUWcXO4Uc8yqXFmQ3aaxMzOOPrwA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.2.123",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.123.tgz",
+      "integrity": "sha512-WDZmAQG1rOiqNLZlSXaCjSWmqJvLk2io+vFQWWqSy2b5HCk9pa3PadLiaLztiihyk81wPhH9Q/44kOxdyfEGMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.2.123",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.123.tgz",
+      "integrity": "sha512-588xrd1i6d4kXQ6FqwL+cgBiN4evRQSi5DCtPa02CZ3VEbuVQBeFlyPlD8tfWtNNeGZ4NM8kjPNNzZz5omezPA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
+      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.1.tgz",
+      "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "vaultpilot-development-agents",
+  "version": "0.1.0",
+  "description": "LLM-driven development session: sonnet orchestrator dispatches issues to N parallel opus coding agents.",
+  "type": "module",
+  "private": true,
+  "bin": {
+    "vp-dev": "dist/bin/vp-dev.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
+    "vp-dev": "node dist/bin/vp-dev.js"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.123",
+    "commander": "^12.1.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "typescript": "^5.5.4"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/src/agent/codingAgent.ts
+++ b/src/agent/codingAgent.ts
@@ -1,0 +1,327 @@
+import { query, type CanUseTool, type PermissionResult, type SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import { buildAgentSystemPrompt } from "./prompt.js";
+import { extractEnvelope } from "./parseResult.js";
+import type { AgentRecord, ResultEnvelope } from "../types.js";
+import type { Logger } from "../log/logger.js";
+
+export interface CodingAgentInput {
+  agent: AgentRecord;
+  issueId: number;
+  targetRepo: string;
+  worktreePath: string;
+  branchName: string;
+  dryRun: boolean;
+  logger: Logger;
+  abortController?: AbortController;
+}
+
+export interface CodingAgentResult {
+  envelope?: ResultEnvelope;
+  finalText: string;
+  parseError?: string;
+  durationMs: number;
+  costUsd?: number;
+  isError: boolean;
+  errorReason?: string;
+}
+
+const ALLOWED_NATIVE_TOOLS = ["Bash", "Read", "Edit", "Write", "Grep", "Glob"];
+
+export async function runCodingAgent(input: CodingAgentInput): Promise<CodingAgentResult> {
+  const start = Date.now();
+  const systemPrompt = await buildAgentSystemPrompt({
+    agent: input.agent,
+    workflow: {
+      issueId: input.issueId,
+      targetRepo: input.targetRepo,
+      worktreePath: input.worktreePath,
+      branchName: input.branchName,
+      dryRun: input.dryRun,
+    },
+  });
+
+  const userPrompt = `Work on issue #${input.issueId} in ${input.targetRepo} per the workflow above. Emit the JSON envelope as your final message.`;
+
+  const canUseTool = makeCanUseTool({
+    branchName: input.branchName,
+    targetRepo: input.targetRepo,
+    dryRun: input.dryRun,
+    issueId: input.issueId,
+    logger: input.logger,
+    agentId: input.agent.agentId,
+  });
+
+  const disallowedTools = [
+    "Bash(git push origin main:*)",
+    "Bash(git push origin HEAD:main:*)",
+    "Bash(git push --force origin main:*)",
+  ];
+
+  let finalText = "";
+  let isError = false;
+  let errorReason: string | undefined;
+  let costUsd: number | undefined;
+
+  try {
+    const stream = query({
+      prompt: userPrompt,
+      options: {
+        model: "claude-opus-4-7",
+        cwd: input.worktreePath,
+        systemPrompt,
+        tools: ALLOWED_NATIVE_TOOLS,
+        permissionMode: "bypassPermissions",
+        allowDangerouslySkipPermissions: true,
+        canUseTool,
+        disallowedTools,
+        env: process.env,
+        abortController: input.abortController,
+        maxTurns: 50,
+        settingSources: [],
+        persistSession: false,
+      },
+    });
+
+    for await (const msg of stream) {
+      onMessage(msg, input);
+      if (msg.type === "assistant") {
+        const text = extractText(msg.message.content);
+        if (text) finalText = text;
+      } else if (msg.type === "result") {
+        if (msg.subtype === "success") {
+          finalText = msg.result || finalText;
+          costUsd = msg.total_cost_usd;
+        } else {
+          isError = true;
+          errorReason = (msg as { errors?: string[] }).errors?.join("; ") ?? msg.subtype;
+          costUsd = msg.total_cost_usd;
+        }
+      }
+    }
+  } catch (err) {
+    isError = true;
+    errorReason = (err as Error).message;
+  }
+
+  const durationMs = Date.now() - start;
+  const parsed = extractEnvelope(finalText);
+  const result: CodingAgentResult = {
+    envelope: parsed.envelope,
+    finalText,
+    parseError: parsed.ok ? undefined : parsed.error,
+    durationMs,
+    costUsd,
+    isError,
+    errorReason,
+  };
+
+  input.logger.info("agent.completed", {
+    agentId: input.agent.agentId,
+    issueId: input.issueId,
+    decision: parsed.envelope?.decision ?? null,
+    prUrl: parsed.envelope?.prUrl ?? null,
+    durationMs,
+    costUsd: costUsd ?? null,
+    isError,
+    parseError: result.parseError ?? null,
+  });
+  return result;
+}
+
+function onMessage(msg: SDKMessage, input: CodingAgentInput): void {
+  if (msg.type === "assistant") {
+    for (const block of msg.message.content as ContentBlock[]) {
+      if (block.type === "tool_use") {
+        const inputStr = JSON.stringify(block.input ?? {});
+        input.logger.info("agent.tool_use", {
+          agentId: input.agent.agentId,
+          issueId: input.issueId,
+          tool: block.name,
+          input: inputStr.length > 500 ? inputStr.slice(0, 497) + "..." : inputStr,
+        });
+      } else if (block.type === "text") {
+        const preview = (block.text || "").slice(0, 200).replace(/\s+/g, " ").trim();
+        if (preview.length > 0) {
+          input.logger.info("agent.message", {
+            agentId: input.agent.agentId,
+            issueId: input.issueId,
+            preview,
+          });
+        }
+      }
+    }
+  }
+}
+
+interface ContentBlock {
+  type: string;
+  name?: string;
+  input?: unknown;
+  text?: string;
+}
+
+function extractText(content: unknown): string | null {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return null;
+  const parts: string[] = [];
+  for (const block of content as ContentBlock[]) {
+    if (block.type === "text" && typeof block.text === "string") parts.push(block.text);
+  }
+  return parts.length > 0 ? parts.join("\n") : null;
+}
+
+interface CanUseOpts {
+  branchName: string;
+  targetRepo: string;
+  dryRun: boolean;
+  issueId: number;
+  logger: Logger;
+  agentId: string;
+}
+
+function makeCanUseTool(opts: CanUseOpts): CanUseTool {
+  return async (toolName, toolInput) => evaluate(toolName, toolInput, opts);
+}
+
+function evaluate(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  opts: CanUseOpts,
+): PermissionResult {
+  if (toolName === "Read" || toolName === "Edit" || toolName === "Write" || toolName === "Grep" || toolName === "Glob") {
+    return { behavior: "allow", updatedInput: toolInput };
+  }
+  if (toolName !== "Bash") {
+    return { behavior: "deny", message: `Tool ${toolName} not in allowlist for vp-dev coding agents.` };
+  }
+
+  const cmdRaw = typeof toolInput.command === "string" ? toolInput.command : "";
+  const cmd = cmdRaw.trim();
+
+  // Hard deny: any push to main on the target repo.
+  if (PUSH_TO_MAIN_RE.test(cmd)) {
+    return { behavior: "deny", message: "Refusing: push to main is forbidden in vp-dev." };
+  }
+
+  // Block force pushes that aren't --force-with-lease.
+  if (PLAIN_FORCE_PUSH_RE.test(cmd)) {
+    return { behavior: "deny", message: "Refusing: plain --force push not allowed; use --force-with-lease on feature branches only." };
+  }
+
+  // Block --no-verify and --no-gpg-sign-style hook bypasses.
+  if (NO_VERIFY_RE.test(cmd)) {
+    return { behavior: "deny", message: "Refusing: --no-verify / --no-gpg-sign bypass not allowed." };
+  }
+
+  if (opts.dryRun) {
+    const intercept = dryRunIntercept(cmd, opts);
+    if (intercept) return intercept;
+  }
+
+  if (isAllowedBash(cmd, opts.branchName)) {
+    return { behavior: "allow", updatedInput: toolInput };
+  }
+  return { behavior: "deny", message: `Bash command not in allowlist: ${truncate(cmd, 160)}` };
+}
+
+const PUSH_TO_MAIN_RE = /\bgit\s+push\b[^\n]*\bmain\b/;
+const PLAIN_FORCE_PUSH_RE = /\bgit\s+push\b[^\n]*--force(?!\s*-with-lease)/;
+const NO_VERIFY_RE = /(--no-verify\b|--no-gpg-sign\b)/;
+
+const ALLOW_PATTERNS: RegExp[] = [
+  /^pwd\b/,
+  /^ls(\s|$)/,
+  /^cat(\s|$)/,
+  /^head(\s|$)/,
+  /^tail(\s|$)/,
+  /^wc(\s|$)/,
+  /^which(\s|$)/,
+  /^find(\s|$)/,
+  /^echo(\s|$)/,
+  /^mkdir(\s|$)/,
+  /^rm\s+(-?[rRfv]+\s+)?[^\/\s]/,
+  /^cp(\s|$)/,
+  /^mv(\s|$)/,
+  /^node(\s|$)/,
+  /^npx\s+tsc(\s|$)/,
+  /^npm\s+(install|i|run|test|ci)(\s|$)/,
+
+  // git read-only / safe
+  /^git\s+(status|diff|log|show|fetch|rebase|branch|checkout|add|commit|stash)(\s|$)/,
+  /^git\s+config\s+--get(\s|$)/,
+  /^git\s+rev-parse(\s|$)/,
+  /^git\s+restore(\s|$)/,
+
+  // gh — issue read + comment, PR create/view/checks, api comments fetch
+  /^gh\s+issue\s+view(\s|$)/,
+  /^gh\s+issue\s+list(\s|$)/,
+  /^gh\s+issue\s+comment(\s|$)/,
+  /^gh\s+pr\s+(create|view|checks|list|diff)(\s|$)/,
+  /^gh\s+api\s+repos\/[^\s]+\/issues\/\d+\/comments(\s|$)/,
+  /^gh\s+api\s+repos\/[^\s]+\/(issues|pulls)\/\d+\/comments(\s|$)/,
+  /^gh\s+repo\s+view(\s|$)/,
+];
+
+function isAllowedBash(cmd: string, branchName: string): boolean {
+  for (const re of ALLOW_PATTERNS) {
+    if (re.test(cmd)) return true;
+  }
+  // Push to a non-main branch. Accept "git push [-u] [--force-with-lease] origin <branch>".
+  if (/^git\s+push\b/.test(cmd)) {
+    const m = /\bgit\s+push\b(?:\s+(?:-u|--force-with-lease))*\s+origin\s+(\S+)/.exec(cmd);
+    if (m) {
+      const target = m[1].replace(/^HEAD:/, "");
+      void branchName;
+      return target !== "main";
+    }
+  }
+  return false;
+}
+
+function dryRunIntercept(cmd: string, opts: CanUseOpts): PermissionResult | null {
+  if (/^gh\s+issue\s+comment\b/.test(cmd)) {
+    const synthetic = `https://dry-run/issue-comment/${opts.targetRepo}/${opts.issueId}`;
+    opts.logger.info("dry_run.intercepted", {
+      agentId: opts.agentId,
+      issueId: opts.issueId,
+      cmd: truncate(cmd, 160),
+      synthetic,
+    });
+    return rewriteAsEcho(synthetic);
+  }
+  if (/^gh\s+pr\s+create\b/.test(cmd)) {
+    const synthetic = `https://dry-run/pr/${opts.targetRepo}/issue-${opts.issueId}`;
+    opts.logger.info("dry_run.intercepted", {
+      agentId: opts.agentId,
+      issueId: opts.issueId,
+      cmd: truncate(cmd, 160),
+      synthetic,
+    });
+    return rewriteAsEcho(synthetic);
+  }
+  if (/^git\s+push\b/.test(cmd)) {
+    opts.logger.info("dry_run.intercepted", {
+      agentId: opts.agentId,
+      issueId: opts.issueId,
+      cmd: truncate(cmd, 160),
+      synthetic: "no-op",
+    });
+    return rewriteAsEcho("dry-run: git push no-op");
+  }
+  return null;
+}
+
+function rewriteAsEcho(message: string): PermissionResult {
+  return {
+    behavior: "allow",
+    updatedInput: { command: `printf %s ${shellQuote(message)}` },
+  };
+}
+
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n - 3) + "..." : s;
+}

--- a/src/agent/parseResult.ts
+++ b/src/agent/parseResult.ts
@@ -1,0 +1,59 @@
+import { ResultEnvelopeSchema, type ResultEnvelope } from "../types.js";
+
+export interface ParseOutcome {
+  ok: boolean;
+  envelope?: ResultEnvelope;
+  error?: string;
+  raw?: string;
+}
+
+const FENCED_JSON_RE = /```json\s*\n([\s\S]*?)\n```/gi;
+
+export function extractEnvelope(finalMessage: string): ParseOutcome {
+  const candidates = collectFencedBlocks(finalMessage);
+
+  if (candidates.length === 0) {
+    const inlineCandidate = trySpliceObject(finalMessage);
+    if (inlineCandidate) candidates.push(inlineCandidate);
+  }
+
+  if (candidates.length === 0) {
+    return { ok: false, error: "No fenced ```json``` block found in final assistant message." };
+  }
+
+  const raw = candidates[candidates.length - 1];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return { ok: false, error: `JSON parse failed: ${(err as Error).message}`, raw };
+  }
+  const result = ResultEnvelopeSchema.safeParse(parsed);
+  if (!result.success) {
+    return { ok: false, error: `Schema validation failed: ${result.error.message}`, raw };
+  }
+  return { ok: true, envelope: result.data, raw };
+}
+
+function collectFencedBlocks(message: string): string[] {
+  const out: string[] = [];
+  let m: RegExpExecArray | null;
+  FENCED_JSON_RE.lastIndex = 0;
+  while ((m = FENCED_JSON_RE.exec(message)) !== null) {
+    out.push(m[1].trim());
+  }
+  return out;
+}
+
+function trySpliceObject(message: string): string | null {
+  const start = message.lastIndexOf("{");
+  const end = message.lastIndexOf("}");
+  if (start < 0 || end < 0 || end <= start) return null;
+  const candidate = message.slice(start, end + 1);
+  try {
+    JSON.parse(candidate);
+    return candidate;
+  } catch {
+    return null;
+  }
+}

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -1,0 +1,33 @@
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { buildMemoryFragment } from "../memory/format.js";
+import { renderWorkflow, type WorkflowVars } from "./workflow.js";
+import type { AgentRecord } from "../types.js";
+
+const FRAMEWORK_REPO_ROOT = path.resolve(process.cwd());
+const FRAMEWORK_CLAUDE_MD = path.join(FRAMEWORK_REPO_ROOT, "CLAUDE.md");
+
+export async function buildAgentSystemPrompt(opts: {
+  agent: AgentRecord;
+  workflow: WorkflowVars;
+}): Promise<string> {
+  const claudeMd = await fs.readFile(FRAMEWORK_CLAUDE_MD, "utf-8");
+  const memory = await buildMemoryFragment(opts.agent);
+  const workflow = renderWorkflow(opts.workflow);
+
+  return [
+    "# CLAUDE.md (project guidance — verbatim)",
+    "",
+    claudeMd.trim(),
+    "",
+    "---",
+    "",
+    "# Agent memory",
+    "",
+    memory.trim(),
+    "",
+    "---",
+    "",
+    workflow.trim(),
+  ].join("\n");
+}

--- a/src/agent/workflow.ts
+++ b/src/agent/workflow.ts
@@ -1,0 +1,83 @@
+export interface WorkflowVars {
+  issueId: number;
+  targetRepo: string;
+  worktreePath: string;
+  branchName: string;
+  dryRun: boolean;
+}
+
+export function renderWorkflow(v: WorkflowVars): string {
+  const dryNote = v.dryRun
+    ? "\n\nDRY-RUN: gh issue comment / gh pr create / git push are intercepted and return synthetic responses. All read paths run for real. Make real edits and commits in your worktree — the human inspects them post-run.\n"
+    : "";
+
+  return `# Workflow
+
+You are an autonomous coding agent working on a single GitHub issue in ${v.targetRepo}.
+Your worktree is ${v.worktreePath} on branch ${v.branchName}. Stay inside it. Never push to main.${dryNote}
+
+## Step 1 — Read the issue and ALL comments
+Run BOTH:
+  gh issue view ${v.issueId} --repo ${v.targetRepo} --json number,title,body,labels,state
+  gh api repos/${v.targetRepo}/issues/${v.issueId}/comments
+
+Per CLAUDE.md "Issue Analysis": comments are where reviewers add follow-up scope or push back on the original framing. Fold every comment into the analysis.
+
+## Step 2 — Apply judgment rules from CLAUDE.md
+- Push-Back Discipline: faulty premise → push back BEFORE acting.
+- Smallest-Solution Discipline: minimum change first; flag larger proposals.
+- Rogue-Agent-Only Triage: pure-advisory threats with no signing flow → close as architectural; do not invent skill-side defenses against rogue agents.
+- Cross-Repo Scope Splits: if the fix splits between MCP code and skill rendering, file the skill half as a tracked issue in vaultpilot-security-skill and link both ways.
+- Typed-Data Signing Discipline applies if the issue touches typed-data signing tools.
+
+## Step 3 — Decide internally: pushback OR implement
+
+### Pushback path
+Compose a comment: one mismatch sentence + 2-3 alternatives + a question.
+Write the body to a tmp file, then:
+  gh issue comment ${v.issueId} --repo ${v.targetRepo} --body-file <tmp>
+Emit the JSON envelope with decision="pushback" and the comment URL.
+
+### Implement path
+1. Confirm pwd == ${v.worktreePath} and \`git status\` is clean on ${v.branchName}.
+2. Make the minimum code change.
+3. Build + test in the worktree:
+     npm run build
+     npm test
+   Do not skip — compile + tests must pass before commit.
+4. Stage explicit files (never \`git add -A\`). Commit with a message ending in:
+     Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+5. Push:
+     git push -u origin ${v.branchName}
+6. Open the PR — body MUST start with "Closes #${v.issueId}" on its own line so GitHub auto-closes:
+     gh pr create --repo ${v.targetRepo} --base main --head ${v.branchName} --title <short title> --body-file <tmp>
+7. Format the returned PR URL as a Markdown hyperlink in your reasoning.
+
+## Step 4 — Emit the JSON envelope as your FINAL message
+
+Wrap it in a fenced \`\`\`json block. Schema:
+
+\`\`\`json
+{
+  "decision": "implement" | "pushback" | "error",
+  "reason": "1-3 sentences on what you did and why",
+  "prUrl": "<only for implement>",
+  "commentUrl": "<only for pushback>",
+  "scopeNotes": "<optional, e.g. skill issue filed at vaultpilot-security-skill#NN>",
+  "memoryUpdate": {
+    "addTags": ["<lowercase domain tags this issue exercised>"],
+    "removeTags": ["<optional>"],
+    "findingTitle": "<optional, ≤80 chars>",
+    "findingBody": "<optional, the breakthrough or non-obvious lesson>"
+  }
+}
+\`\`\`
+
+Tags: lowercase, dash-separated, domain-specific (e.g. solana, spl-token, aave, ledger-firmware, typed-data, preflight, eip-712). Avoid generic tags like "fix" or "bug".
+
+Hard rules:
+- Never push to main. Never run \`git push origin main\`.
+- Never use --no-verify, --force without --force-with-lease, or amend a pushed commit.
+- The JSON envelope MUST be your last message. Missing or malformed → the run records the issue as failed.
+`;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,263 @@
+import { Command } from "commander";
+import {
+  clearCurrentRunId,
+  downgradeInFlightToPending,
+  isRunComplete,
+  loadRunState,
+  makeRunId,
+  newRunState,
+  readCurrentRunId,
+  saveRunState,
+  writeCurrentRunId,
+} from "./state/runState.js";
+import { loadRegistry } from "./state/registry.js";
+import { parseRangeSpec } from "./github/range.js";
+import { resolveRangeToIssues } from "./github/gh.js";
+import { runOrchestrator } from "./orchestrator/orchestrator.js";
+import { Logger } from "./log/logger.js";
+import { pruneWorktrees, targetRepoPath } from "./git/worktree.js";
+import type { IssueRangeSpec } from "./types.js";
+
+const DEFAULT_TARGET_REPO = "szhygulin/vaultpilot-mcp";
+const DEFAULT_MAX_TICKS = 200;
+
+export function buildCli(): Command {
+  const program = new Command();
+  program.name("vp-dev").description("LLM-driven development agent runner").version("0.1.0");
+
+  program
+    .command("run")
+    .description("Run agents against a range of GitHub issues")
+    .requiredOption("--agents <n>", "Number of parallel coding agents", parsePositive)
+    .option("--issues <range>", "Issue range: 100-150, csv 100,103,108, or all-open")
+    .option("--target-repo <owner/repo>", "Target GitHub repo", DEFAULT_TARGET_REPO)
+    .option("--resume", "Resume the most recent unfinished run")
+    .option("--dry-run", "Intercept comment / PR / push tools with synthetic responses")
+    .option("--max-ticks <n>", "Safety cap on scheduling ticks", parsePositive, DEFAULT_MAX_TICKS)
+    .option("--verbose", "Mirror a colorized subset of events to stderr")
+    .action(async (opts) => {
+      await cmdRun(opts);
+    });
+
+  program
+    .command("status")
+    .description("Print summary of the current run + per-agent state")
+    .action(async () => {
+      await cmdStatus();
+    });
+
+  program
+    .command("agents")
+    .description("Agent management")
+    .addCommand(
+      new Command("list")
+        .description("List the agent roster + specializations")
+        .action(async () => {
+          await cmdAgentsList();
+        }),
+    );
+
+  return program;
+}
+
+interface RunOpts {
+  agents: number;
+  issues?: string;
+  targetRepo: string;
+  resume?: boolean;
+  dryRun?: boolean;
+  maxTicks: number;
+  verbose?: boolean;
+}
+
+async function cmdRun(opts: RunOpts): Promise<void> {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error("ERROR: ANTHROPIC_API_KEY is not set.");
+    process.exit(2);
+  }
+
+  if (opts.resume) {
+    await runResume(opts);
+    return;
+  }
+
+  if (!opts.issues) {
+    console.error("ERROR: --issues is required (or pass --resume).");
+    process.exit(2);
+  }
+
+  const existing = await readCurrentRunId();
+  if (existing) {
+    try {
+      const state = await loadRunState(existing);
+      if (!isRunComplete(state)) {
+        console.error(
+          `ERROR: unfinished run ${existing} exists. Pass --resume to continue, or wait for it to complete.`,
+        );
+        process.exit(2);
+      }
+    } catch {
+      // current-run pointer is stale — ignore and start fresh
+      await clearCurrentRunId();
+    }
+  }
+
+  const range: IssueRangeSpec = parseRangeSpec(opts.issues);
+  const { open, skippedClosed } = await resolveRangeToIssues(opts.targetRepo, range);
+  for (const id of skippedClosed) {
+    console.error(`INFO: skipping closed issue #${id}`);
+  }
+  if (open.length === 0) {
+    console.error("ERROR: no open issues in range.");
+    process.exit(2);
+  }
+
+  const runId = makeRunId();
+  const state = newRunState({
+    runId,
+    targetRepo: opts.targetRepo,
+    issueRange: range,
+    parallelism: opts.agents,
+    issueIds: open.map((i) => i.id),
+    dryRun: !!opts.dryRun,
+  });
+  await saveRunState(state);
+  await writeCurrentRunId(runId);
+
+  const logger = new Logger({ runId, verbose: !!opts.verbose });
+  await logger.open();
+  logger.info("run.started", {
+    runId,
+    targetRepo: opts.targetRepo,
+    parallelism: opts.agents,
+    range: opts.issues,
+    issueCount: open.length,
+    dryRun: !!opts.dryRun,
+  });
+
+  try {
+    const repoPath = await targetRepoPath(opts.targetRepo);
+    await pruneWorktrees(repoPath);
+    await runOrchestrator({
+      state,
+      issues: open,
+      parallelism: opts.agents,
+      maxTicks: opts.maxTicks,
+      logger,
+      dryRun: !!opts.dryRun,
+    });
+    logger.info("run.completed", {
+      runId,
+      complete: isRunComplete(state),
+      issueCount: open.length,
+    });
+    if (isRunComplete(state)) await clearCurrentRunId();
+  } finally {
+    await logger.close();
+  }
+  process.stdout.write(`Run ${runId} log: logs/${runId}.jsonl\n`);
+}
+
+async function runResume(opts: RunOpts): Promise<void> {
+  const runId = await readCurrentRunId();
+  if (!runId) {
+    console.error("ERROR: no current run to resume.");
+    process.exit(2);
+  }
+  const state = await loadRunState(runId);
+  downgradeInFlightToPending(state);
+  await saveRunState(state);
+
+  const repoPath = await targetRepoPath(state.targetRepo);
+  await pruneWorktrees(repoPath);
+
+  const { open, skippedClosed } = await resolveRangeToIssues(state.targetRepo, state.issueRange);
+  for (const id of skippedClosed) {
+    console.error(`INFO: skipping closed issue #${id}`);
+  }
+  // Filter to issues that are still tracked in run state.
+  const tracked = new Set(Object.keys(state.issues).map(Number));
+  const issues = open.filter((i) => tracked.has(i.id));
+
+  const logger = new Logger({ runId, verbose: !!opts.verbose });
+  await logger.open();
+  logger.info("run.resumed", {
+    runId,
+    parallelism: state.parallelism,
+    issueCount: issues.length,
+  });
+  try {
+    await runOrchestrator({
+      state,
+      issues,
+      parallelism: state.parallelism,
+      maxTicks: opts.maxTicks,
+      logger,
+      dryRun: state.dryRun,
+    });
+    logger.info("run.completed", {
+      runId,
+      complete: isRunComplete(state),
+      issueCount: issues.length,
+    });
+    if (isRunComplete(state)) await clearCurrentRunId();
+  } finally {
+    await logger.close();
+  }
+}
+
+async function cmdStatus(): Promise<void> {
+  const runId = await readCurrentRunId();
+  if (!runId) {
+    process.stdout.write("No active run.\n");
+    return;
+  }
+  const state = await loadRunState(runId);
+  const total = Object.keys(state.issues).length;
+  const counts = { pending: 0, "in-flight": 0, done: 0, failed: 0 };
+  for (const e of Object.values(state.issues)) counts[e.status] += 1;
+  process.stdout.write(`Run ${runId} on ${state.targetRepo}\n`);
+  process.stdout.write(
+    `  total=${total} pending=${counts.pending} in-flight=${counts["in-flight"]} done=${counts.done} failed=${counts.failed}\n`,
+  );
+  process.stdout.write(`  ticks=${state.tickCount} parallelism=${state.parallelism} dryRun=${state.dryRun}\n`);
+  for (const a of state.agents) {
+    process.stdout.write(`  agent ${a.agentId}: ${a.status}\n`);
+  }
+}
+
+async function cmdAgentsList(): Promise<void> {
+  const reg = await loadRegistry();
+  if (reg.agents.length === 0) {
+    process.stdout.write("No agents in registry yet.\n");
+    return;
+  }
+  const headers = ["agentId", "tags", "issuesHandled", "implement", "pushback", "error", "lastActive"];
+  const rows = reg.agents.map((a) => [
+    a.agentId,
+    a.tags.join(","),
+    String(a.issuesHandled),
+    String(a.implementCount),
+    String(a.pushbackCount),
+    String(a.errorCount),
+    a.lastActiveAt,
+  ]);
+  printTable(headers, rows);
+}
+
+function printTable(headers: string[], rows: string[][]): void {
+  const widths = headers.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i]?.length ?? 0)));
+  const fmt = (cells: string[]) =>
+    cells.map((c, i) => (c ?? "").padEnd(widths[i])).join("  ");
+  process.stdout.write(fmt(headers) + "\n");
+  process.stdout.write(widths.map((w) => "-".repeat(w)).join("  ") + "\n");
+  for (const r of rows) process.stdout.write(fmt(r) + "\n");
+}
+
+function parsePositive(value: string): number {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`Expected positive integer, got "${value}"`);
+  }
+  return n;
+}

--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -1,0 +1,81 @@
+import { promisify } from "node:util";
+import { execFile as execFileCb } from "node:child_process";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+
+const execFile = promisify(execFileCb);
+
+export interface WorktreeHandle {
+  path: string;
+  branch: string;
+}
+
+export async function targetRepoPath(targetRepo: string): Promise<string> {
+  // Convention from CLAUDE.md: target repo lives at /home/szhygulin/dev/<name>
+  const name = targetRepo.split("/").pop() ?? targetRepo;
+  const candidate = path.resolve("/home/szhygulin/dev", name);
+  await fs.access(candidate);
+  return candidate;
+}
+
+export async function fetchOriginMain(repoPath: string): Promise<void> {
+  await execFile("git", ["fetch", "origin", "main"], { cwd: repoPath });
+}
+
+export async function pruneWorktrees(repoPath: string): Promise<void> {
+  await execFile("git", ["worktree", "prune"], { cwd: repoPath });
+}
+
+export async function createWorktree(opts: {
+  repoPath: string;
+  agentId: string;
+  issueId: number;
+}): Promise<WorktreeHandle> {
+  const branch = `vp-dev/${opts.agentId}/issue-${opts.issueId}`;
+  const wtPath = path.join(opts.repoPath, ".claude", "worktrees", `${opts.agentId}-issue-${opts.issueId}`);
+
+  // CLAUDE.md: cd <repoPath> BEFORE worktree add — execFile with cwd does that explicitly.
+  await execFile("git", ["fetch", "origin", "main"], { cwd: opts.repoPath });
+  try {
+    await execFile(
+      "git",
+      ["worktree", "add", path.join(".claude", "worktrees", `${opts.agentId}-issue-${opts.issueId}`), "-b", branch, "origin/main"],
+      { cwd: opts.repoPath },
+    );
+  } catch (err) {
+    const msg = (err as { stderr?: string }).stderr ?? String(err);
+    throw new Error(`worktree add failed: ${msg}`);
+  }
+  return { path: wtPath, branch };
+}
+
+export async function removeWorktree(opts: {
+  repoPath: string;
+  worktree: WorktreeHandle;
+  deleteBranch: boolean;
+}): Promise<void> {
+  try {
+    await execFile("git", ["worktree", "remove", opts.worktree.path, "--force"], { cwd: opts.repoPath });
+  } catch {
+    // ignore — already removed or path missing
+  }
+  if (opts.deleteBranch) {
+    try {
+      await execFile("git", ["branch", "-D", opts.worktree.branch], { cwd: opts.repoPath });
+    } catch {
+      // ignore
+    }
+  }
+}
+
+export async function listWorktrees(repoPath: string): Promise<string[]> {
+  try {
+    const { stdout } = await execFile("git", ["worktree", "list", "--porcelain"], { cwd: repoPath });
+    return stdout
+      .split("\n")
+      .filter((l) => l.startsWith("worktree "))
+      .map((l) => l.slice("worktree ".length).trim());
+  } catch {
+    return [];
+  }
+}

--- a/src/github/gh.ts
+++ b/src/github/gh.ts
@@ -1,0 +1,95 @@
+import { promisify } from "node:util";
+import { execFile as execFileCb } from "node:child_process";
+import type { IssueRangeSpec, IssueSummary } from "../types.js";
+
+const execFile = promisify(execFileCb);
+
+interface GhIssueRecord {
+  number: number;
+  title: string;
+  state: string;
+  labels: { name: string }[];
+}
+
+export async function listOpenIssues(targetRepo: string): Promise<IssueSummary[]> {
+  const { stdout } = await execFile(
+    "gh",
+    [
+      "issue",
+      "list",
+      "--repo",
+      targetRepo,
+      "--state",
+      "open",
+      "--limit",
+      "1000",
+      "--json",
+      "number,title,state,labels",
+    ],
+    { maxBuffer: 50 * 1024 * 1024 },
+  );
+  const records = JSON.parse(stdout) as GhIssueRecord[];
+  return records.map(toSummary);
+}
+
+export async function getIssue(targetRepo: string, number: number): Promise<IssueSummary | null> {
+  try {
+    const { stdout } = await execFile(
+      "gh",
+      [
+        "issue",
+        "view",
+        String(number),
+        "--repo",
+        targetRepo,
+        "--json",
+        "number,title,state,labels",
+      ],
+      { maxBuffer: 5 * 1024 * 1024 },
+    );
+    return toSummary(JSON.parse(stdout) as GhIssueRecord);
+  } catch {
+    return null;
+  }
+}
+
+function toSummary(rec: GhIssueRecord): IssueSummary {
+  const state = rec.state.toLowerCase() === "open" ? "open" : "closed";
+  return {
+    id: rec.number,
+    title: rec.title,
+    labels: rec.labels.map((l) => l.name),
+    state,
+  };
+}
+
+export async function resolveRangeToIssues(
+  targetRepo: string,
+  spec: IssueRangeSpec,
+): Promise<{ open: IssueSummary[]; skippedClosed: number[] }> {
+  if (spec.kind === "all-open") {
+    return { open: await listOpenIssues(targetRepo), skippedClosed: [] };
+  }
+
+  const ids = spec.kind === "range"
+    ? rangeToIds(spec.from, spec.to)
+    : [...spec.ids];
+
+  const results = await Promise.all(ids.map((id) => getIssue(targetRepo, id)));
+
+  const open: IssueSummary[] = [];
+  const skippedClosed: number[] = [];
+  for (let i = 0; i < ids.length; i++) {
+    const issue = results[i];
+    if (!issue) continue; // missing/inaccessible — silently skipped (404 etc.)
+    if (issue.state === "closed") skippedClosed.push(ids[i]);
+    else open.push(issue);
+  }
+  return { open, skippedClosed };
+}
+
+function rangeToIds(from: number, to: number): number[] {
+  const out: number[] = [];
+  for (let n = from; n <= to; n++) out.push(n);
+  return out;
+}

--- a/src/github/range.ts
+++ b/src/github/range.ts
@@ -1,0 +1,42 @@
+import type { IssueRangeSpec } from "../types.js";
+
+export function parseRangeSpec(input: string): IssueRangeSpec {
+  const trimmed = input.trim();
+  if (trimmed === "all-open") return { kind: "all-open" };
+
+  if (trimmed.includes(",")) {
+    const ids = trimmed
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+      .map(parsePositiveInt);
+    return { kind: "csv", ids };
+  }
+
+  if (trimmed.includes("-")) {
+    const [fromStr, toStr] = trimmed.split("-");
+    const from = parsePositiveInt(fromStr);
+    const to = parsePositiveInt(toStr);
+    if (to < from) throw new Error(`Invalid range "${input}": to (${to}) < from (${from})`);
+    return { kind: "range", from, to };
+  }
+
+  return { kind: "csv", ids: [parsePositiveInt(trimmed)] };
+}
+
+function parsePositiveInt(s: string): number {
+  const n = Number(s);
+  if (!Number.isInteger(n) || n <= 0) throw new Error(`Not a positive integer: "${s}"`);
+  return n;
+}
+
+export function describeRange(spec: IssueRangeSpec): string {
+  switch (spec.kind) {
+    case "range":
+      return `${spec.from}-${spec.to}`;
+    case "csv":
+      return spec.ids.join(",");
+    case "all-open":
+      return "all-open";
+  }
+}

--- a/src/log/logger.ts
+++ b/src/log/logger.ts
@@ -1,0 +1,99 @@
+import { createWriteStream, type WriteStream } from "node:fs";
+import path from "node:path";
+import { ensureDir } from "../state/locks.js";
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export interface LogEvent {
+  ts: string;
+  event: string;
+  [key: string]: unknown;
+}
+
+export class Logger {
+  private stream: WriteStream | null = null;
+  private readonly logPath: string;
+  private readonly verbose: boolean;
+
+  constructor(opts: { runId: string; verbose: boolean; logsDir?: string }) {
+    const dir = opts.logsDir ?? path.resolve(process.cwd(), "logs");
+    this.logPath = path.join(dir, `${opts.runId}.jsonl`);
+    this.verbose = opts.verbose;
+  }
+
+  async open(): Promise<void> {
+    await ensureDir(path.dirname(this.logPath));
+    this.stream = createWriteStream(this.logPath, { flags: "a" });
+  }
+
+  log(event: string, data: Record<string, unknown> = {}): void {
+    const line: LogEvent = { ts: new Date().toISOString(), event, ...data };
+    const json = JSON.stringify(line);
+    if (this.stream) this.stream.write(json + "\n");
+    if (this.verbose) {
+      const tag = colorize(event);
+      const summary = formatVerbose(line);
+      process.stderr.write(`${tag} ${summary}\n`);
+    }
+  }
+
+  info(event: string, data: Record<string, unknown> = {}): void {
+    this.log(event, data);
+  }
+
+  warn(event: string, data: Record<string, unknown> = {}): void {
+    this.log(`warn.${event}`, data);
+  }
+
+  error(event: string, data: Record<string, unknown> = {}): void {
+    this.log(`error.${event}`, data);
+  }
+
+  async close(): Promise<void> {
+    if (!this.stream) return;
+    await new Promise<void>((resolve) => this.stream?.end(resolve));
+    this.stream = null;
+  }
+
+  filePath(): string {
+    return this.logPath;
+  }
+}
+
+const COLORS: Record<string, string> = {
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  cyan: "\x1b[36m",
+  magenta: "\x1b[35m",
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
+};
+
+function colorize(event: string): string {
+  if (event.startsWith("error")) return `${COLORS.red}[${event}]${COLORS.reset}`;
+  if (event.startsWith("warn")) return `${COLORS.yellow}[${event}]${COLORS.reset}`;
+  if (event.startsWith("agent.completed")) return `${COLORS.green}[${event}]${COLORS.reset}`;
+  if (event.startsWith("agent")) return `${COLORS.cyan}[${event}]${COLORS.reset}`;
+  if (event.startsWith("tick")) return `${COLORS.magenta}[${event}]${COLORS.reset}`;
+  return `${COLORS.dim}[${event}]${COLORS.reset}`;
+}
+
+function formatVerbose(line: LogEvent): string {
+  const { ts, event, ...rest } = line;
+  void ts;
+  void event;
+  const keys = Object.keys(rest);
+  if (keys.length === 0) return "";
+  const compact = keys
+    .map((k) => `${k}=${truncateValue(rest[k])}`)
+    .join(" ");
+  return compact;
+}
+
+function truncateValue(v: unknown): string {
+  if (v == null) return String(v);
+  const s = typeof v === "string" ? v : JSON.stringify(v);
+  return s.length > 200 ? s.slice(0, 197) + "..." : s;
+}

--- a/src/memory/format.ts
+++ b/src/memory/format.ts
@@ -1,0 +1,63 @@
+import { promises as fs } from "node:fs";
+import {
+  listFindings,
+  memoryIndexPath,
+  readIfExists,
+  specializationPath,
+} from "./store.js";
+import type { AgentRecord } from "../types.js";
+
+const MAX_TOTAL_BYTES = 8 * 1024;
+const MAX_INDEX_BYTES = 2 * 1024;
+const MAX_FINDINGS = 3;
+
+export async function buildMemoryFragment(agent: AgentRecord): Promise<string> {
+  const parts: string[] = [];
+
+  const spec = await readIfExists(specializationPath(agent.agentId));
+  parts.push(`# Agent ${agent.agentId} — specialization\n\n${spec ?? defaultSpecialization(agent)}`);
+
+  const indexRaw = (await readIfExists(memoryIndexPath(agent.agentId))) ?? "";
+  const index = truncateBytes(indexRaw, MAX_INDEX_BYTES);
+  if (index.trim().length > 0) {
+    parts.push(`## MEMORY index\n\n${index}`);
+  }
+
+  const findingPaths = await listFindings(agent.agentId);
+  const stat = await Promise.all(
+    findingPaths.map(async (p) => ({ path: p, mtime: (await fs.stat(p)).mtimeMs })),
+  );
+  stat.sort((a, b) => b.mtime - a.mtime);
+  const recent = stat.slice(0, MAX_FINDINGS);
+
+  for (const f of recent) {
+    const body = await readIfExists(f.path);
+    if (!body) continue;
+    parts.push(`## Recent finding (${pathBasename(f.path)})\n\n${body}`);
+  }
+
+  return truncateBytes(parts.join("\n\n---\n\n"), MAX_TOTAL_BYTES);
+}
+
+function defaultSpecialization(agent: AgentRecord): string {
+  return `---
+agentId: ${agent.agentId}
+issuesHandled: 0
+tags: [general]
+updatedAt: ${agent.createdAt}
+---
+
+New agent. No prior issues handled. Tags: general.
+`;
+}
+
+function truncateBytes(input: string, maxBytes: number): string {
+  const buf = Buffer.from(input, "utf-8");
+  if (buf.length <= maxBytes) return input;
+  return buf.subarray(0, maxBytes).toString("utf-8") + "\n...[truncated]";
+}
+
+function pathBasename(p: string): string {
+  const idx = p.lastIndexOf("/");
+  return idx >= 0 ? p.slice(idx + 1) : p;
+}

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -1,0 +1,59 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { ensureDir } from "../state/locks.js";
+
+export const AGENTS_ROOT = path.resolve(process.cwd(), "agents");
+
+export function agentDir(agentId: string): string {
+  return path.join(AGENTS_ROOT, agentId);
+}
+
+export function findingsDir(agentId: string): string {
+  return path.join(agentDir(agentId), "findings");
+}
+
+export function specializationPath(agentId: string): string {
+  return path.join(agentDir(agentId), "specialization.md");
+}
+
+export function memoryIndexPath(agentId: string): string {
+  return path.join(agentDir(agentId), "MEMORY.md");
+}
+
+export async function ensureAgentDir(agentId: string): Promise<void> {
+  await ensureDir(findingsDir(agentId));
+}
+
+export async function readIfExists(filePath: string): Promise<string | null> {
+  try {
+    return await fs.readFile(filePath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+export async function writeFileAtomic(filePath: string, content: string): Promise<void> {
+  await ensureDir(path.dirname(filePath));
+  const tmp = `${filePath}.tmp.${process.pid}`;
+  await fs.writeFile(tmp, content);
+  await fs.rename(tmp, filePath);
+}
+
+export async function listFindings(agentId: string): Promise<string[]> {
+  try {
+    const entries = await fs.readdir(findingsDir(agentId));
+    return entries.filter((e) => e.endsWith(".md")).map((e) => path.join(findingsDir(agentId), e));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+}
+
+export function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)+/g, "")
+    .slice(0, 80) || "finding";
+}

--- a/src/memory/tagger.ts
+++ b/src/memory/tagger.ts
@@ -1,0 +1,127 @@
+import path from "node:path";
+import {
+  ensureAgentDir,
+  findingsDir,
+  memoryIndexPath,
+  readIfExists,
+  slugify,
+  specializationPath,
+  writeFileAtomic,
+} from "./store.js";
+import type { AgentRecord, ResultEnvelope } from "../types.js";
+
+const MAX_INDEX_LINES = 20;
+
+export interface ApplyOpts {
+  agent: AgentRecord;
+  envelope: ResultEnvelope;
+  issueId: number;
+}
+
+export async function applyMemoryUpdate(opts: ApplyOpts): Promise<void> {
+  await ensureAgentDir(opts.agent.agentId);
+  await updateTags(opts.agent, opts.envelope);
+  await writeSpecialization(opts.agent);
+  if (opts.envelope.memoryUpdate.findingTitle && opts.envelope.memoryUpdate.findingBody) {
+    await writeFinding(opts.agent.agentId, {
+      title: opts.envelope.memoryUpdate.findingTitle,
+      body: opts.envelope.memoryUpdate.findingBody,
+      issueId: opts.issueId,
+    });
+  }
+  await appendMemoryIndex(opts.agent.agentId, {
+    issueId: opts.issueId,
+    decision: opts.envelope.decision,
+    reason: opts.envelope.reason,
+    findingTitle: opts.envelope.memoryUpdate.findingTitle,
+  });
+}
+
+async function updateTags(agent: AgentRecord, env: ResultEnvelope): Promise<void> {
+  const tags = new Set(agent.tags);
+  for (const t of env.memoryUpdate.addTags) tags.add(t.toLowerCase());
+  for (const t of env.memoryUpdate.removeTags ?? []) tags.delete(t.toLowerCase());
+  if (tags.size === 0) tags.add("general");
+  agent.tags = [...tags].sort();
+  agent.lastActiveAt = new Date().toISOString();
+}
+
+async function writeSpecialization(agent: AgentRecord): Promise<void> {
+  const frontmatter = [
+    "---",
+    `agentId: ${agent.agentId}`,
+    `issuesHandled: ${agent.issuesHandled}`,
+    `tags: [${agent.tags.join(", ")}]`,
+    `updatedAt: ${agent.lastActiveAt}`,
+    "---",
+    "",
+  ].join("\n");
+
+  const existing = (await readIfExists(specializationPath(agent.agentId))) ?? "";
+  const prose = stripFrontmatter(existing).trim();
+  const truncatedProse = prose.length > 500 ? prose.slice(0, 500) : prose;
+  const body = truncatedProse.length > 0 ? truncatedProse : autoProse(agent);
+  await writeFileAtomic(specializationPath(agent.agentId), `${frontmatter}${body}\n`);
+}
+
+function autoProse(agent: AgentRecord): string {
+  if (agent.tags.length === 1 && agent.tags[0] === "general") {
+    return "General-purpose agent. No specialization yet.";
+  }
+  return `Specializes in: ${agent.tags.filter((t) => t !== "general").join(", ")}.`;
+}
+
+function stripFrontmatter(content: string): string {
+  if (!content.startsWith("---")) return content;
+  const end = content.indexOf("\n---", 3);
+  if (end < 0) return content;
+  return content.slice(end + 4).replace(/^\n+/, "");
+}
+
+async function writeFinding(
+  agentId: string,
+  f: { title: string; body: string; issueId: number },
+): Promise<void> {
+  const slug = slugify(f.title);
+  const filePath = path.join(findingsDir(agentId), `${slug}.md`);
+  const now = new Date().toISOString();
+  const content = [
+    "---",
+    `title: ${escapeYaml(f.title)}`,
+    `issueId: ${f.issueId}`,
+    `createdAt: ${now}`,
+    "---",
+    "",
+    f.body,
+    "",
+  ].join("\n");
+  await writeFileAtomic(filePath, content);
+}
+
+function escapeYaml(s: string): string {
+  if (/[:#\n"']/.test(s)) return JSON.stringify(s);
+  return s;
+}
+
+interface IndexEntry {
+  issueId: number;
+  decision: string;
+  reason: string;
+  findingTitle?: string;
+}
+
+async function appendMemoryIndex(agentId: string, entry: IndexEntry): Promise<void> {
+  const existing = (await readIfExists(memoryIndexPath(agentId))) ?? "";
+  const lines = existing.split("\n").filter((l) => l.trim().length > 0);
+  const newLine = `- #${entry.issueId} [${entry.decision}] — ${truncateLine(entry.reason)}${
+    entry.findingTitle ? ` (finding: ${entry.findingTitle})` : ""
+  }`;
+  lines.unshift(newLine);
+  const trimmed = lines.slice(0, MAX_INDEX_LINES);
+  await writeFileAtomic(memoryIndexPath(agentId), trimmed.join("\n") + "\n");
+}
+
+function truncateLine(s: string): string {
+  const oneLine = s.replace(/\s+/g, " ").trim();
+  return oneLine.length > 200 ? oneLine.slice(0, 197) + "..." : oneLine;
+}

--- a/src/orchestrator/dispatcher.ts
+++ b/src/orchestrator/dispatcher.ts
@@ -1,0 +1,175 @@
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { buildTickPrompt } from "./prompt.js";
+import { TickProposalSchema, type TickAssignment } from "../types.js";
+import { deterministicFallback } from "./routing.js";
+import type { AgentRecord, IssueSummary } from "../types.js";
+import type { Logger } from "../log/logger.js";
+
+export interface DispatchInput {
+  idleAgents: AgentRecord[];
+  pendingIssues: IssueSummary[];
+  cap: number;
+  logger: Logger;
+}
+
+export interface DispatchResult {
+  assignments: TickAssignment[];
+  source: "llm" | "llm-retry" | "fallback";
+}
+
+const ORCHESTRATOR_MODEL = "claude-sonnet-4-6";
+
+export async function dispatch(input: DispatchInput): Promise<DispatchResult> {
+  const cap = Math.min(input.cap, input.idleAgents.length, input.pendingIssues.length);
+  if (cap <= 0) return { assignments: [], source: "llm" };
+
+  const firstAttempt = await tryProposeWithLLM({
+    pendingIssues: input.pendingIssues,
+    idleAgents: input.idleAgents,
+    cap,
+    logger: input.logger,
+  });
+  if (firstAttempt.assignments) {
+    return { assignments: firstAttempt.assignments, source: "llm" };
+  }
+
+  input.logger.warn("dispatcher.proposal_invalid", {
+    errors: firstAttempt.errors,
+    attempt: 1,
+  });
+
+  const retry = await tryProposeWithLLM({
+    pendingIssues: input.pendingIssues,
+    idleAgents: input.idleAgents,
+    cap,
+    logger: input.logger,
+    errorsFromPrior: firstAttempt.errors,
+  });
+  if (retry.assignments) {
+    return { assignments: retry.assignments, source: "llm-retry" };
+  }
+
+  input.logger.warn("dispatcher.proposal_invalid", {
+    errors: retry.errors,
+    attempt: 2,
+  });
+
+  const fallback = deterministicFallback({
+    idleAgents: input.idleAgents,
+    pendingIssues: input.pendingIssues,
+    cap,
+  });
+  return { assignments: fallback, source: "fallback" };
+}
+
+interface ProposeOutcome {
+  assignments?: TickAssignment[];
+  errors?: string[];
+}
+
+async function tryProposeWithLLM(opts: {
+  pendingIssues: IssueSummary[];
+  idleAgents: AgentRecord[];
+  cap: number;
+  logger: Logger;
+  errorsFromPrior?: string[];
+}): Promise<ProposeOutcome> {
+  const prompt = buildTickPrompt({
+    pendingIssues: opts.pendingIssues,
+    idleAgents: opts.idleAgents,
+    cap: opts.cap,
+    errorsFromPrior: opts.errorsFromPrior,
+  });
+
+  let raw = "";
+  try {
+    const stream = query({
+      prompt,
+      options: {
+        model: ORCHESTRATOR_MODEL,
+        tools: [],
+        permissionMode: "default",
+        env: process.env,
+        maxTurns: 1,
+        settingSources: [],
+        persistSession: false,
+      },
+    });
+    for await (const msg of stream) {
+      if (msg.type === "result") {
+        if (msg.subtype === "success") raw = msg.result;
+        else return { errors: [`Orchestrator query failed: ${msg.subtype}`] };
+      }
+    }
+  } catch (err) {
+    return { errors: [`Orchestrator query exception: ${(err as Error).message}`] };
+  }
+
+  opts.logger.info("tick.llm_io", {
+    promptBytes: prompt.length,
+    responseBytes: raw.length,
+    response: raw.length > 4000 ? raw.slice(0, 4000) + "..." : raw,
+  });
+
+  const parsedJson = parseJsonLoose(raw);
+  if (!parsedJson) return { errors: ["Orchestrator response is not valid JSON."] };
+
+  const proposal = TickProposalSchema.safeParse(parsedJson);
+  if (!proposal.success) return { errors: [`Schema invalid: ${proposal.error.message}`] };
+
+  const errors = validateProposal({
+    proposal: proposal.data.assignments,
+    cap: opts.cap,
+    idleAgents: opts.idleAgents,
+    pendingIssues: opts.pendingIssues,
+  });
+  if (errors.length > 0) return { errors };
+  return { assignments: proposal.data.assignments };
+}
+
+function parseJsonLoose(raw: string): unknown {
+  const trimmed = raw.trim();
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    // try fenced extraction
+    const match = /```(?:json)?\s*\n([\s\S]*?)\n```/i.exec(trimmed);
+    if (match) {
+      try {
+        return JSON.parse(match[1]);
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
+}
+
+interface ValidateInput {
+  proposal: TickAssignment[];
+  cap: number;
+  idleAgents: AgentRecord[];
+  pendingIssues: IssueSummary[];
+}
+
+function validateProposal(input: ValidateInput): string[] {
+  const errors: string[] = [];
+  const idleSet = new Set(input.idleAgents.map((a) => a.agentId));
+  const pendingSet = new Set(input.pendingIssues.map((i) => i.id));
+
+  if (input.proposal.length > input.cap) {
+    errors.push(`Too many assignments: ${input.proposal.length} > cap ${input.cap}`);
+  }
+
+  const seenAgents = new Set<string>();
+  const seenIssues = new Set<number>();
+  for (const a of input.proposal) {
+    if (!idleSet.has(a.agentId)) errors.push(`agentId ${a.agentId} is not idle / unknown.`);
+    if (!pendingSet.has(a.issueId)) errors.push(`issueId ${a.issueId} is not pending / out of range.`);
+    if (seenAgents.has(a.agentId)) errors.push(`agent ${a.agentId} assigned twice.`);
+    if (seenIssues.has(a.issueId)) errors.push(`issue ${a.issueId} assigned twice.`);
+    seenAgents.add(a.agentId);
+    seenIssues.add(a.issueId);
+  }
+  return errors;
+}

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -1,0 +1,263 @@
+import { promises as fs } from "node:fs";
+import {
+  isRunComplete,
+  pendingIssueIds,
+  saveRunState,
+} from "../state/runState.js";
+import { loadRegistry, saveRegistry, createAgent, ensureAgent, mutateRegistry } from "../state/registry.js";
+import { dispatch } from "./dispatcher.js";
+import { runCodingAgent } from "../agent/codingAgent.js";
+import { applyMemoryUpdate } from "../memory/tagger.js";
+import {
+  createWorktree,
+  fetchOriginMain,
+  removeWorktree,
+  targetRepoPath,
+  type WorktreeHandle,
+} from "../git/worktree.js";
+import type { Logger } from "../log/logger.js";
+import type { AgentRecord, IssueSummary, RunState } from "../types.js";
+
+export interface OrchestratorInput {
+  state: RunState;
+  issues: IssueSummary[];
+  parallelism: number;
+  maxTicks: number;
+  logger: Logger;
+  dryRun: boolean;
+}
+
+export async function runOrchestrator(input: OrchestratorInput): Promise<void> {
+  const repoPath = await targetRepoPath(input.state.targetRepo);
+  await fetchOriginMain(repoPath);
+
+  const issuesById = new Map(input.issues.map((i) => [i.id, i]));
+
+  const inFlight = new Map<string, Promise<void>>();
+
+  while (!isRunComplete(input.state) && input.state.tickCount < input.maxTicks) {
+    input.state.tickCount += 1;
+    input.state.lastTickAt = new Date().toISOString();
+    await saveRunState(input.state);
+
+    const reg = await loadRegistry();
+    const idleAgents = await ensureIdleAgents({
+      desiredParallelism: input.parallelism,
+      state: input.state,
+      reg,
+    });
+    await saveRegistry(reg);
+    await saveRunState(input.state);
+
+    const pending = pendingIssueIds(input.state)
+      .map((id) => issuesById.get(id))
+      .filter((i): i is IssueSummary => i !== undefined);
+
+    const cap = Math.min(idleAgents.length, pending.length, input.parallelism - inFlight.size);
+
+    if (cap > 0) {
+      const proposal = await dispatch({
+        idleAgents: idleAgents.slice(0, cap),
+        pendingIssues: pending,
+        cap,
+        logger: input.logger,
+      });
+      input.logger.info("tick.proposal", {
+        tick: input.state.tickCount,
+        source: proposal.source,
+        assignments: proposal.assignments,
+      });
+
+      for (const assignment of proposal.assignments) {
+        const agent = ensureAgent(reg, assignment.agentId);
+        const issue = issuesById.get(assignment.issueId);
+        if (!issue) continue;
+
+        markInFlight(input.state, agent.agentId, assignment.issueId);
+        await saveRunState(input.state);
+
+        const promise = runOneIssue({
+          agent,
+          issue,
+          repoPath,
+          dryRun: input.dryRun,
+          logger: input.logger,
+          state: input.state,
+        }).catch(async (err) => {
+          input.logger.error("agent.uncaught", {
+            agentId: agent.agentId,
+            issueId: issue.id,
+            err: (err as Error).message,
+          });
+          markFailed(input.state, agent.agentId, issue.id, (err as Error).message);
+          await saveRunState(input.state);
+        }).finally(() => {
+          inFlight.delete(`${agent.agentId}:${issue.id}`);
+        });
+        inFlight.set(`${agent.agentId}:${issue.id}`, promise);
+      }
+      await saveRegistry(reg);
+    }
+
+    if (inFlight.size === 0) {
+      // No work was scheduled and nothing is running — break to avoid infinite tick loop.
+      input.logger.warn("orchestrator.no_progress", {
+        tick: input.state.tickCount,
+        pending: pendingIssueIds(input.state).length,
+      });
+      break;
+    }
+    await Promise.race(inFlight.values());
+  }
+
+  await Promise.allSettled(inFlight.values());
+  await saveRunState(input.state);
+}
+
+async function ensureIdleAgents(opts: {
+  desiredParallelism: number;
+  state: RunState;
+  reg: Awaited<ReturnType<typeof loadRegistry>>;
+}): Promise<AgentRecord[]> {
+  const inFlightAgents = new Set(
+    opts.state.agents.filter((a) => a.status === "in-flight").map((a) => a.agentId),
+  );
+
+  // Lazily create agents up to parallelism cap.
+  const knownIds = new Set(opts.reg.agents.map((a) => a.agentId));
+  for (const a of opts.state.agents) knownIds.add(a.agentId);
+  while (knownIds.size < opts.desiredParallelism) {
+    const fresh = createAgent(opts.reg);
+    knownIds.add(fresh.agentId);
+    if (!opts.state.agents.some((a) => a.agentId === fresh.agentId)) {
+      opts.state.agents.push({ agentId: fresh.agentId, status: "idle" });
+    }
+  }
+
+  return opts.reg.agents.filter((a) => !inFlightAgents.has(a.agentId));
+}
+
+function markInFlight(state: RunState, agentId: string, issueId: number): void {
+  state.issues[String(issueId)] = { status: "in-flight", agentId };
+  let entry = state.agents.find((a) => a.agentId === agentId);
+  if (!entry) {
+    entry = { agentId, status: "in-flight" };
+    state.agents.push(entry);
+  } else {
+    entry.status = "in-flight";
+  }
+}
+
+function markFailed(state: RunState, agentId: string, issueId: number, reason: string): void {
+  state.issues[String(issueId)] = {
+    status: "failed",
+    agentId,
+    outcome: "error",
+    error: reason,
+  };
+  const a = state.agents.find((x) => x.agentId === agentId);
+  if (a) a.status = "idle";
+}
+
+async function runOneIssue(opts: {
+  agent: AgentRecord;
+  issue: IssueSummary;
+  repoPath: string;
+  dryRun: boolean;
+  logger: Logger;
+  state: RunState;
+}): Promise<void> {
+  let worktree: WorktreeHandle | null = null;
+  try {
+    worktree = await createWorktree({
+      repoPath: opts.repoPath,
+      agentId: opts.agent.agentId,
+      issueId: opts.issue.id,
+    });
+    opts.logger.info("agent.spawned", {
+      agentId: opts.agent.agentId,
+      issueId: opts.issue.id,
+      worktree: worktree.path,
+      branch: worktree.branch,
+    });
+
+    const result = await runCodingAgent({
+      agent: opts.agent,
+      issueId: opts.issue.id,
+      targetRepo: opts.state.targetRepo,
+      worktreePath: worktree.path,
+      branchName: worktree.branch,
+      dryRun: opts.dryRun,
+      logger: opts.logger,
+    });
+
+    if (result.envelope) {
+      const env = result.envelope;
+      opts.agent.issuesHandled += 1;
+      if (env.decision === "implement") opts.agent.implementCount += 1;
+      else if (env.decision === "pushback") opts.agent.pushbackCount += 1;
+      else opts.agent.errorCount += 1;
+
+      await applyMemoryUpdate({
+        agent: opts.agent,
+        envelope: env,
+        issueId: opts.issue.id,
+      });
+      opts.logger.info("memory.updated", {
+        agentId: opts.agent.agentId,
+        issueId: opts.issue.id,
+        addTags: env.memoryUpdate.addTags,
+        finding: env.memoryUpdate.findingTitle ?? null,
+      });
+
+      opts.state.issues[String(opts.issue.id)] = {
+        status: env.decision === "error" ? "failed" : "done",
+        agentId: opts.agent.agentId,
+        outcome: env.decision,
+        prUrl: env.prUrl,
+        commentUrl: env.commentUrl,
+      };
+    } else {
+      opts.agent.errorCount += 1;
+      opts.state.issues[String(opts.issue.id)] = {
+        status: "failed",
+        agentId: opts.agent.agentId,
+        outcome: "error",
+        error: result.parseError ?? result.errorReason ?? "Unknown agent failure",
+      };
+    }
+
+    await mutateRegistry((reg) => {
+      const persisted = ensureAgent(reg, opts.agent.agentId);
+      Object.assign(persisted, {
+        tags: opts.agent.tags,
+        issuesHandled: opts.agent.issuesHandled,
+        implementCount: opts.agent.implementCount,
+        pushbackCount: opts.agent.pushbackCount,
+        errorCount: opts.agent.errorCount,
+        lastActiveAt: new Date().toISOString(),
+      });
+    });
+
+    const stateAgent = opts.state.agents.find((a) => a.agentId === opts.agent.agentId);
+    if (stateAgent) stateAgent.status = "idle";
+    await saveRunState(opts.state);
+  } finally {
+    if (worktree) {
+      const isImplement = opts.state.issues[String(opts.issue.id)]?.outcome === "implement";
+      // For pushback / error / no-envelope we delete the local branch (no remote tracking).
+      // For implement we keep the branch so the user can inspect or push if dry-run.
+      await removeWorktree({
+        repoPath: opts.repoPath,
+        worktree,
+        deleteBranch: !isImplement,
+      });
+      // Best-effort cleanup of an empty worktree dir.
+      try {
+        await fs.rmdir(worktree.path);
+      } catch {
+        // ignore
+      }
+    }
+  }
+}

--- a/src/orchestrator/prompt.ts
+++ b/src/orchestrator/prompt.ts
@@ -1,0 +1,41 @@
+import type { AgentRecord, IssueSummary } from "../types.js";
+
+export interface TickPromptInput {
+  pendingIssues: IssueSummary[];
+  idleAgents: AgentRecord[];
+  cap: number;
+  errorsFromPrior?: string[];
+}
+
+export function buildTickPrompt(input: TickPromptInput): string {
+  const pending = input.pendingIssues.map((i) => ({
+    id: i.id,
+    title: i.title,
+    labels: i.labels,
+  }));
+  const idle = input.idleAgents.map((a) => ({
+    agentId: a.agentId,
+    tags: a.tags,
+    issuesHandled: a.issuesHandled,
+  }));
+
+  const errorBlock = input.errorsFromPrior?.length
+    ? `\n\nYour PRIOR proposal failed validation. Fix these and re-emit:\n${input.errorsFromPrior.map((e) => `- ${e}`).join("\n")}\n`
+    : "";
+
+  return `You are the dispatcher for vp-dev. You assign idle agents to pending issues for ONE scheduling tick.
+
+Routing rule:
+- Prefer specialists by Jaccard overlap between agent.tags and issue.labels.
+- Brand-new general agents (tags == ["general"]) should pick up issues with no obvious specialist match.
+- Each agent gets at most ONE issue per tick. Each issue is assigned to at most ONE agent.
+- Emit at most ${input.cap} assignments.
+
+Inputs (JSON):
+${JSON.stringify({ pending, idle, cap: input.cap }, null, 2)}${errorBlock}
+
+Output ONLY valid JSON in this exact shape, no prose, no markdown:
+{"assignments":[{"agentId":"<id>","issueId":<number>}, ...]}
+
+If no productive assignments are available, emit {"assignments":[]}.`;
+}

--- a/src/orchestrator/routing.ts
+++ b/src/orchestrator/routing.ts
@@ -1,0 +1,64 @@
+import type { AgentRecord, IssueSummary } from "../types.js";
+
+export interface ScoredPair {
+  agentId: string;
+  issueId: number;
+  score: number;
+}
+
+export function jaccard(a: Iterable<string>, b: Iterable<string>): number {
+  const setA = new Set(toLowerSet(a));
+  const setB = new Set(toLowerSet(b));
+  if (setA.size === 0 && setB.size === 0) return 0;
+  let inter = 0;
+  for (const v of setA) if (setB.has(v)) inter++;
+  const union = setA.size + setB.size - inter;
+  return union === 0 ? 0 : inter / union;
+}
+
+function toLowerSet(it: Iterable<string>): string[] {
+  const out: string[] = [];
+  for (const v of it) out.push(v.toLowerCase());
+  return out;
+}
+
+export function scoreAgentIssue(agent: AgentRecord, issue: IssueSummary): number {
+  const j = jaccard(agent.tags, issue.labels);
+  return j + 0.05 * Math.log(1 + agent.issuesHandled);
+}
+
+export interface FallbackInput {
+  idleAgents: AgentRecord[];
+  pendingIssues: IssueSummary[];
+  cap: number;
+}
+
+export interface FallbackAssignment {
+  agentId: string;
+  issueId: number;
+}
+
+export function deterministicFallback(input: FallbackInput): FallbackAssignment[] {
+  const cap = Math.min(input.cap, input.idleAgents.length, input.pendingIssues.length);
+  if (cap <= 0) return [];
+
+  const pairs: ScoredPair[] = [];
+  for (const a of input.idleAgents) {
+    for (const i of input.pendingIssues) {
+      pairs.push({ agentId: a.agentId, issueId: i.id, score: scoreAgentIssue(a, i) });
+    }
+  }
+  pairs.sort((p, q) => q.score - p.score || p.agentId.localeCompare(q.agentId) || p.issueId - q.issueId);
+
+  const usedAgents = new Set<string>();
+  const usedIssues = new Set<number>();
+  const out: FallbackAssignment[] = [];
+  for (const p of pairs) {
+    if (out.length >= cap) break;
+    if (usedAgents.has(p.agentId) || usedIssues.has(p.issueId)) continue;
+    out.push({ agentId: p.agentId, issueId: p.issueId });
+    usedAgents.add(p.agentId);
+    usedIssues.add(p.issueId);
+  }
+  return out;
+}

--- a/src/state/locks.ts
+++ b/src/state/locks.ts
@@ -1,0 +1,85 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const ACQUIRE_TIMEOUT_MS = 5_000;
+const RETRY_INTERVAL_MS = 50;
+
+export class FileLock {
+  private readonly lockPath: string;
+  private acquired = false;
+
+  constructor(filePath: string) {
+    this.lockPath = `${filePath}.lock`;
+  }
+
+  async acquire(): Promise<void> {
+    const start = Date.now();
+    while (true) {
+      try {
+        const handle = await fs.open(this.lockPath, "wx");
+        await handle.writeFile(String(process.pid));
+        await handle.close();
+        this.acquired = true;
+        return;
+      } catch (err: unknown) {
+        if (!isENoEntOrEExist(err)) throw err;
+        if (Date.now() - start > ACQUIRE_TIMEOUT_MS) {
+          const stale = await this.staleHolder();
+          if (stale) {
+            await fs.rm(this.lockPath, { force: true });
+            continue;
+          }
+          throw new Error(`Timeout acquiring ${this.lockPath}`);
+        }
+        await sleep(RETRY_INTERVAL_MS);
+      }
+    }
+  }
+
+  async release(): Promise<void> {
+    if (!this.acquired) return;
+    await fs.rm(this.lockPath, { force: true });
+    this.acquired = false;
+  }
+
+  private async staleHolder(): Promise<boolean> {
+    try {
+      const pidStr = await fs.readFile(this.lockPath, "utf-8");
+      const pid = Number(pidStr.trim());
+      if (!Number.isInteger(pid) || pid <= 0) return true;
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+  }
+}
+
+export async function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
+  await ensureDir(path.dirname(filePath));
+  const lock = new FileLock(filePath);
+  await lock.acquire();
+  try {
+    return await fn();
+  } finally {
+    await lock.release();
+  }
+}
+
+export async function ensureDir(dir: string): Promise<void> {
+  await fs.mkdir(dir, { recursive: true });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isENoEntOrEExist(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const code = (err as { code?: string }).code;
+  return code === "EEXIST" || code === "ENOENT";
+}

--- a/src/state/registry.ts
+++ b/src/state/registry.ts
@@ -1,0 +1,72 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import { atomicWriteJson, STATE_DIR } from "./runState.js";
+import { withFileLock } from "./locks.js";
+import type { AgentRecord, AgentRegistryFile } from "../types.js";
+
+export const REGISTRY_FILE = path.join(STATE_DIR, "agents-registry.json");
+
+export async function loadRegistry(): Promise<AgentRegistryFile> {
+  try {
+    const raw = await fs.readFile(REGISTRY_FILE, "utf-8");
+    return JSON.parse(raw) as AgentRegistryFile;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return { agents: [] };
+    throw err;
+  }
+}
+
+export async function saveRegistry(reg: AgentRegistryFile): Promise<void> {
+  await withFileLock(REGISTRY_FILE, async () => {
+    await atomicWriteJson(REGISTRY_FILE, reg);
+  });
+}
+
+export async function mutateRegistry<T>(
+  fn: (reg: AgentRegistryFile) => T | Promise<T>,
+): Promise<T> {
+  return withFileLock(REGISTRY_FILE, async () => {
+    let raw: string;
+    try {
+      raw = await fs.readFile(REGISTRY_FILE, "utf-8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") raw = '{"agents":[]}';
+      else throw err;
+    }
+    const reg = JSON.parse(raw) as AgentRegistryFile;
+    const result = await fn(reg);
+    await atomicWriteJson(REGISTRY_FILE, reg);
+    return result;
+  });
+}
+
+export function newAgentId(): string {
+  const suffix = crypto.randomBytes(2).toString("hex");
+  return `agent-${suffix}`;
+}
+
+export function ensureAgent(reg: AgentRegistryFile, agentId: string): AgentRecord {
+  let rec = reg.agents.find((a) => a.agentId === agentId);
+  if (!rec) {
+    const now = new Date().toISOString();
+    rec = {
+      agentId,
+      createdAt: now,
+      tags: ["general"],
+      issuesHandled: 0,
+      implementCount: 0,
+      pushbackCount: 0,
+      errorCount: 0,
+      lastActiveAt: now,
+    };
+    reg.agents.push(rec);
+  }
+  return rec;
+}
+
+export function createAgent(reg: AgentRegistryFile): AgentRecord {
+  let id = newAgentId();
+  while (reg.agents.some((a) => a.agentId === id)) id = newAgentId();
+  return ensureAgent(reg, id);
+}

--- a/src/state/runState.ts
+++ b/src/state/runState.ts
@@ -1,0 +1,112 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { ensureDir, withFileLock } from "./locks.js";
+import type { RunState, RunIssueEntry, IssueRangeSpec } from "../types.js";
+
+export const STATE_DIR = path.resolve(process.cwd(), "state");
+const CURRENT_RUN_FILE = path.join(STATE_DIR, "current-run.txt");
+
+export function runFilePath(runId: string): string {
+  return path.join(STATE_DIR, `${runId}.json`);
+}
+
+export function makeRunId(): string {
+  const ts = new Date().toISOString().replace(/[:.]/g, "-").replace(/Z$/, "Z");
+  return `run-${ts}`;
+}
+
+export async function atomicWriteJson(filePath: string, data: unknown): Promise<void> {
+  await ensureDir(path.dirname(filePath));
+  const tmp = `${filePath}.tmp.${process.pid}`;
+  await fs.writeFile(tmp, JSON.stringify(data, null, 2));
+  await fs.rename(tmp, filePath);
+}
+
+export async function loadRunState(runId: string): Promise<RunState> {
+  const raw = await fs.readFile(runFilePath(runId), "utf-8");
+  return JSON.parse(raw) as RunState;
+}
+
+export async function saveRunState(state: RunState): Promise<void> {
+  const filePath = runFilePath(state.runId);
+  await withFileLock(filePath, async () => {
+    await atomicWriteJson(filePath, state);
+  });
+}
+
+export async function readCurrentRunId(): Promise<string | null> {
+  try {
+    const raw = await fs.readFile(CURRENT_RUN_FILE, "utf-8");
+    const id = raw.trim();
+    return id.length > 0 ? id : null;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+export async function writeCurrentRunId(runId: string): Promise<void> {
+  await ensureDir(STATE_DIR);
+  const tmp = `${CURRENT_RUN_FILE}.tmp.${process.pid}`;
+  await fs.writeFile(tmp, `${runId}\n`);
+  await fs.rename(tmp, CURRENT_RUN_FILE);
+}
+
+export async function clearCurrentRunId(): Promise<void> {
+  await fs.rm(CURRENT_RUN_FILE, { force: true });
+}
+
+export function newRunState(opts: {
+  runId: string;
+  targetRepo: string;
+  issueRange: IssueRangeSpec;
+  parallelism: number;
+  issueIds: number[];
+  dryRun: boolean;
+}): RunState {
+  const issues: Record<string, RunIssueEntry> = {};
+  for (const id of opts.issueIds) {
+    issues[String(id)] = { status: "pending" };
+  }
+  const now = new Date().toISOString();
+  return {
+    runId: opts.runId,
+    targetRepo: opts.targetRepo,
+    issueRange: opts.issueRange,
+    parallelism: opts.parallelism,
+    agents: [],
+    issues,
+    tickCount: 0,
+    lastTickAt: now,
+    startedAt: now,
+    dryRun: opts.dryRun,
+  };
+}
+
+export function isRunComplete(state: RunState): boolean {
+  for (const entry of Object.values(state.issues)) {
+    if (entry.status !== "done" && entry.status !== "failed") return false;
+  }
+  return true;
+}
+
+export function pendingIssueIds(state: RunState): number[] {
+  return Object.entries(state.issues)
+    .filter(([, entry]) => entry.status === "pending")
+    .map(([id]) => Number(id));
+}
+
+export function inFlightIssueIds(state: RunState): number[] {
+  return Object.entries(state.issues)
+    .filter(([, entry]) => entry.status === "in-flight")
+    .map(([id]) => Number(id));
+}
+
+export function downgradeInFlightToPending(state: RunState): void {
+  for (const [id, entry] of Object.entries(state.issues)) {
+    if (entry.status === "in-flight") {
+      state.issues[id] = { status: "pending" };
+    }
+  }
+  for (const a of state.agents) a.status = "idle";
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+
+export type IssueRangeSpec =
+  | { kind: "range"; from: number; to: number }
+  | { kind: "csv"; ids: number[] }
+  | { kind: "all-open" };
+
+export type AgentStatus = "idle" | "in-flight";
+
+export type IssueStatus = "pending" | "in-flight" | "done" | "failed";
+
+export type AgentDecision = "implement" | "pushback" | "error";
+
+export interface AgentRecord {
+  agentId: string;
+  createdAt: string;
+  tags: string[];
+  issuesHandled: number;
+  implementCount: number;
+  pushbackCount: number;
+  errorCount: number;
+  lastActiveAt: string;
+}
+
+export interface AgentRegistryFile {
+  agents: AgentRecord[];
+}
+
+export interface RunAgentEntry {
+  agentId: string;
+  status: AgentStatus;
+}
+
+export interface RunIssueEntry {
+  status: IssueStatus;
+  agentId?: string;
+  outcome?: AgentDecision;
+  prUrl?: string;
+  commentUrl?: string;
+  error?: string;
+}
+
+export interface RunState {
+  runId: string;
+  targetRepo: string;
+  issueRange: IssueRangeSpec;
+  parallelism: number;
+  agents: RunAgentEntry[];
+  issues: Record<string, RunIssueEntry>;
+  tickCount: number;
+  lastTickAt: string;
+  startedAt: string;
+  dryRun: boolean;
+}
+
+export const ResultEnvelopeSchema = z.object({
+  decision: z.enum(["implement", "pushback", "error"]),
+  reason: z.string().min(1),
+  prUrl: z.string().optional(),
+  commentUrl: z.string().optional(),
+  scopeNotes: z.string().optional(),
+  memoryUpdate: z.object({
+    addTags: z.array(z.string()).default([]),
+    removeTags: z.array(z.string()).optional(),
+    findingTitle: z.string().optional(),
+    findingBody: z.string().optional(),
+  }),
+});
+
+export type ResultEnvelope = z.infer<typeof ResultEnvelopeSchema>;
+
+export const TickAssignmentSchema = z.object({
+  agentId: z.string().min(1),
+  issueId: z.number().int().positive(),
+});
+
+export const TickProposalSchema = z.object({
+  assignments: z.array(TickAssignmentSchema),
+});
+
+export type TickAssignment = z.infer<typeof TickAssignmentSchema>;
+export type TickProposal = z.infer<typeof TickProposalSchema>;
+
+export interface IssueSummary {
+  id: number;
+  title: string;
+  labels: string[];
+  state: "open" | "closed";
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts", "bin/**/*.ts"],
+  "exclude": ["node_modules", "dist", "state", "agents", "logs"]
+}


### PR DESCRIPTION
## Summary
- Implements the TypeScript framework per the agreed plan: sonnet orchestrator dispatches issues to N parallel opus coding agents.
- File-backed JSON state, per-agent persistent memory, gh/git tool allowlist, three-layer block on pushes to main.
- Adds GitHub Actions CI: typecheck + build on every PR and main push.

## Test plan
- [x] \`npm ci\` clean
- [x] \`npm run typecheck\` passes
- [x] \`npm run build\` produces \`dist/\`
- [x] \`vp-dev --help\`, \`vp-dev status\`, \`vp-dev agents list\` run
- [x] Smoke: range parser, deterministic Jaccard fallback, envelope extractor
- [ ] Live dry-run smoke against two real \`vaultpilot-mcp\` issues — pending separate run

🤖 Generated with [Claude Code](https://claude.com/claude-code)