### PR TITLE
fix(prompt): instruct Write tool + separate Bash call for tmp body files

### DIFF
--- a/src/agent/workflow.ts
+++ b/src/agent/workflow.ts
@@ -43,7 +43,7 @@ Per CLAUDE.md "Issue Analysis": comments are where reviewers add follow-up scope
 
 ### Pushback path
 Compose a comment: one mismatch sentence + 2-3 alternatives + a question.
-Write the body to a tmp file, then:
+Write the body to a tmp file using the **\`Write\` tool** (NOT a shell heredoc — \`cat > FILE << EOF ... EOF\` chained with \`gh issue comment\` in one Bash call trips the dry-run gate, since the chained \`gh issue comment\` would actually post in a non-dry-run). Then issue the comment as its OWN top-level Bash invocation:
   gh issue comment ${v.issueId} --repo ${v.targetRepo} --body-file <tmp>
 Emit the JSON envelope with decision="pushback" and the comment URL.
 
@@ -58,7 +58,8 @@ Emit the JSON envelope with decision="pushback" and the comment URL.
      Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
 5. Push:
      git push -u origin ${v.branchName}
-6. Open the PR — body MUST start with "Closes #${v.issueId}" on its own line so GitHub auto-closes:
+6. Open the PR — body MUST start with "Closes #${v.issueId}" on its own line so GitHub auto-closes.
+   Write the PR body to a tmp file using the **\`Write\` tool** (same reason as Pushback path: heredoc chained with \`gh pr create\` trips the dry-run gate). Then run \`gh pr create\` as its OWN top-level Bash invocation:
      gh pr create --repo ${v.targetRepo} --base main --head ${v.branchName} --title <short title> --body-file <tmp>
 7. Format the returned PR URL as a Markdown hyperlink in your reasoning.
 


### PR DESCRIPTION
## Summary

Diagnosed root cause of the 4 heredoc denies in the 2026-05-01 dry-run that PR #13's `HEREDOC_FILE_WRITE_RE` exemption didn't catch. Instrumented the gate (`process.stderr.write` of regex match + cmd head/tail) and re-ran a single-issue spawn with `agent-d396` on #162. Got:

    [DEBUG-HEREDOC] matches=false len=740
      head="cat > /tmp/issue-162-comment.md <<'EOF'\nRe-checked the upstr"
      tail="hygulin/vaultpilot-mcp --body-file /tmp/issue-162-comment.md"

The agent isn't emitting a pure heredoc — it chains `gh issue comment` into the **same** Bash call after the heredoc:

    cat > /tmp/issue-162-comment.md <<'EOF'
    …prose…
    EOF
    gh issue comment 162 --repo szhygulin/vaultpilot-mcp --body-file /tmp/issue-162-comment.md

The dry-run gate correctly denies this — chained `gh issue comment` would actually post in non-dry-run, since `dryRunIntercept` anchors on leading position. **The deny is working as designed.** Tightening the regex to allow chained forms would weaken the intercept guard.

## Fix at the prompt layer

`src/agent/workflow.ts` Pushback + Implement paths now explicitly say:
- Use the **`Write` tool** for the tmp body (no Bash, bypasses the gate entirely).
- Issue `gh issue comment` / `gh pr create` as its **OWN top-level Bash invocation**.
- Names the failure mode (`heredoc + chained gh trips the dry-run gate`) so the agent understands WHY — otherwise the next agent re-discovers the friction.

## Push-protection invariant preserved

No gate code touched. The three layers (target branch protection / `disallowedTools` / `canUseTool` regex) are unchanged. Push-Protection rule from CLAUDE.md applies.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Smoke-test rendered prompt: both Pushback path and Implement step 6 contain the new Write-tool + separate-Bash-call instruction
- [ ] Re-run a 3-agent / 6-issue dry-run on the same vaultpilot-mcp issues and verify zero heredoc-related `permission.evaluated ... behavior=deny` events

Closes the heredoc-deny finding from the 2026-05-01 vp-dev runs that PR #13's exemption didn't fully address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
