### PR TITLE
fix(summarizer): require quote-escaping in body strings

### DIFF
--- a/src/agent/summarizer.ts
+++ b/src/agent/summarizer.ts
@@ -140,6 +140,7 @@ Hard rules:
 - Heading: ≤ 120 chars, no trailing colon, no markdown prefix (no leading "##"). The append step prepends "##".
 - Body: ≤ 2000 chars. 2–8 short lines. No prose paragraphs.
 - Do NOT mention the specific issue number, PR number, or run id — that's in the provenance comment. Talk about the class of situation, not this instance.
+- Inside heading / body / skipReason string values: escape every double-quote as \\" and every literal newline as \\n. Unescaped quotes break the JSON parser even when the rest of the payload is valid (we lose the whole lesson). Prefer single-quote ' or backticks for emphasis when the alternative is acceptable.
 
 Output: a single JSON object, no fences, no prose. The \`skip\` field is MANDATORY in every response. Use \`{"skip": false, "heading": "...", "body": "..."}\` when there is a lesson worth saving, and \`{"skip": true, "skipReason": "..."}\` otherwise. Schema:
   {"skip": boolean, "skipReason"?: string, "heading"?: string, "body"?: string}`;
@@ -173,7 +174,7 @@ ${trace || "(none captured)"}
 Agent's final reasoning text (truncated):
 ${truncate(input.finalText, 4000)}
 
-Decide: is there a generalizable rule worth committing to this agent's CLAUDE.md? If yes, emit {"skip": false, "heading": "...", "body": "..."}. If no, emit {"skip": true, "skipReason": "..."}. The skip field is mandatory in both shapes. JSON only.`;
+Decide: is there a generalizable rule worth committing to this agent's CLAUDE.md? If yes, emit {"skip": false, "heading": "...", "body": "..."}. If no, emit {"skip": true, "skipReason": "..."}. The skip field is mandatory in both shapes. JSON only — escape every \\" inside string values.`;
 }
 
 function truncate(s: string, max: number): string {


### PR DESCRIPTION
## Summary

The 2026-05-01 5-agent / 15-newest-issues dry-run hit `warn.summarizer.malformed_payload` **5 of 14 successful runs (36%)**. Direct `JSON.parse` of one captured payload (agent-d396 #612, 1241 chars) reports:

    Expected ',' or '}' after property value in JSON at position 569
    around position 569: …"(a)/(b)/(c)"…

The LLM emits literal unescaped double-quotes inside the `body` field. `JSON.parse` rejects before schema validation runs, so the specialization is skipped and the per-agent `CLAUDE.md` isn't updated.

PR #16's `skip` default fix was the wrong shape — that addressed missing required fields. The 5 failures this run all had `"skip": false` present and otherwise-valid framing; the corruption was strictly mid-string from unescaped `"`.

## Fix

Add an explicit Hard-rule to the system prompt:

> Inside heading / body / skipReason string values: escape every double-quote as `\"` and every literal newline as `\n`. Unescaped quotes break the JSON parser even when the rest of the payload is valid (we lose the whole lesson). Prefer single-quote `'` or backticks for emphasis when the alternative is acceptable.

Plus a one-line reminder in the user-prompt closing instruction: `JSON only — escape every \" inside string values.`

## Why prompt-only

Pre-parse repair (a regex pass that escapes inner quotes before `JSON.parse`) was rejected: a quote-fixer can't reliably distinguish intentional `"…"` inside text from string delimiters without actually parsing, which is exactly the failure mode we're trying to avoid duplicating.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Inspected compiled output: the new rule appears verbatim in the system prompt block; the user-prompt closing reminder also present
- [ ] Re-run a 5-agent dry run; expect `warn.summarizer.malformed_payload` event count to drop from 5/14 to near-zero. Length-clamp warns (`warn.summarizer.clamped`) should still fire for legitimate length overruns — that's correct behavior, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
