### PR TITLE
fix(can-use-tool): exempt pure heredoc-to-file writes; allow bare gh-api issue/PR reads

### DIFF
--- a/src/agent/codingAgent.ts
+++ b/src/agent/codingAgent.ts
@@ -306,7 +306,20 @@ const DRY_RUN_SENSITIVE_LEADING: RegExp[] = [
   /^git\s+push\b/,
 ];
 
+// Pure file-write heredoc as the WHOLE command: `cat > FILE << DELIM\n…body…\nDELIM`
+// with nothing trailing. The body is data being redirected to disk — it cannot
+// shell-execute, so sensitive substrings inside it (agents writing pushback
+// prose that mentions `gh issue comment`) shouldn't trip the compound-deny scan.
+// Anchored to end-of-string: any trailing compound (`&& gh issue comment`,
+// `; git push`, `| bash`) fails the match and falls through to the normal scan.
+// Push-to-main / force-push / --no-verify denials run BEFORE this exemption
+// (PUSH_TO_MAIN_RE etc. on lines above) and use [\s\S]* to catch heredoc
+// bodies, so this does not weaken push-protection.
+const HEREDOC_FILE_WRITE_RE =
+  /^\s*cat\s*>>?\s*\S+\s*<<-?\s*['"]?(\w+)['"]?\s*\n[\s\S]*?\n\s*\1\s*$/;
+
 function denyCompoundDryRun(cmd: string): PermissionResult | null {
+  if (HEREDOC_FILE_WRITE_RE.test(cmd)) return null;
   for (let i = 0; i < DRY_RUN_SENSITIVE_PATTERNS.length; i++) {
     const { re, label } = DRY_RUN_SENSITIVE_PATTERNS[i];
     const leading = DRY_RUN_SENSITIVE_LEADING[i];
@@ -344,13 +357,16 @@ const ALLOW_PATTERNS: RegExp[] = [
   /^git\s+rev-parse(\s|$)/,
   /^git\s+restore(\s|$)/,
 
-  // gh — issue read + comment, PR create/view/checks, api comments fetch
+  // gh — issue read + comment, PR create/view/checks, api issue/PR fetch
   /^gh\s+issue\s+view(\s|$)/,
   /^gh\s+issue\s+list(\s|$)/,
   /^gh\s+issue\s+comment(\s|$)/,
   /^gh\s+pr\s+(create|view|checks|list|diff)(\s|$)/,
-  /^gh\s+api\s+repos\/[^\s]+\/issues\/\d+\/comments(\s|$)/,
-  /^gh\s+api\s+repos\/[^\s]+\/(issues|pulls)\/\d+\/comments(\s|$)/,
+  // Cross-org issue/PR reads: agents need to verify upstream tracker state
+  // (e.g. "is mrgnlabs/mrgn-ts#1139 still open?") for tracking-issue triage.
+  // Bare `/issues/N` and `/pulls/N` cover the issue/PR body; the optional
+  // `/comments` suffix covers the comment thread. Both are read-only.
+  /^gh\s+api\s+repos\/[^\s]+\/(issues|pulls)\/\d+(\/comments)?(\s|$)/,
   /^gh\s+api\s+\/?advisories\//,
   /^gh\s+repo\s+view(\s|$)/,
 


### PR DESCRIPTION
## Summary

Two gate-over-restriction bugs from a `vp-dev --dry-run` on vaultpilot-mcp #156, #162, #558, #559 — each of the 4 agent runs tripped at least one and recovered via the `Write` tool, burning retry tokens.

- **Heredoc file-writes false-deny**: `cat > /tmp/x.md << 'EOF' …prose mentioning gh issue comment… EOF` denied because `denyCompoundDryRun` scans the whole `cmd` for sensitive substrings anywhere not-at-start. Pushback prose routinely names those commands in body text. Add a strict whole-command exemption (`HEREDOC_FILE_WRITE_RE`) anchored end-of-string so any trailing compound (`&& gh issue comment`, `; git push`, `| bash`) still falls through to the normal scan.
- **Bare `gh api` issue/PR reads denied**: allowlist only had `/issues/N/comments`, not `/issues/N` itself. Tracking-issue triage needs the issue body (e.g. verify `mrgnlabs/mrgn-ts#1139` is still open). Make `/comments` optional.

## Push-protection invariant preserved

Per CLAUDE.md "Three-layer push-protection ... is load-bearing". The exemption is in `denyCompoundDryRun` (Layer 3 dry-run-intercept-bypass guard for `gh issue comment` / `gh pr create` / `git push`), but `PUSH_TO_MAIN_RE` / `PLAIN_FORCE_PUSH_RE` / `NO_VERIFY_RE` run BEFORE this function (lines 257–268) and use `[\s\S]*` to catch heredoc-body smuggling. Smoke-tested: a heredoc body containing `git push origin main` still matches `PUSH_TO_MAIN_RE`. Layers 1 (target branch protection) and 2 (`disallowedTools`) are untouched.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Regex smoke test: 9 assertions covering heredoc-write, trailing-compound, piped-to-bash, body-smuggled-push, bare `/issues/N`, `/pulls/N`, `/comments` back-compat, unrelated `/contents/...` denial — all pass
- [ ] Re-run the same dry-run (`vp-dev run --agents 2 --target-repo szhygulin/vaultpilot-mcp --issues 156,162,558,559 --dry-run --yes`) and verify zero `permission.evaluated ... behavior=deny` events for the heredoc + cross-org `gh api` patterns

Closes the heredoc + cross-org `gh api` findings from the 2026-05-01 vp-dev dry-run. Summarizer schema-invalid (the third finding) was already fixed by #11 (`bbee532`); the dry-run hit it because `fix/orchestrator-redispatch` was branched off pre-`bbee532` and didn't carry the summarizer fix forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)