### PR TITLE
fix(summarizer): default skip:false + tighten prompt to require skip field

### DIFF
--- a/src/agent/summarizer.ts
+++ b/src/agent/summarizer.ts
@@ -9,7 +9,13 @@ const HEADING_MAX = 120;
 const BODY_MAX = 2000;
 
 export const SummarizerOutputSchema = z.object({
-  skip: z.boolean(),
+  // Default false: action-case payloads ({heading, body}) routinely omit
+  // skip. The prompt's prose treats absence as "not skipping" — the LLM
+  // only includes skip:true when it explicitly chooses to skip. Defaulting
+  // matches that intent and keeps the rare-but-legitimate omission from
+  // discarding an otherwise-valid lesson. The prompt still asks for the
+  // field explicitly (suspenders), this is the belt.
+  skip: z.boolean().default(false),
   skipReason: z.string().optional(),
   heading: z.string().min(3).max(HEADING_MAX).optional(),
   body: z.string().min(3).max(BODY_MAX).optional(),
@@ -135,7 +141,7 @@ Hard rules:
 - Body: ≤ 2000 chars. 2–8 short lines. No prose paragraphs.
 - Do NOT mention the specific issue number, PR number, or run id — that's in the provenance comment. Talk about the class of situation, not this instance.
 
-Output: a single JSON object, no fences, no prose. Schema:
+Output: a single JSON object, no fences, no prose. The \`skip\` field is MANDATORY in every response. Use \`{"skip": false, "heading": "...", "body": "..."}\` when there is a lesson worth saving, and \`{"skip": true, "skipReason": "..."}\` otherwise. Schema:
   {"skip": boolean, "skipReason"?: string, "heading"?: string, "body"?: string}`;
 
 function buildPrompt(input: SummarizerInput): string {
@@ -167,7 +173,7 @@ ${trace || "(none captured)"}
 Agent's final reasoning text (truncated):
 ${truncate(input.finalText, 4000)}
 
-Decide: is there a generalizable rule worth committing to this agent's CLAUDE.md? If yes, emit {heading, body}. If no, emit {"skip": true, "skipReason": "..."}. JSON only.`;
+Decide: is there a generalizable rule worth committing to this agent's CLAUDE.md? If yes, emit {"skip": false, "heading": "...", "body": "..."}. If no, emit {"skip": true, "skipReason": "..."}. The skip field is mandatory in both shapes. JSON only.`;
 }
 
 function truncate(s: string, max: number): string {


### PR DESCRIPTION
## Summary

The 2026-05-01 5-agent / 15-issue dry-run hit `summarizer.malformed_payload` 3× with `zodError path=["skip"], code=invalid_type, expected=boolean, received=undefined`. The LLM was omitting the required `skip` field on action-case payloads (`{heading, body}`); the summarizer was discarding otherwise-valid lessons, and per-agent CLAUDE.md updates were being skipped.

The prompt's prose treats absence as "not skipping" — the LLM only includes `skipReason` when explicitly skipping — but the schema and the prompt's emit-instruction both required `skip: boolean` without naming the action-case shape's `skip: false`.

## Two-pronged fix

1. **Schema default (belt)**: `skip: z.boolean().default(false)`. Action-case payloads missing `skip` now validate as `skip: false`, matching the prompt's prose intent. Length and other validations are unaffected.

2. **Prompt (suspenders)**: system prompt now states "The `skip` field is MANDATORY in every response" with both shapes spelled out. User prompt says `emit {"skip": false, "heading": "...", "body": "..."}` instead of `emit {heading, body}`. Future model versions won't re-introduce the omission.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Schema smoke test:
  - missing skip + valid heading/body → `success=true, skip=false` (the action-case fix)
  - missing skip + heading too long → still fails on `["heading"]` path (length validation intact)
  - explicit `skip: true` + skipReason → `success=true, skip=true`
  - explicit `skip: false` + heading + body → `success=true, skip=false`
  - bad type (`skip: "yes"`) → still fails (type validation intact)
- [ ] Re-run a 5-agent dry-run; expect `warn.summarizer.malformed_payload` events drop to ~0 for the missing-skip class. Length-clamp warns (`warn.summarizer.clamped`) should still fire for legitimate length overruns — that's correct behavior, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
