### PR TITLE
fix(summarizer): clamp oversize body before schema, log raw payload on failure

### DIFF
--- a/src/agent/summarizer.ts
+++ b/src/agent/summarizer.ts
@@ -5,11 +5,14 @@ import type { Logger } from "../log/logger.js";
 
 const SUMMARIZER_MODEL = "claude-sonnet-4-6";
 
+const HEADING_MAX = 120;
+const BODY_MAX = 2000;
+
 export const SummarizerOutputSchema = z.object({
   skip: z.boolean(),
   skipReason: z.string().optional(),
-  heading: z.string().min(3).max(120).optional(),
-  body: z.string().min(3).max(800).optional(),
+  heading: z.string().min(3).max(HEADING_MAX).optional(),
+  body: z.string().min(3).max(BODY_MAX).optional(),
 });
 export type SummarizerOutput = z.infer<typeof SummarizerOutputSchema>;
 
@@ -64,16 +67,61 @@ export async function summarizeRun(input: SummarizerInput): Promise<SummarizerOu
 
   const json = parseJsonLoose(raw);
   if (!json) {
+    input.logger.warn("summarizer.malformed_payload", {
+      agentId: input.agent.agentId,
+      issueId: input.issue.id,
+      raw: raw.slice(0, 4000),
+    });
     return { skip: true, skipReason: "summarizer output not valid JSON" };
   }
-  const parsed = SummarizerOutputSchema.safeParse(json);
+
+  // Post-parse safety net: clamp oversize heading/body BEFORE schema
+  // validation so the entire summary isn't discarded just because the LLM
+  // ignored the prompt's length directive. The schema's max bounds still
+  // act as a hard ceiling — clamping happens against those same constants.
+  const clamped = clampLengths(json, input);
+
+  const parsed = SummarizerOutputSchema.safeParse(clamped);
   if (!parsed.success) {
-    return { skip: true, skipReason: `summarizer schema invalid: ${parsed.error.message}` };
+    input.logger.warn("summarizer.malformed_payload", {
+      agentId: input.agent.agentId,
+      issueId: input.issue.id,
+      raw: raw.slice(0, 4000),
+      zodError: parsed.error.message.replace(/\s+/g, " "),
+    });
+    return { skip: true, skipReason: `summarizer schema invalid: ${parsed.error.message.replace(/\s+/g, " ").slice(0, 400)}` };
   }
   if (!parsed.data.skip && (!parsed.data.heading || !parsed.data.body)) {
     return { skip: true, skipReason: "missing heading or body" };
   }
   return parsed.data;
