### PR TITLE
Chat-orchestrator primitives: vp-dev spawn + agents pick

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
   push:
     branches: [main]
 

--- a/src/agent/runIssueCore.ts
+++ b/src/agent/runIssueCore.ts
@@ -1,0 +1,177 @@
+import { promises as fs } from "node:fs";
+import { ensureAgent, mutateRegistry } from "../state/registry.js";
+import { runCodingAgent } from "./codingAgent.js";
+import { appendBlock, forkClaudeMd, type AppendOutcome } from "./specialization.js";
+import { summarizeRun } from "./summarizer.js";
+import {
+  createWorktree,
+  removeWorktree,
+  type WorktreeHandle,
+} from "../git/worktree.js";
+import type { Logger } from "../log/logger.js";
+import type { AgentRecord, IssueSummary, ResultEnvelope } from "../types.js";
+
+export interface RunIssueCoreInput {
+  agent: AgentRecord;
+  issue: IssueSummary;
+  targetRepo: string;
+  targetRepoPath: string;
+  runId: string;
+  dryRun: boolean;
+  logger: Logger;
+  skipSummary?: boolean;
+}
+
+export interface RunIssueCoreResult {
+  envelope?: ResultEnvelope;
+  finalText: string;
+  parseError?: string;
+  durationMs: number;
+  costUsd?: number;
+  isError: boolean;
+  errorReason?: string;
+  appendOutcome?: AppendOutcome;
+  summarySkipReason?: string;
+  worktreePath?: string;
+  branchName?: string;
+}
+
+export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCoreResult> {
+  let worktree: WorktreeHandle | null = null;
+  let envelope: ResultEnvelope | undefined;
+
+  try {
+    await forkClaudeMd(input.agent.agentId, input.targetRepoPath);
+
+    worktree = await createWorktree({
+      repoPath: input.targetRepoPath,
+      agentId: input.agent.agentId,
+      issueId: input.issue.id,
+    });
+    input.logger.info("agent.spawned", {
+      agentId: input.agent.agentId,
+      issueId: input.issue.id,
+      worktree: worktree.path,
+      branch: worktree.branch,
+    });
+
+    const result = await runCodingAgent({
+      agent: input.agent,
+      issueId: input.issue.id,
+      targetRepo: input.targetRepo,
+      targetRepoPath: input.targetRepoPath,
+      worktreePath: worktree.path,
+      branchName: worktree.branch,
+      dryRun: input.dryRun,
+      logger: input.logger,
+    });
+
+    envelope = result.envelope;
+    let appendOutcome: AppendOutcome | undefined;
+    let summarySkipReason: string | undefined;
+
+    if (envelope) {
+      input.agent.issuesHandled += 1;
+      if (envelope.decision === "implement") input.agent.implementCount += 1;
+      else if (envelope.decision === "pushback") input.agent.pushbackCount += 1;
+      else input.agent.errorCount += 1;
+
+      applyTagUpdate(input.agent, envelope);
+
+      if (!input.skipSummary) {
+        const summary = await summarizeRun({
+          agent: input.agent,
+          issue: input.issue,
+          envelope,
+          toolUseTrace: result.toolUseTrace,
+          finalText: result.finalText,
+          logger: input.logger,
+        });
+
+        if (summary.skip || !summary.heading || !summary.body) {
+          summarySkipReason = summary.skipReason ?? "no body";
+          input.logger.info("specialization.skipped", {
+            agentId: input.agent.agentId,
+            issueId: input.issue.id,
+            reason: summarySkipReason,
+          });
+        } else {
+          appendOutcome = await appendBlock({
+            agentId: input.agent.agentId,
+            runId: input.runId,
+            issueId: input.issue.id,
+            outcome: envelope.decision,
+            heading: summary.heading,
+            body: summary.body,
+            targetRepoPath: input.targetRepoPath,
+          });
+          if (appendOutcome.kind === "appended") {
+            input.logger.info("specialization.appended", {
+              agentId: input.agent.agentId,
+              issueId: input.issue.id,
+              heading: summary.heading,
+              bytesAppended: appendOutcome.bytesAppended,
+              totalBytes: appendOutcome.totalBytes,
+            });
+          } else {
+            input.logger.warn("specialization.cap", {
+              agentId: input.agent.agentId,
+              issueId: input.issue.id,
+              totalBytes: appendOutcome.totalBytes,
+            });
+          }
+        }
+      }
+    } else {
+      input.agent.errorCount += 1;
+    }
+
+    await mutateRegistry((reg) => {
+      const persisted = ensureAgent(reg, input.agent.agentId);
+      Object.assign(persisted, {
+        tags: input.agent.tags,
+        issuesHandled: input.agent.issuesHandled,
+        implementCount: input.agent.implementCount,
+        pushbackCount: input.agent.pushbackCount,
+        errorCount: input.agent.errorCount,
+        lastActiveAt: new Date().toISOString(),
+      });
+    });
+
+    return {
+      envelope,
+      finalText: result.finalText,
+      parseError: result.parseError,
+      durationMs: result.durationMs,
+      costUsd: result.costUsd,
+      isError: result.isError,
+      errorReason: result.errorReason,
+      appendOutcome,
+      summarySkipReason,
+      worktreePath: worktree?.path,
+      branchName: worktree?.branch,
+    };
+  } finally {
+    if (worktree) {
+      const isImplement = envelope?.decision === "implement";
+      await removeWorktree({
+        repoPath: input.targetRepoPath,
+        worktree,
+        deleteBranch: !isImplement,
+      });
+      try {
+        await fs.rmdir(worktree.path);
+      } catch {
+        // ignore
+      }
+    }
+  }
+}
+
+function applyTagUpdate(agent: AgentRecord, env: ResultEnvelope): void {
+  const tags = new Set(agent.tags);
+  for (const t of env.memoryUpdate.addTags) tags.add(t.toLowerCase());
+  for (const t of env.memoryUpdate.removeTags ?? []) tags.delete(t.toLowerCase());
+  if (tags.size === 0) tags.add("general");
+  agent.tags = [...tags].sort();
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,14 +10,16 @@ import {
   saveRunState,
   writeCurrentRunId,
 } from "./state/runState.js";
-import { loadRegistry } from "./state/registry.js";
+import { createAgent, loadRegistry, mutateRegistry } from "./state/registry.js";
 import { parseRangeSpec, describeRange } from "./github/range.js";
-import { resolveRangeToIssues } from "./github/gh.js";
-import { runOrchestrator } from "./orchestrator/orchestrator.js";
+import { getIssue, resolveRangeToIssues } from "./github/gh.js";
+import { pickAgents, runOrchestrator } from "./orchestrator/orchestrator.js";
 import { approveSetup, buildSetupPreview } from "./orchestrator/setup.js";
 import { Logger } from "./log/logger.js";
-import { pruneWorktrees, resolveTargetRepoPath } from "./git/worktree.js";
-import type { IssueRangeSpec } from "./types.js";
+import { fetchOriginMain, pruneWorktrees, resolveTargetRepoPath } from "./git/worktree.js";
+import { forkClaudeMd } from "./agent/specialization.js";
+import { runIssueCore } from "./agent/runIssueCore.js";
+import type { AgentRecord, IssueRangeSpec, IssueSummary } from "./types.js";
 
 const DEFAULT_MAX_TICKS = 200;
 
@@ -49,7 +51,20 @@ export function buildCli(): Command {
     });
 
   program
