### PR TITLE
fix(round3): summarizer apostrophe rule + gh issue create intercept + npm ls + bash-grep prompt

### DIFF
--- a/src/agent/codingAgent.ts
+++ b/src/agent/codingAgent.ts
@@ -297,11 +297,13 @@ const NO_VERIFY_RE = /(--no-verify\b|--no-gpg-sign\b)/;
 // on each in isolation.
 const DRY_RUN_SENSITIVE_PATTERNS: { re: RegExp; label: string }[] = [
   { re: /\bgh\s+issue\s+comment\b/, label: "gh issue comment" },
+  { re: /\bgh\s+issue\s+create\b/, label: "gh issue create" },
   { re: /\bgh\s+pr\s+create\b/, label: "gh pr create" },
   { re: /\bgit\s+push\b/, label: "git push" },
 ];
 const DRY_RUN_SENSITIVE_LEADING: RegExp[] = [
   /^gh\s+issue\s+comment\b/,
+  /^gh\s+issue\s+create\b/,
   /^gh\s+pr\s+create\b/,
   /^git\s+push\b/,
 ];
@@ -349,7 +351,7 @@ const ALLOW_PATTERNS: RegExp[] = [
   /^mv(\s|$)/,
   /^node(\s|$)/,
   /^npx\s+(tsc|vitest|tsx)(\s|$)/,
-  /^npm\s+(install|i|run|test|ci|view|show|pack)(\s|$)/,
+  /^npm\s+(install|i|run|test|ci|view|show|pack|ls|list)(\s|$)/,
 
   // git read-only / safe
   /^git\s+(status|diff|log|show|fetch|rebase|branch|checkout|add|commit|stash)(\s|$)/,
@@ -357,10 +359,15 @@ const ALLOW_PATTERNS: RegExp[] = [
   /^git\s+rev-parse(\s|$)/,
   /^git\s+restore(\s|$)/,
 
-  // gh — issue read + comment, PR create/view/checks, api issue/PR fetch
+  // gh — issue read + comment + create, PR create/view/checks, api issue/PR fetch
   /^gh\s+issue\s+view(\s|$)/,
   /^gh\s+issue\s+list(\s|$)/,
   /^gh\s+issue\s+comment(\s|$)/,
+  // `gh issue create` is the canonical cross-repo-scope-split workflow:
+  // an MCP-side fix needs to file the skill-side half as a tracked issue
+  // in vaultpilot-security-skill. Allowlisted here; dry-run synthesizes a
+  // fake issue URL via dryRunIntercept (same pattern as `gh issue comment`).
+  /^gh\s+issue\s+create(\s|$)/,
   /^gh\s+pr\s+(create|view|checks|list|diff)(\s|$)/,
   // Cross-issue/PR triage: search by keyword, dedup detection.
   /^gh\s+search\s+(issues|prs)(\s|$)/,
@@ -403,6 +410,21 @@ function isAllowedBash(cmd: string, branchName: string): boolean {
 function dryRunIntercept(cmd: string, opts: CanUseOpts): PermissionResult | null {
   if (/^gh\s+issue\s+comment\b/.test(cmd)) {
     const synthetic = `https://dry-run/issue-comment/${opts.targetRepo}/${opts.issueId}`;
+    opts.logger.info("dry_run.intercepted", {
+      agentId: opts.agentId,
+      issueId: opts.issueId,
+      cmd: truncate(cmd, 160),
+      synthetic,
+    });
+    return rewriteAsEcho(synthetic);
+  }
+  if (/^gh\s+issue\s+create\b/.test(cmd)) {
+    // The new issue is in whatever repo the agent named with --repo (often a
+    // cross-repo skill-issue file). Extract it for the synthetic URL; fall
+    // back to opts.targetRepo if --repo isn't present.
+    const repoMatch = /--repo\s+(\S+)/.exec(cmd);
+    const targetForUrl = repoMatch ? repoMatch[1] : opts.targetRepo;
+    const synthetic = `https://dry-run/issue-create/${targetForUrl}/new`;
     opts.logger.info("dry_run.intercepted", {
       agentId: opts.agentId,
       issueId: opts.issueId,

--- a/src/agent/summarizer.ts
+++ b/src/agent/summarizer.ts
@@ -140,7 +140,7 @@ Hard rules:
 - Heading: ≤ 120 chars, no trailing colon, no markdown prefix (no leading "##"). The append step prepends "##".
 - Body: ≤ 2000 chars. 2–8 short lines. No prose paragraphs.
 - Do NOT mention the specific issue number, PR number, or run id — that's in the provenance comment. Talk about the class of situation, not this instance.
-- Inside heading / body / skipReason string values: escape every double-quote as \\" and every literal newline as \\n. Unescaped quotes break the JSON parser even when the rest of the payload is valid (we lose the whole lesson). Prefer single-quote ' or backticks for emphasis when the alternative is acceptable.
+- Inside heading / body / skipReason string values: escape every double-quote as \\" and every literal newline as \\n. Do NOT escape apostrophes — \\' is INVALID JSON (the parser only knows \\", \\\\, \\/, \\b, \\f, \\n, \\r, \\t, \\uXXXX). Write apostrophes as a plain ': don't, isn't, can't. Prefer single-quote ' or backticks for emphasis when the alternative is acceptable.
 
 Output: a single JSON object, no fences, no prose. The \`skip\` field is MANDATORY in every response. Use \`{"skip": false, "heading": "...", "body": "..."}\` when there is a lesson worth saving, and \`{"skip": true, "skipReason": "..."}\` otherwise. Schema:
   {"skip": boolean, "skipReason"?: string, "heading"?: string, "body"?: string}`;

--- a/src/agent/workflow.ts
+++ b/src/agent/workflow.ts
@@ -23,7 +23,7 @@ ${v.inspectPaths.map((p) => `- \`${p}\``).join("\n")}
   return `# Workflow
 
 You are an autonomous coding agent working on a single GitHub issue in ${v.targetRepo}.
-Your worktree is ${v.worktreePath} on branch ${v.branchName}. Your shell already starts in this directory for every Bash invocation — the cwd is preset. **Never prefix Bash commands with \`cd ${v.worktreePath} && …\`**: the leading word becomes \`cd\` (not on the gate's allowlist) and the call is denied. Run commands directly: \`npm run build\`, \`git status\`, \`git diff\`. Stay inside the worktree. Never push to main.${dryNote}${inspectNote}
+Your worktree is ${v.worktreePath} on branch ${v.branchName}. Your shell already starts in this directory for every Bash invocation — the cwd is preset. **Never prefix Bash commands with \`cd ${v.worktreePath} && …\`**: the leading word becomes \`cd\` (not on the gate's allowlist) and the call is denied. Run commands directly: \`npm run build\`, \`git status\`, \`git diff\`. **For text search, use the \`Grep\` tool (any path, any pattern) — bash \`grep\` is not allowlisted and will be denied.** Stay inside the worktree. Never push to main.${dryNote}${inspectNote}
 
 ## Step 1 — Read the issue and ALL comments
 Run BOTH:


### PR DESCRIPTION
## Summary

Three small fixes from the post-merge re-run of the 5-agent / 15-newest-issues dry-run (2026-05-01). All bundled — each is a few lines and all are independent surface areas in the same call path (gate + prompts).

### 1. Summarizer over-escapes apostrophes

PR #18's quote-escape rule worked (`malformed_payload` count: 5/14 → 1/9), but the model is now emitting `doesn\'t` / `isn\'t`. JSON does **not** allow `\'` as an escape (the spec only knows `\"`, `\\`, `\/`, `\b`, `\f`, `\n`, `\r`, `\t`, `\uXXXX`); parse fails at position 454.

Tighten the prompt:
> Do NOT escape apostrophes — `\'` is INVALID JSON (the parser only knows `\"`, `\\`, `\/`, `\b`, `\f`, `\n`, `\r`, `\t`, `\uXXXX`). Write apostrophes as a plain `'`: `don't`, `isn't`, `can't`.

### 2. `gh issue create` not intercepted in dry-run

Agent-e287 #599 hit 2 denies trying to file a cross-repo skill issue at `szhygulin/vaultpilot-security-skill` — the canonical **cross-repo-scope-split** workflow that the agent prompt explicitly endorses. State-changing op, so it has to be intercepted (synthesize a fake URL like `gh issue comment` and `gh pr create` already do).

Three changes in `src/agent/codingAgent.ts`:
- **Allowlist**: `^gh\s+issue\s+create(\s|$)`.
- **Compound-smuggling guard**: add to `DRY_RUN_SENSITIVE_PATTERNS` + `DRY_RUN_SENSITIVE_LEADING`.
- **dryRunIntercept arm**: extract `--repo X/Y` from the cmd and synthesize `https://dry-run/issue-create/X/Y/new` (falls back to `opts.targetRepo` if `--repo` absent).

### 3a. `npm ls` denied

Read-only inspection of transitive deps. Extend the npm allowlist regex to include `ls|list`.

### 3b. Bash `grep` denied (agent prompt nudge)

Agent-d396 #610 reached for bash `grep` to search inside node_modules. The harness provides the `Grep` tool with **no path restriction**. Header prompt now says:
> For text search, use the `Grep` tool (any path, any pattern) — bash `grep` is not allowlisted and will be denied.

## Push-protection invariant preserved

Per CLAUDE.md "Three-layer push-protection":
- Only **additions** to the allowlist (`gh issue create`, `npm ls|list`) — both are non-state-changing or routed through dry-run intercept.
- New intercept arm rewrites to `printf` (synthetic URL), so it **cannot** reach the real `gh issue create` endpoint in dry-run.
- New compound-deny pattern **strengthens** the guard for `gh issue create` (compound-smuggling can no longer bypass intercept).
- `PUSH_TO_MAIN_RE`, `PLAIN_FORCE_PUSH_RE`, `NO_VERIFY_RE`, `disallowedTools` all unchanged.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] **15 regex assertions pass**:
  - 4 newly-allowed shapes (`gh issue create` with various flag orders, `npm ls`, `npm list`)
  - 5 PR back-compat (existing `gh issue view`/`comment`, `gh pr create`, `npm run`/`view`)
  - 4 still-denied (`gh issue close`, `gh issue edit`, `npm publish`, `npm uninstall`)
  - 2 compound-deny (chained `gh issue create` after `&&` denied; leading `gh issue create` not denied — intercept handles)
- [x] Both prompt strings render correctly in the compiled JS dist
- [ ] Re-run a 5-agent dry-run; expect zero `gh issue create` denies, zero `npm ls` denies, zero bash-`grep` denies, and `summarizer.malformed_payload` rate drops from 1/9 toward 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