+}
+
+function clampLengths(json: unknown, input: SummarizerInput): unknown {
+  if (!json || typeof json !== "object") return json;
+  const obj = json as Record<string, unknown>;
+  const out: Record<string, unknown> = { ...obj };
+  if (typeof obj.heading === "string" && obj.heading.length > HEADING_MAX) {
+    out.heading = obj.heading.slice(0, HEADING_MAX - 3) + "...";
+    input.logger.warn("summarizer.clamped", {
+      agentId: input.agent.agentId,
+      issueId: input.issue.id,
+      field: "heading",
+      originalLength: obj.heading.length,
+      max: HEADING_MAX,
+    });
+  }
+  if (typeof obj.body === "string" && obj.body.length > BODY_MAX) {
+    out.body = obj.body.slice(0, BODY_MAX - 16) + "\n[…truncated]";
+    input.logger.warn("summarizer.clamped", {
+      agentId: input.agent.agentId,
+      issueId: input.issue.id,
+      field: "body",
+      originalLength: obj.body.length,
+      max: BODY_MAX,
+    });
+  }
+  return out;
 }
 
 const SUMMARIZER_SYSTEM_PROMPT = `You are a distillation agent. After a coding agent has finished work on a single GitHub issue, your job is to extract any GENERALIZABLE rule that should bind the agent's behavior on FUTURE similar issues — and append it to the agent's evolving CLAUDE.md.
@@ -84,7 +132,7 @@ Hard rules:
 - If there is no GENERALIZABLE lesson — only a one-off fix, a routine implementation, a trivial pushback — return {"skip": true, "skipReason": "<one short sentence>"}. Empty learnings beat noisy ones.
 - If the agent failed (decision="error"), default to skip unless there's a clear lesson about the failure mode itself.
 - Heading: ≤ 120 chars, no trailing colon, no markdown prefix (no leading "##"). The append step prepends "##".
-- Body: ≤ 800 chars. 2–6 short lines. No prose paragraphs.
+- Body: ≤ 2000 chars. 2–8 short lines. No prose paragraphs.
 - Do NOT mention the specific issue number, PR number, or run id — that's in the provenance comment. Talk about the class of situation, not this instance.
 
 Output: a single JSON object, no fences, no prose. Schema:

--- a/src/log/logger.ts
+++ b/src/log/logger.ts
@@ -94,6 +94,9 @@ function formatVerbose(line: LogEvent): string {
 
 function truncateValue(v: unknown): string {
   if (v == null) return String(v);
-  const s = typeof v === "string" ? v : JSON.stringify(v);
-  return s.length > 200 ? s.slice(0, 197) + "..." : s;
+  const raw = typeof v === "string" ? v : JSON.stringify(v);
+  // Collapse newlines + leading whitespace so verbose stderr stays single-line
+  // per event. The persisted JSONL keeps the original (no flattening).
+  const flat = raw.replace(/\s+/g, " ");
+  return flat.length > 200 ? flat.slice(0, 197) + "..." : flat;
 }


### PR DESCRIPTION
## Summary

Bug fix from the 2026-05-01 vp-dev dry-run test where the summarizer rejected its own output 2× in one run (`specialization.skipped reason=summarizer schema invalid`). Root cause: `body: z.string().max(800)` was too tight — the LLM ignored the prompt directive and produced longer bodies, Zod rejected, the entire summary was discarded.

## Changes

- **Raise `BODY_MAX` 800 → 2000** (`src/agent/summarizer.ts`). Matches realistic length of summary content this writes back into per-agent `CLAUDE.md`. Updated the prompt directive to match (`≤ 2000 chars, 2–8 short lines`).
- **Post-parse safety net** (`clampLengths`): if `heading > 120` or `body > 2000` after the LLM returns, truncate with a marker and emit `summarizer.clamped` warn event — schema bounds remain the hard ceiling but a single LLM length-overshoot no longer discards the whole summary.
- **Raw-payload diagnostics**: on JSON-parse failure or schema-validation failure, emit `summarizer.malformed_payload` with the raw LLM output (first 4000 chars). Operator can inspect what the LLM actually returned without reproducing.
- **Verbose log flattening** (`src/log/logger.ts:truncateValue`): collapse all whitespace runs to single spaces in the verbose-stderr formatter so multi-line reasons (e.g. zod error JSON) render on one line. The persisted JSONL keeps the original (no flattening).

## Why this isn't just "raise the limit"

The summarizer's robustness is a one-shot LLM call — there's no retry, no recovery. Today an LLM that returns 801 chars (1 over) costs the operator the entire summary. The clamp adds a single safety net so prompt drift doesn't silently break per-agent memory updates. The schema bounds stay as a hard ceiling so the clamp can't be used to smuggle giant payloads (the LLM gets one chance to stay under 2000 + truncation marker).

## Verification

- `npm run typecheck` ✓
- `npm run build` ✓
- End-to-end: re-running the dry-run on the same 4 issues should show zero `specialization.skipped reason=summarizer schema invalid` events. If a body still overshoots 2000 chars (unlikely), expect `summarizer.clamped` instead.

## Test plan
- [ ] `npm ci && npm run typecheck && npm run build`
- [ ] Re-run dry-run, confirm no schema-invalid skips
- [ ] If schema fails for a different reason, confirm raw payload is logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)