-    .command("agents")
+    .command("spawn")
+    .description("Run one coding agent on one issue (chat-orchestrator primitive)")
+    .requiredOption("--agent <id-or-new>", "Existing agent ID or 'new' to mint a fresh general")
+    .requiredOption("--issue <n>", "Issue number to work on", parsePositive)
+    .requiredOption("--target-repo <owner/repo>", "Target GitHub repo")
+    .option("--target-repo-path <path>", "Local clone path of the target repo")
+    .option("--dry-run", "Intercept comment / PR / push tools with synthetic responses")
+    .option("--verbose", "Mirror a colorized event subset to stderr")
+    .option("--skip-summary", "Skip summarizer + CLAUDE.md append")
+    .action(async (opts) => {
+      await cmdSpawn(opts);
+    });
+
+  const agentsCmd = new Command("agents")
     .description("Agent management")
     .addCommand(
       new Command("list")
@@ -57,7 +72,20 @@ export function buildCli(): Command {
         .action(async () => {
           await cmdAgentsList();
         }),
+    )
+    .addCommand(
+      new Command("pick")
+        .description("Score the registry against a set of pending issues; print picks (no mutation)")
+        .requiredOption("--issues <csv>", "Issue numbers (comma-separated)")
+        .requiredOption("--target-repo <owner/repo>", "Target GitHub repo")
+        .requiredOption("--parallelism <n>", "Desired parallelism", parsePositive)
+        .option("--target-repo-path <path>", "Local clone path of the target repo")
+        .option("--json", "Print machine-readable JSON")
+        .action(async (opts) => {
+          await cmdAgentsPick(opts);
+        }),
     );
+  program.addCommand(agentsCmd);
 
   return program;
 }
