### PR TITLE
fix(orchestrator): require dispatcher to fill cap, retry on under-dispatch

### DIFF
--- a/src/orchestrator/dispatcher.ts
+++ b/src/orchestrator/dispatcher.ts
@@ -160,6 +160,17 @@ function validateProposal(input: ValidateInput): string[] {
   if (input.proposal.length > input.cap) {
     errors.push(`Too many assignments: ${input.proposal.length} > cap ${input.cap}`);
   }
+  // Under-dispatch wastes parallelism: when cap > 0 the dispatcher must fill
+  // every available slot. Past incident 2026-05-01: dispatcher returned 1
+  // assignment at tick 2 with cap=2 (both agents idle, both issues pending),
+  // costing a 10-min wall-clock gap before the next tick re-tried. Treating
+  // under-dispatch as a validation error triggers the retry → deterministic
+  // fallback path which always fills cap.
+  if (input.cap > 0 && input.proposal.length < input.cap) {
+    errors.push(
+      `Under-dispatch: ${input.proposal.length} assignments < cap ${input.cap}. Fill every available slot — the cap reflects what's actually dispatchable.`,
+    );
+  }
 
   const seenAgents = new Set<string>();
   const seenIssues = new Set<number>();

--- a/src/orchestrator/prompt.ts
+++ b/src/orchestrator/prompt.ts
@@ -29,13 +29,11 @@ Routing rule:
 - Prefer specialists by Jaccard overlap between agent.tags and issue.labels.
 - Brand-new general agents (tags == ["general"]) should pick up issues with no obvious specialist match.
 - Each agent gets at most ONE issue per tick. Each issue is assigned to at most ONE agent.
-- Emit at most ${input.cap} assignments.
+- Emit EXACTLY ${input.cap} assignment${input.cap === 1 ? "" : "s"}. The cap reflects how many idle-agent × pending-issue pairs are available — leaving slots empty wastes parallelism. If the routing fit is weak, still assign — Jaccard overlap of 0 is acceptable when no better match exists.
 
 Inputs (JSON):
 ${JSON.stringify({ pending, idle, cap: input.cap }, null, 2)}${errorBlock}
 
 Output ONLY valid JSON in this exact shape, no prose, no markdown:
-{"assignments":[{"agentId":"<id>","issueId":<number>}, ...]}
-
-If no productive assignments are available, emit {"assignments":[]}.`;
+{"assignments":[{"agentId":"<id>","issueId":<number>}, ...]}`;
 }


### PR DESCRIPTION
## Summary

Bug fix from the 2026-05-01 vp-dev dry-run test. Tick timings from the run log show the gap concretely:

| tick | wall clock | assignments | cap |
|---|---|---|---|
| 1 | 11:33:09 | `agent-d396` → #156, `agent-90e4` → #558 | 2 |
| 2 | 11:35:19 | `agent-90e4` → #559 (only) | **2** ← idle slot wasted |
| 3 | 11:45:11 | `agent-d396` → #162 | 1 |

At tick 2, `agent-d396` had finished #156 at ~11:35:02 (113s after start) — both agents were idle, both #162 and #559 were pending, so `cap = min(2, 2, 2) = 2`. The LLM dispatcher returned only 1 assignment. agent-d396 sat idle for ~10 minutes until tick 3 finally re-attempted and filled the second slot.

The cap is `min(idleAgents, pendingIssues, parallelism - inFlight.size)` — every value reflects "what's actually dispatchable right now", so under-allocation wastes parallelism by definition.

## Changes

- **`src/orchestrator/prompt.ts`**: `"Emit at most ${cap}"` → `"Emit EXACTLY ${cap}"`. Remove the `"If no productive assignments are available, emit {assignments: []}"` escape hatch — when `cap > 0` the dispatcher has idle agents AND pending issues, so a non-empty proposal always exists. Add an explicit note that Jaccard overlap of 0 is acceptable when no better match exists.
- **`src/orchestrator/dispatcher.ts:validateProposal`**: under-dispatch (`proposal.length < cap` when `cap > 0`) is now a validation error, triggering the existing retry path. Two LLM attempts at under-dispatch fall through to `deterministicFallback`, which always fills cap by ranking idle-agent × pending-issue pairs (`src/orchestrator/routing.ts:41-64`).

## Why retry → deterministic instead of loop restructure

The original plan called for restructuring the tick loop to re-dispatch after `Promise.race` resolves. That's a bigger change targeting the same symptom. The simpler diagnosis: the dispatcher is correctly invoked at every tick — it just allows under-dispatch as a valid output. Forcing the validator to require cap-fill (with the existing retry → fallback chain as the safety net) addresses the root cause without restructuring the loop, and reuses code paths that already exist.

## Verification

- `npm run typecheck` ✓
- `npm run build` ✓
- End-to-end: re-running the same dry-run should show #162 dispatched at tick 2 (not tick 3), eliminating the wall-clock gap.

## Test plan
- [ ] `npm ci && npm run typecheck && npm run build`
- [ ] Re-run dry-run, confirm tick 2 assignments include both pending issues
- [ ] Confirm `tick.proposal source` is `llm` on a typical run (not always `fallback`) — i.e. the LLM honors the new directive

🤖 Generated with [Claude Code](https://claude.com/claude-code)