### PR TITLE
fix(prompt): tell agents not to prefix Bash with cd <worktree>

### DIFF
--- a/src/agent/workflow.ts
+++ b/src/agent/workflow.ts
@@ -23,7 +23,7 @@ ${v.inspectPaths.map((p) => `- \`${p}\``).join("\n")}
   return `# Workflow
 
 You are an autonomous coding agent working on a single GitHub issue in ${v.targetRepo}.
-Your worktree is ${v.worktreePath} on branch ${v.branchName}. Stay inside it. Never push to main.${dryNote}${inspectNote}
+Your worktree is ${v.worktreePath} on branch ${v.branchName}. Your shell already starts in this directory for every Bash invocation — the cwd is preset. **Never prefix Bash commands with \`cd ${v.worktreePath} && …\`**: the leading word becomes \`cd\` (not on the gate's allowlist) and the call is denied. Run commands directly: \`npm run build\`, \`git status\`, \`git diff\`. Stay inside the worktree. Never push to main.${dryNote}${inspectNote}
 
 ## Step 1 — Read the issue and ALL comments
 Run BOTH:
@@ -48,7 +48,7 @@ Write the body to a tmp file using the **\`Write\` tool** (NOT a shell heredoc �
 Emit the JSON envelope with decision="pushback" and the comment URL.
 
 ### Implement path
-1. Confirm pwd == ${v.worktreePath} and \`git status\` is clean on ${v.branchName}.
+1. Verify clean state: \`pwd && git status && git log --oneline -1\`. The shell is already in ${v.worktreePath} on ${v.branchName} — no cd needed.
 2. Make the minimum code change.
 3. Build + test in the worktree:
      npm run build


### PR DESCRIPTION
## Summary

The 2026-05-01 5-agent / 15-newest-issues dry run hit ~10 consecutive denies on agent-e287 #599 emitting:

    cd /home/szhygulin/dev/vaultpilot-mcp/.claude/worktrees/agent-e287-issue-599 && npm run build

The SDK already presets `cwd` to the worktree for every Bash invocation, so the `cd` is redundant — and it shifts the leading command from `npm` (allowlisted) to `cd` (not allowlisted), so the gate denies the call. The agent eventually escaped the loop and completed but burned tokens on the dead-end retries.

## Fix — two prompt edits

**Header (read by every agent)** explicitly states the cwd is preset and forbids the cd-prefix pattern with concrete examples:

> Your shell already starts in this directory for every Bash invocation — the cwd is preset. **Never prefix Bash commands with `cd <worktree> && …`**: the leading word becomes `cd` (not on the gate's allowlist) and the call is denied. Run commands directly: `npm run build`, `git status`, `git diff`.

**Implement path step 1** — replace ambiguous "Confirm pwd ==" with an explicit no-cd reminder:

    1. Verify clean state: `pwd && git status && git log --oneline -1`. The shell is already in <worktree> on <branch> — no cd needed.

## Why prompt-only

Gate-fix alternative (allowlist `cd <worktree> && <allowlisted-leading>`) was rejected: it'd be too permissive (`cd <anywhere> && …` patterns would also need rules) and the agent never legitimately needs to cd at all — the SDK is the source of truth for cwd.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Smoke-tested rendered prompt: header includes the no-cd rule with concrete commands; step 1 includes the same reinforcement.
- [ ] Re-run a 5-agent dry run; expect zero `cd <worktree>` denies in `permission.evaluated` events.
- [ ] Negative regression: agents using already-allowlisted compounds like `pwd && git status` should still pass (those have `pwd` as the leading command).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