@@ -280,6 +308,165 @@ async function cmdAgentsList(): Promise<void> {
     a.lastActiveAt,
   ]);
   printTable(headers, rows);
+}
+
+interface SpawnOpts {
+  agent: string;
+  issue: number;
+  targetRepo: string;
+  targetRepoPath?: string;
+  dryRun?: boolean;
+  verbose?: boolean;
+  skipSummary?: boolean;
+}
+
+async function cmdSpawn(opts: SpawnOpts): Promise<void> {
+  const repoPath = await resolveTargetRepoPath(opts.targetRepo, opts.targetRepoPath);
+  const issue = await getIssue(opts.targetRepo, opts.issue);
+  if (!issue) {
+    process.stderr.write(`ERROR: issue #${opts.issue} not found in ${opts.targetRepo}.\n`);
+    process.exit(2);
+  }
+  if (issue.state === "closed") {
+    process.stderr.write(`ERROR: issue #${opts.issue} is closed.\n`);
+    process.exit(2);
+  }
+
+  const agent = await resolveOrMintAgent(opts.agent, repoPath);
+  if (!agent) {
+    process.stderr.write(`ERROR: agent '${opts.agent}' not found in registry. Pass --agent new to mint a fresh general.\n`);
+    process.exit(2);
+  }
+
+  const runId = `spawn-${new Date().toISOString().replace(/[:.]/g, "-")}-issue-${opts.issue}`;
+  const logger = new Logger({ runId, verbose: !!opts.verbose });
+  await logger.open();
+  logger.info("spawn.started", {
+    runId,
+    agentId: agent.agentId,
+    issueId: opts.issue,
+    targetRepo: opts.targetRepo,
+    targetRepoPath: repoPath,
+    dryRun: !!opts.dryRun,
+    skipSummary: !!opts.skipSummary,
+  });
+
+  try {
+    await fetchOriginMain(repoPath);
+    await pruneWorktrees(repoPath);
+
+    const result = await runIssueCore({
+      agent,
+      issue,
+      targetRepo: opts.targetRepo,
+      targetRepoPath: repoPath,
+      runId,
+      dryRun: !!opts.dryRun,
+      logger,
+      skipSummary: !!opts.skipSummary,
+    });
+
+    const out = {
+      runId,
+      agentId: agent.agentId,
+      agentTags: agent.tags,
+      issueId: opts.issue,
+      envelope: result.envelope ?? null,
+      isError: result.isError,
+      errorReason: result.errorReason ?? null,
+      parseError: result.parseError ?? null,
+      durationMs: result.durationMs,
+      costUsd: result.costUsd ?? null,
+      appendOutcome: result.appendOutcome ?? null,
+      summarySkipReason: result.summarySkipReason ?? null,
+    };
+    process.stdout.write(JSON.stringify(out, null, 2) + "\n");
+  } finally {
+    await logger.close();
+  }
+}
+
+async function resolveOrMintAgent(spec: string, repoPath: string): Promise<AgentRecord | null> {
+  if (spec === "new") {
+    const fresh = await mutateRegistry((reg) => createAgent(reg));
+    await forkClaudeMd(fresh.agentId, repoPath);
+    return fresh;
+  }
+  const reg = await loadRegistry();
+  const found = reg.agents.find((a) => a.agentId === spec);
+  return found ?? null;
+}
+
+interface PickOpts {
+  issues: string;
+  targetRepo: string;
+  parallelism: number;
+  targetRepoPath?: string;
+  json?: boolean;
+}
+
+async function cmdAgentsPick(opts: PickOpts): Promise<void> {
+  const ids = opts.issues
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .map((s) => parsePositive(s));
+
+  const issues: IssueSummary[] = [];
+  const closed: number[] = [];
+  const missing: number[] = [];
+  for (const id of ids) {
+    const issue = await getIssue(opts.targetRepo, id);
+    if (!issue) missing.push(id);
+    else if (issue.state === "closed") closed.push(id);
+    else issues.push(issue);
+  }
+
+  const reg = await loadRegistry();
+  const result = pickAgents({
+    reg,
+    pendingIssues: issues,
+    desiredParallelism: opts.parallelism,
+  });
+
+  if (opts.json) {
+    const payload = {
+      targetRepo: opts.targetRepo,
+      parallelism: opts.parallelism,
+      issues: issues.map((i) => ({ id: i.id, title: i.title, labels: i.labels })),
+      missing,
+      closed,
+      reusedAgents: result.reusedAgents.map((p) => ({
+        agentId: p.agent.agentId,
+        tags: p.agent.tags,
+        issuesHandled: p.agent.issuesHandled,
+        score: p.score,
+      })),
+      newAgentsToMint: result.newAgentsToMint,
+    };
+    process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
+    return;
+  }
+
+  process.stdout.write(`Picks for ${opts.targetRepo} (parallelism=${opts.parallelism}):\n`);
+  process.stdout.write(`  open issues:    ${issues.length}\n`);
+  if (closed.length) process.stdout.write(`  closed skipped: ${closed.length} (${closed.join(",")})\n`);
+  if (missing.length) process.stdout.write(`  not found:      ${missing.length} (${missing.join(",")})\n`);
+  process.stdout.write("\n");
+
+  if (result.reusedAgents.length === 0) {
+    process.stdout.write("  (no agents in registry)\n");
+  } else {
+    for (const p of result.reusedAgents) {
+      const tagStr = p.agent.tags.length > 0 ? p.agent.tags.join(",") : "general";
+      process.stdout.write(
+        `  ${p.agent.agentId}  tags=[${tagStr}]  issuesHandled=${p.agent.issuesHandled}  score=${p.score.toFixed(3)}\n`,
+      );
+    }
+  }
+  if (result.newAgentsToMint > 0) {
+    process.stdout.write(`  + ${result.newAgentsToMint} fresh general agent(s) needed\n`);
+  }
 }
 
 function printTable(headers: string[], rows: string[][]): void {

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -1,28 +1,22 @@
-import { promises as fs } from "node:fs";
 import {
   isRunComplete,
   pendingIssueIds,
   saveRunState,
 } from "../state/runState.js";
-import { createAgent, ensureAgent, mutateRegistry } from "../state/registry.js";
+import { createAgent, mutateRegistry } from "../state/registry.js";
 import { dispatch } from "./dispatcher.js";
-import { runCodingAgent } from "../agent/codingAgent.js";
 import { jaccard } from "./routing.js";
-import { appendBlock, forkClaudeMd } from "../agent/specialization.js";
-import { summarizeRun } from "../agent/summarizer.js";
+import { forkClaudeMd } from "../agent/specialization.js";
+import { runIssueCore } from "../agent/runIssueCore.js";
 import {
-  createWorktree,
   fetchOriginMain,
-  removeWorktree,
   resolveTargetRepoPath,
-  type WorktreeHandle,
 } from "../git/worktree.js";
 import type { Logger } from "../log/logger.js";
 import type {
   AgentRecord,
   AgentRegistryFile,
   IssueSummary,
-  ResultEnvelope,
   RunState,
 } from "../types.js";
 
@@ -255,137 +249,35 @@ async function runOneIssue(opts: {
   logger: Logger;
   state: RunState;
 }): Promise<void> {
-  let worktree: WorktreeHandle | null = null;
-  try {
-    await forkClaudeMd(opts.agent.agentId, opts.repoPath);
+  const result = await runIssueCore({
+    agent: opts.agent,
+    issue: opts.issue,
+    targetRepo: opts.state.targetRepo,
+    targetRepoPath: opts.repoPath,
+    runId: opts.state.runId,
+    dryRun: opts.dryRun,
+    logger: opts.logger,
+  });
 
-    worktree = await createWorktree({
-      repoPath: opts.repoPath,
+  if (result.envelope) {
+    const env = result.envelope;
+    opts.state.issues[String(opts.issue.id)] = {
+      status: env.decision === "error" ? "failed" : "done",
       agentId: opts.agent.agentId,
-      issueId: opts.issue.id,
-    });
-    opts.logger.info("agent.spawned", {
+      outcome: env.decision,
+      prUrl: env.prUrl,
+      commentUrl: env.commentUrl,
+    };
+  } else {
+    opts.state.issues[String(opts.issue.id)] = {
+      status: "failed",
       agentId: opts.agent.agentId,
-      issueId: opts.issue.id,
-      worktree: worktree.path,
-      branch: worktree.branch,
-    });
-
-    const result = await runCodingAgent({
-      agent: opts.agent,
-      issueId: opts.issue.id,
-      targetRepo: opts.state.targetRepo,
-      targetRepoPath: opts.repoPath,
-      worktreePath: worktree.path,
-      branchName: worktree.branch,
-      dryRun: opts.dryRun,
-      logger: opts.logger,
-    });
-
-    if (result.envelope) {
-      const env = result.envelope;
-      opts.agent.issuesHandled += 1;
-      if (env.decision === "implement") opts.agent.implementCount += 1;
-      else if (env.decision === "pushback") opts.agent.pushbackCount += 1;
-      else opts.agent.errorCount += 1;
-
-      applyTagUpdate(opts.agent, env);
-
-      opts.state.issues[String(opts.issue.id)] = {
-        status: env.decision === "error" ? "failed" : "done",
-        agentId: opts.agent.agentId,
-        outcome: env.decision,
-        prUrl: env.prUrl,
-        commentUrl: env.commentUrl,
-      };
-
-      const summary = await summarizeRun({
-        agent: opts.agent,
-        issue: opts.issue,
-        envelope: env,
-        toolUseTrace: result.toolUseTrace,
-        finalText: result.finalText,
-        logger: opts.logger,
-      });
-
-      if (summary.skip || !summary.heading || !summary.body) {
-        opts.logger.info("specialization.skipped", {
-          agentId: opts.agent.agentId,
-          issueId: opts.issue.id,
-          reason: summary.skipReason ?? "no body",
-        });
-      } else {
-        const outcome = await appendBlock({
-          agentId: opts.agent.agentId,
-          runId: opts.state.runId,
-          issueId: opts.issue.id,
-          outcome: env.decision,
-          heading: summary.heading,
-          body: summary.body,
-          targetRepoPath: opts.repoPath,
-        });
-        if (outcome.kind === "appended") {
-          opts.logger.info("specialization.appended", {
-            agentId: opts.agent.agentId,
-            issueId: opts.issue.id,
-            heading: summary.heading,
-            bytesAppended: outcome.bytesAppended,
-            totalBytes: outcome.totalBytes,
-          });
-        } else {
-          opts.logger.warn("specialization.cap", {
-            agentId: opts.agent.agentId,
-            issueId: opts.issue.id,
-            totalBytes: outcome.totalBytes,
-          });
-        }
-      }
-    } else {
-      opts.agent.errorCount += 1;
-      opts.state.issues[String(opts.issue.id)] = {
-        status: "failed",
-        agentId: opts.agent.agentId,
-        outcome: "error",
-        error: result.parseError ?? result.errorReason ?? "Unknown agent failure",
-      };
-    }
-
-    await mutateRegistry((reg) => {
-      const persisted = ensureAgent(reg, opts.agent.agentId);
-      Object.assign(persisted, {
-        tags: opts.agent.tags,
-        issuesHandled: opts.agent.issuesHandled,
-        implementCount: opts.agent.implementCount,
-        pushbackCount: opts.agent.pushbackCount,
-        errorCount: opts.agent.errorCount,
-        lastActiveAt: new Date().toISOString(),
-      });
-    });
-
-    const stateAgent = opts.state.agents.find((a) => a.agentId === opts.agent.agentId);
-    if (stateAgent) stateAgent.status = "idle";
-    await saveRunState(opts.state);
-  } finally {
-    if (worktree) {
-      const isImplement = opts.state.issues[String(opts.issue.id)]?.outcome === "implement";
-      await removeWorktree({
-        repoPath: opts.repoPath,
-        worktree,
-        deleteBranch: !isImplement,
-      });
-      try {
-        await fs.rmdir(worktree.path);
-      } catch {
-        // ignore
-      }
-    }
+      outcome: "error",
+      error: result.parseError ?? result.errorReason ?? "Unknown agent failure",
+    };
   }
-}
 
-function applyTagUpdate(agent: AgentRecord, env: ResultEnvelope): void {
-  const tags = new Set(agent.tags);
-  for (const t of env.memoryUpdate.addTags) tags.add(t.toLowerCase());
-  for (const t of env.memoryUpdate.removeTags ?? []) tags.delete(t.toLowerCase());
-  if (tags.size === 0) tags.add("general");
-  agent.tags = [...tags].sort();
+  const stateAgent = opts.state.agents.find((a) => a.agentId === opts.agent.agentId);
+  if (stateAgent) stateAgent.status = "idle";
+  await saveRunState(opts.state);
 }


### PR DESCRIPTION
## Summary

Extracts the per-issue lifecycle (fork → worktree → \`query()\` → summarize → append → cleanup) into \`runIssueCore()\` with no \`RunState\` dependency, and exposes two new CLI subcommands so a chat assistant can drive orchestration directly:

- **\`vp-dev agents pick --issues <csv> --target-repo <r> --parallelism N [--json]\`** — pure scoring, no mutation.
- **\`vp-dev spawn --agent <id|new> --issue <N> --target-repo <r> [--dry-run] [--verbose] [--skip-summary]\`** — one coding agent on one issue, prints envelope JSON. Updates registry; does not write run-state.

\`vp-dev run\` and \`src/orchestrator/dispatcher.ts\` stay — reserved for future level-2 subagents under a higher-level scripted orchestrator.

## Stacking note
Branched off [#3](https://github.com/szhygulin/vaultpilot-development-agents/pull/3) (still open) because \`pickAgents()\` lives there. Will rebase onto \`main\` after #3 merges.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` clean
- [x] \`vp-dev --help\` lists \`spawn\` and \`agents pick\`
- [x] \`vp-dev agents pick --json\` against empty registry → \`{newAgentsToMint: 2, reusedAgents: []}\`
- [x] \`vp-dev spawn --issue 999999\` exits 2 with clear error
- [ ] Live spawn against a real issue — pending separate run

🤖 Generated with [Claude Code](https://claude.com/claude-code)