### PR TITLE
fix(orchestrator): serialize worktree-add per repo + always emit prune summary

### DIFF
--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -18,6 +18,45 @@ export interface WorktreeHandle {
 const VP_DEV_BRANCH_PATTERN = "vp-dev/agent-*/issue-*";
 const VP_DEV_BRANCH_RE = /^vp-dev\/(agent-[a-z0-9]+)\/issue-(\d+)$/;
 
+// Per-target-repo serialization for `git worktree add`.
+//
+// `git worktree add` writes upstream-tracking config into the target repo's
+// `.git/config` during creation. Two parallel adds against the SAME repo race
+// on the lock file `.git/config.lock` and one fails with `error: could not
+// lock config file .git/config: File exists`. Observed 2026-05-01 in a
+// 5-agent dry run on issue #608 — the failure surfaced as
+// `error.agent.uncaught` and the issue was silently dropped.
+//
+// Different target repos have independent `.git/config` files, so we key on
+// repoPath and let cross-repo adds run in parallel.
+//
+// The map stores each caller's "tail" promise (resolves when its fn
+// completes). The next caller awaits the prior tail, so the chain serializes
+// per-key. Cleanup checks `Map.get(key) === tail` and drops the entry if no
+// later caller has chained on — keeps the map from leaking across many runs.
+const worktreeAddLocks = new Map<string, Promise<void>>();
+
+async function withRepoLock<T>(
+  repoPath: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prior = worktreeAddLocks.get(repoPath) ?? Promise.resolve();
+  let release!: () => void;
+  const tail = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  worktreeAddLocks.set(repoPath, tail);
+  try {
+    await prior;
+    return await fn();
+  } finally {
+    release();
+    if (worktreeAddLocks.get(repoPath) === tail) {
+      worktreeAddLocks.delete(repoPath);
+    }
+  }
+}
+
 export async function resolveTargetRepoPath(
   targetRepo: string,
   explicit?: string,
@@ -52,11 +91,17 @@ export async function createWorktree(opts: {
 
   // CLAUDE.md: cd <repoPath> BEFORE worktree add — execFile with cwd does that explicitly.
   await execFile("git", ["fetch", "origin", "main"], { cwd: opts.repoPath });
+  // Serialize the worktree-add against this target repo to avoid the
+  // `.git/config` lock race when multiple agents spawn in the same tick
+  // (see worktreeAddLocks comment above). Fetch is read-mostly and runs
+  // outside the lock to maximize parallelism.
   try {
-    await execFile(
-      "git",
-      ["worktree", "add", path.join(".claude", "worktrees", `${opts.agentId}-issue-${opts.issueId}`), "-b", branch, "origin/main"],
-      { cwd: opts.repoPath },
+    await withRepoLock(opts.repoPath, () =>
+      execFile(
+        "git",
+        ["worktree", "add", path.join(".claude", "worktrees", `${opts.agentId}-issue-${opts.issueId}`), "-b", branch, "origin/main"],
+        { cwd: opts.repoPath },
+      ),
     );
   } catch (err) {
     const msg = (err as { stderr?: string }).stderr ?? String(err);
@@ -131,7 +176,10 @@ export async function pruneStaleAgentBranches(
     });
     return { pruned: 0, kept: 0 };
   }
-  if (branches.length === 0) return { pruned: 0, kept: 0 };
+  if (branches.length === 0) {
+    logger?.info("worktree.stale_branches_swept", { pruned: 0, kept: 0 });
+    return { pruned: 0, kept: 0 };
+  }
 
   let pruned = 0;
   let kept = 0;


### PR DESCRIPTION
## Summary

Two fixes in `src/git/worktree.ts` from the 2026-05-01 5-agent / 15-newest-issues dry run:

**(2) `.git/config` lock race on parallel worktree-add** — Issue #608 hit `error: could not lock config file .git/config: File exists; unable to write upstream branch configuration` when two `git worktree add` calls fired simultaneously in the same tick. `git worktree add` writes upstream-tracking config into `.git/config`, and parallel writes to `.git/config.lock` fail. The error surfaced as `error.agent.uncaught` and the issue was silently dropped — same blast radius as the original Bug 1 from PR #17.

Add a per-`repoPath` async mutex (`worktreeAddLocks` Map keyed on repoPath, each caller stores its "tail" promise; subsequent callers await the prior tail). Calls against the **same** target repo serialize; calls against **different** target repos still run in parallel.

**(4) Cosmetic** — `pruneStaleAgentBranches` (added in PR #17) returned early on the empty-branch-list path without emitting `worktree.stale_branches_swept`. Operators couldn't confirm the helper ran on a clean target. Add the summary event with `{pruned: 0, kept: 0}` before the early return.

## Push-protection invariant preserved

Pure local serialization within the harness process. No remote effects. The three push-protection layers (target branch protection, `disallowedTools`, `canUseTool` regex gate) are unchanged.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] **Mutex contract** (4 tests, all pass):
  - Same-key serialization: 5 parallel `withRepoLock("/repo-a", …)` calls execute in strict start/end order with no overlap.
  - Cross-key parallelism: 3 parallel calls on `/r1`, `/r2`, `/r3` complete in ~50ms (parallel) instead of ~150ms (serial).
  - Map cleanup: after a single call completes, `worktreeAddLocks.size === 0` (no leak).
  - Error doesn't poison: a thrown error in fn() releases the lock; subsequent caller still runs; map still cleared.
- [x] **Real-git race repro**: 5 parallel `createWorktree(sameRepoPath, …)` calls in a temp git repo. Pre-fix: at least one fails on `.git/config` lock. Post-fix: all 5 succeed.
- [ ] Re-run a 5-agent dry run; expect zero `error.agent.uncaught` from `.git/config` locking, and a `worktree.stale_branches_swept` event in the run log even when the helper finds no stale branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
