### PR TITLE
fix(orchestrator): auto-prune stale vp-dev branches at run-start

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,7 @@ import { getIssue, resolveRangeToIssues } from "./github/gh.js";
 import { pickAgents, runOrchestrator } from "./orchestrator/orchestrator.js";
 import { approveSetup, buildSetupPreview } from "./orchestrator/setup.js";
 import { Logger } from "./log/logger.js";
-import { fetchOriginMain, pruneWorktrees, resolveTargetRepoPath } from "./git/worktree.js";
+import { fetchOriginMain, pruneStaleAgentBranches, pruneWorktrees, resolveTargetRepoPath } from "./git/worktree.js";
 import { forkClaudeMd } from "./agent/specialization.js";
 import { runIssueCore } from "./agent/runIssueCore.js";
 import type { AgentRecord, IssueRangeSpec, IssueSummary } from "./types.js";
@@ -188,6 +188,7 @@ async function cmdRun(opts: RunOpts): Promise<void> {
 
   try {
     await pruneWorktrees(repoPath);
+    await pruneStaleAgentBranches(repoPath, opts.targetRepo, logger);
     await runOrchestrator({
       state,
       issues: open,
@@ -252,6 +253,7 @@ async function runResume(opts: RunOpts): Promise<void> {
     issueCount: issues.length,
   });
   try {
+    await pruneStaleAgentBranches(repoPath, state.targetRepo, logger);
     await runOrchestrator({
       state,
       issues,
@@ -356,6 +358,7 @@ async function cmdSpawn(opts: SpawnOpts): Promise<void> {
   try {
     await fetchOriginMain(repoPath);
     await pruneWorktrees(repoPath);
+    await pruneStaleAgentBranches(repoPath, opts.targetRepo, logger);
 
     const inspectPaths = opts.inspectPaths
       ? opts.inspectPaths.split(",").map((s) => s.trim()).filter((s) => s.length > 0)

--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -2,6 +2,7 @@ import { promisify } from "node:util";
 import { execFile as execFileCb } from "node:child_process";
 import path from "node:path";
 import { promises as fs } from "node:fs";
+import type { Logger } from "../log/logger.js";
 
 const execFile = promisify(execFileCb);
 
@@ -9,6 +10,13 @@ export interface WorktreeHandle {
   path: string;
   branch: string;
 }
+
+// vp-dev branch shape: vp-dev/<agentId>/issue-<N>. Producer is createWorktree
+// below (line "vp-dev/${opts.agentId}/issue-${opts.issueId}"). Keep these in
+// sync — pruneStaleAgentBranches uses this to decode an `agent-<id>+issue-<N>`
+// pair from a branch name.
+const VP_DEV_BRANCH_PATTERN = "vp-dev/agent-*/issue-*";
+const VP_DEV_BRANCH_RE = /^vp-dev\/(agent-[a-z0-9]+)\/issue-(\d+)$/;
 
 export async function resolveTargetRepoPath(
   targetRepo: string,
@@ -86,4 +94,109 @@ export async function listWorktrees(repoPath: string): Promise<string[]> {
   } catch {
     return [];
   }
+}
+
+// Sweep stale `vp-dev/agent-*/issue-*` branches whose PR is no longer open.
+//
+// After a successful "implement" run, runIssueCore intentionally retains the
+// branch (deleteBranch: false) because the open PR's head depends on it.
+// Once that PR merges or closes, the branch is dead weight — and worse,
+// `git worktree add ... -b <branch>` collides on the next dispatch of the
+// same (agent, issue) pair, throwing `error.agent.uncaught` and silently
+// skipping the issue.
+//
+// Safety: only branches matching the vp-dev pattern are considered (no
+// human-authored branch matches), and a branch is preserved if `gh pr list
+// --head <branch> --state open` returns any rows. If `gh pr list` itself
+// fails (network, auth), we keep the branch — fail-safe defaults.
+//
+// Push-protection invariant: all writes are local (`git branch -D`,
+// `git worktree remove`). No `git push --delete`, no remote mutation.
+export async function pruneStaleAgentBranches(
+  repoPath: string,
+  targetRepo: string,
+  logger?: Logger,
+): Promise<{ pruned: number; kept: number }> {
+  let branches: string[] = [];
+  try {
+    const { stdout } = await execFile(
+      "git",
+      ["branch", "--list", VP_DEV_BRANCH_PATTERN, "--format=%(refname:short)"],
+      { cwd: repoPath },
+    );
+    branches = stdout.trim().split("\n").filter(Boolean);
+  } catch (err) {
+    logger?.warn("worktree.stale_branches_list_failed", {
+      err: (err as Error).message,
+    });
+    return { pruned: 0, kept: 0 };
+  }
+  if (branches.length === 0) return { pruned: 0, kept: 0 };
+
+  let pruned = 0;
+  let kept = 0;
+  for (const branch of branches) {
+    const m = VP_DEV_BRANCH_RE.exec(branch);
+    if (!m) {
+      kept++;
+      continue;
+    }
+    const [, agentId, issueIdStr] = m;
+    const issueId = parseInt(issueIdStr, 10);
+
+    let prsOpen: number;
+    try {
+      const { stdout } = await execFile(
+        "gh",
+        ["pr", "list", "--repo", targetRepo, "--head", branch, "--state", "open", "--json", "number"],
+        { cwd: repoPath },
+      );
+      const arr = JSON.parse(stdout) as unknown;
+      prsOpen = Array.isArray(arr) ? arr.length : 0;
+    } catch (err) {
+      // Network/auth/unknown — fail-safe: keep the branch.
+      kept++;
+      logger?.info("worktree.stale_branch_kept", {
+        branch,
+        agentId,
+        issueId,
+        reason: `gh pr list failed: ${(err as { stderr?: string }).stderr ?? (err as Error).message}`,
+      });
+      continue;
+    }
+
+    if (prsOpen > 0) {
+      kept++;
+      logger?.info("worktree.stale_branch_kept", {
+        branch,
+        agentId,
+        issueId,
+        reason: `open PR exists (count=${prsOpen})`,
+      });
+      continue;
+    }
+
+    // No open PR — branch is stale. Delete it; remove any leftover worktree dir.
+    const wtPath = path.join(repoPath, ".claude", "worktrees", `${agentId}-issue-${issueId}`);
+    try {
+      await fs.access(wtPath);
+      await execFile("git", ["worktree", "remove", wtPath, "--force"], { cwd: repoPath });
+    } catch {
+      // No leftover dir, or remove already failed — branch delete proceeds.
+    }
+    try {
+      await execFile("git", ["branch", "-D", branch], { cwd: repoPath });
+      pruned++;
+      logger?.info("worktree.stale_branch_pruned", { branch, agentId, issueId });
+    } catch (err) {
+      kept++;
+      logger?.warn("worktree.stale_branch_delete_failed", {
+        branch,
+        err: (err as { stderr?: string }).stderr ?? (err as Error).message,
+      });
+    }
+  }
+
+  logger?.info("worktree.stale_branches_swept", { pruned, kept });
+  return { pruned, kept };
 }


### PR DESCRIPTION
## Summary

The 2026-05-01 5-agent / 15-issue dry-run dispatched `agent-51e5` to issue #559, but the local branch `vp-dev/agent-51e5/issue-559` already existed from a prior implement run (intentionally retained for the open PR). `git worktree add ... -b <existing>` failed with "branch already exists", threw `error.agent.uncaught`, and the orchestrator silently skipped the issue.

After the prior PR merged, the branch became dead weight: no open PR depends on it, but it still blocks the next dispatch of the same `(agent, issue)` pair.

## Approach: auto-prune at run-start

`pruneStaleAgentBranches(repoPath, targetRepo, logger?)` runs at the start of `cmdRun`, `runResume`, and `cmdSpawn`:

1. List local branches matching `vp-dev/agent-*/issue-*`.
2. For each, query `gh pr list --repo X --head <branch> --state open --json number`.
3. If any open PR depends on the branch → **keep** (emits `worktree.stale_branch_kept` with `count`).
4. Otherwise → `git branch -D` + remove the leftover worktree dir at the canonical path if it exists.
5. Emits `worktree.stale_branch_pruned` per delete + `worktree.stale_branches_swept` summary at the end.

## Safety

- The `vp-dev/agent-*/issue-*` pattern is exclusively created by this harness; no human-authored branch matches the regex `^vp-dev\/(agent-[a-z0-9]+)\/issue-(\d+)$`.
- The `gh pr list --head` query is the load-bearing guard. If it fails (network, auth, rate limit), the branch is **kept**, not pruned — fail-safe defaults.
- All writes are local: `git branch -D`, `git worktree remove`. No `git push --delete`, no remote mutation.

## Push-protection invariant preserved

Per CLAUDE.md "Three-layer push-protection ... is load-bearing". This change touches only local-repo state in the **target** repo (e.g. `~/dev/vaultpilot-mcp`), and only branches matching the harness-created pattern. The three protection layers (target branch protection, `disallowedTools`, `canUseTool` regex gate) are unchanged.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Regex unit-test: 8 cases (`vp-dev/agent-51e5/issue-559` parses to `agent-51e5+559`; bare `main`, `feature/agent-...`, `vp-dev/some-other/...` all reject)
- [x] **End-to-end against real stale state**: target repo had 4 stale `vp-dev/agent-*/issue-*` branches with no open PRs (agent-51e5 #559, #573, #610; agent-90e4 #559). Helper pruned all 4, emitted 4 `stale_branch_pruned` events + summary. Second invocation is a clean no-op.
- [ ] Re-run a 5-agent / 15-issue dry-run; expect issue #559 to dispatch cleanly to whichever agent gets it (no `error.agent.uncaught` from worktree-already-exists), and startup-time prune events to appear in the run log.
- [ ] Negative regression: with no `vp-dev/*` branches present, confirm prune is a silent no-op (zero `gh pr list` invocations, zero log events except the summary with `pruned: 0, kept: 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
