### PR TITLE
feat: human-readable names for agents

### DIFF
--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -10,8 +10,11 @@ export async function buildAgentSystemPrompt(opts: {
   const claudeMd = await readAgentClaudeMd(opts.agent.agentId, opts.targetRepoPath);
   const workflow = renderWorkflow(opts.workflow);
 
+  const label = opts.agent.name
+    ? `${opts.agent.name} [${opts.agent.agentId}]`
+    : opts.agent.agentId;
   return [
-    `# CLAUDE.md (agent ${opts.agent.agentId} — evolving specialization)`,
+    `# CLAUDE.md (agent ${label} — evolving specialization)`,
     "",
     claudeMd.trim(),
     "",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -299,8 +299,12 @@ async function cmdStatus(): Promise<void> {
     `  total=${total} pending=${counts.pending} in-flight=${counts["in-flight"]} done=${counts.done} failed=${counts.failed}\n`,
   );
   process.stdout.write(`  ticks=${state.tickCount} parallelism=${state.parallelism} dryRun=${state.dryRun}\n`);
+  // Resolve names from registry (best-effort — keep status read-only).
+  const reg = await loadRegistry();
+  const nameOf = new Map(reg.agents.map((a) => [a.agentId, a.name]));
   for (const a of state.agents) {
-    process.stdout.write(`  agent ${a.agentId}: ${a.status}\n`);
+    const label = nameOf.get(a.agentId) ? `${nameOf.get(a.agentId)} (${a.agentId})` : a.agentId;
+    process.stdout.write(`  agent ${label}: ${a.status}\n`);
   }
 }
 
@@ -325,6 +329,7 @@ async function cmdAgentsSpecialties(opts: AgentsSpecialtiesOpts): Promise<void> 
 
   type Profile = {
     agentId: string;
+    name?: string;
     issuesHandled: number;
     implementCount: number;
     pushbackCount: number;
@@ -347,6 +352,7 @@ async function cmdAgentsSpecialties(opts: AgentsSpecialtiesOpts): Promise<void> 
       .slice(0, opts.topTags);
     profiles.push({
       agentId: a.agentId,
+      name: a.name,
       issuesHandled: a.issuesHandled,
       implementCount: a.implementCount,
       pushbackCount: a.pushbackCount,
@@ -366,8 +372,9 @@ async function cmdAgentsSpecialties(opts: AgentsSpecialtiesOpts): Promise<void> 
   }
 
   for (const p of profiles) {
+    const label = p.name ? `${p.name} (${p.agentId})` : p.agentId;
     process.stdout.write(
-      `\n=== ${p.agentId}  handled=${p.issuesHandled}  impl=${p.implementCount}  pb=${p.pushbackCount}  err=${p.errorCount}  lastActive=${p.lastActiveAt}\n`,
+      `\n=== ${label}  handled=${p.issuesHandled}  impl=${p.implementCount}  pb=${p.pushbackCount}  err=${p.errorCount}  lastActive=${p.lastActiveAt}\n`,
     );
     process.stdout.write(
       `Distinctive tags (in ≤${distinctiveCutoff}/${reg.agents.length} agents): ${p.distinctiveTags.length > 0 ? p.distinctiveTags.join(", ") : "(none — all tags are widely shared)"}\n`,
@@ -402,8 +409,9 @@ async function cmdAgentsList(): Promise<void> {
     process.stdout.write("No agents in registry yet.\n");
     return;
   }
-  const headers = ["agentId", "tags", "issuesHandled", "implement", "pushback", "error", "lastActive"];
+  const headers = ["name", "agentId", "tags", "issuesHandled", "implement", "pushback", "error", "lastActive"];
   const rows = reg.agents.map((a) => [
+    a.name ?? "",
     a.agentId,
     a.tags.join(","),
     String(a.issuesHandled),
@@ -550,6 +558,7 @@ async function cmdAgentsPick(opts: PickOpts): Promise<void> {
       closed,
       reusedAgents: result.reusedAgents.map((p) => ({
         agentId: p.agent.agentId,
+        name: p.agent.name,
         tags: p.agent.tags,
         issuesHandled: p.agent.issuesHandled,
         score: p.score,
@@ -571,8 +580,9 @@ async function cmdAgentsPick(opts: PickOpts): Promise<void> {
   } else {
     for (const p of result.reusedAgents) {
       const tagStr = p.agent.tags.length > 0 ? p.agent.tags.join(",") : "general";
+      const label = p.agent.name ? `${p.agent.name} (${p.agent.agentId})` : p.agent.agentId;
       process.stdout.write(
-        `  ${p.agent.agentId}  tags=[${tagStr}]  issuesHandled=${p.agent.issuesHandled}  score=${p.score.toFixed(3)}\n`,
+        `  ${label}  tags=[${tagStr}]  issuesHandled=${p.agent.issuesHandled}  score=${p.score.toFixed(3)}\n`,
       );
     }
   }

--- a/src/orchestrator/setup.ts
+++ b/src/orchestrator/setup.ts
@@ -69,8 +69,9 @@ export function formatSetupPreview(p: SetupPreview): string {
   } else {
     for (const r of p.reusedAgents) {
       const tagStr = r.agent.tags.length > 0 ? r.agent.tags.join(",") : "general";
+      const label = r.agent.name ? `${r.agent.name} (${r.agent.agentId})` : r.agent.agentId;
       lines.push(
-        `  ${r.agent.agentId}  tags=[${tagStr}]  issuesHandled=${r.agent.issuesHandled}  score=${r.score.toFixed(3)}`,
+        `  ${label}  tags=[${tagStr}]  issuesHandled=${r.agent.issuesHandled}  score=${r.score.toFixed(3)}`,
       );
     }
   }

--- a/src/state/names.ts
+++ b/src/state/names.ts
@@ -1,0 +1,69 @@
+import crypto from "node:crypto";
+
+// Curated pool of names from computing / mathematics / engineering history.
+// Pure-display labels for AgentRecord — agentId stays the canonical handle,
+// so adding / reordering this pool can never break routing, branch parsing,
+// or directory paths. New names are safe to append.
+export const NAME_POOL: readonly string[] = [
+  "Ada", "Alan", "Albert", "Alonzo", "Andrei", "Archimedes", "Aristotle",
+  "Aryabhata", "Bhaskara", "Blaise", "Bohr", "Boole", "Bose", "Brahmagupta",
+  "Brouwer", "Cantor", "Cauchy", "Cayley", "Chaitin", "Charles", "Church",
+  "Cleo", "Clifford", "Codd", "Cohen", "Conway", "Cook", "Copernicus",
+  "Cormen", "Curie", "Curry", "Dahl", "Dantzig", "Darwin", "Dedekind",
+  "Descartes", "Diffie", "Dijkstra", "Dirac", "Donald", "Edsger", "Eilenberg",
+  "Einstein", "Eratosthenes", "Erdos", "Erlang", "Euclid", "Eudoxus", "Euler",
+  "Evelyn", "Faraday", "Fei", "Fermat", "Feynman", "Fibonacci", "Floyd",
+  "Fourier", "Frances", "Frege", "Friedrich", "Galileo", "Galois", "Gauss",
+  "George", "Godel", "Grace", "Hamilton", "Hardy", "Hassler", "Hawking",
+  "Hedy", "Heisenberg", "Henri", "Hermann", "Hertz", "Hilbert", "Hipparchus",
+  "Hippasus", "Hoare", "Hopper", "Howard", "Hypatia", "Iyengar", "Jacobi",
+  "Jane", "Janelle", "Jean", "John", "Joseph", "Joy", "Karen", "Katherine",
+  "Khalil", "Khwarizmi", "Kleene", "Knuth", "Kolmogorov", "Kovalevskaya",
+  "Kronecker", "Kummer", "Lagrange", "Lamarr", "Lambert", "Lamport",
+  "Landau", "Laplace", "Lavoisier", "Lebesgue", "Legendre", "Leibniz",
+  "Leslie", "Levi", "Linus", "Lipschitz", "Lise", "Liskov", "Lovelace",
+  "Mae", "Malik", "Mandelbrot", "Margaret", "Marie", "Markov", "Mary",
+  "Maryam", "Maxwell", "McCarthy", "Meitner", "Mendel", "Mercator", "Mersenne",
+  "Mihaela", "Milgram", "Milne", "Mira", "Mirzakhani", "Naomi", "Napier",
+  "Nash", "Neumann", "Newton", "Niels", "Nikola", "Niloufar", "Nyquist",
+  "Oersted", "Ohm", "Olga", "Oppenheimer", "Pascal", "Pasteur", "Patrick",
+  "Paul", "Pauli", "Perelman", "Pieter", "Planck", "Plato", "Poincare",
+  "Poisson", "Polya", "Postel", "Ptolemy", "Pythagoras", "Radia", "Rajagopal",
+  "Ramanujan", "Raman", "Reed", "Riemann", "Ritchie", "Rosalind", "Russell",
+  "Saadia", "Sally", "Saunders", "Scholze", "Schrodinger", "Seki", "Selma",
+  "Shannon", "Shing", "Shreya", "Sierpinski", "Sofia", "Stallman", "Stephen",
+  "Steve", "Stokes", "Sundar", "Tagore", "Tao", "Tarski", "Tesla", "Thales",
+  "Tim", "Torvalds", "Tu", "Turing", "Vera", "Vidya", "Vint", "Wallis",
+  "Wassily", "Watson", "Weierstrass", "Wernher", "Wiles", "Wirth",
+  "Wittgenstein", "Yann", "Yoshua", "Zhang", "Zuse",
+];
+
+const POOL_SIZE = NAME_POOL.length;
+
+/**
+ * Pick a display name for a freshly-minted agent.
+ *
+ * - Deterministic given agentId: identical agentId always hashes to the same
+ *   pool offset, so re-deriving a name on a record that lost its `name` field
+ *   yields the same result.
+ * - Linear-probes the pool on collision against `takenNames`.
+ * - If the entire pool is exhausted, falls back to "<base>-<hexSuffix>" using
+ *   the agentId's hex tail (e.g. "Ada-d396") — keeps display unique without
+ *   inventing new mythology entries.
+ */
+export function pickName(agentId: string, takenNames: Iterable<string>): string {
+  const taken = new Set<string>();
+  for (const t of takenNames) taken.add(t);
+
+  const hash = crypto.createHash("sha256").update(agentId).digest();
+  const start = hash.readUInt32BE(0) % POOL_SIZE;
+
+  for (let step = 0; step < POOL_SIZE; step++) {
+    const candidate = NAME_POOL[(start + step) % POOL_SIZE];
+    if (!taken.has(candidate)) return candidate;
+  }
+
+  const suffix = agentId.replace(/^agent-/, "");
+  const base = NAME_POOL[start];
+  return `${base}-${suffix}`;
+}

--- a/src/state/registry.ts
+++ b/src/state/registry.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import crypto from "node:crypto";
 import { atomicWriteJson, STATE_DIR } from "./runState.js";
 import { withFileLock } from "./locks.js";
+import { pickName } from "./names.js";
 import type { AgentRecord, AgentRegistryFile } from "../types.js";
 
 export const REGISTRY_FILE = path.join(STATE_DIR, "agents-registry.json");
@@ -10,7 +11,11 @@ export const REGISTRY_FILE = path.join(STATE_DIR, "agents-registry.json");
 export async function loadRegistry(): Promise<AgentRegistryFile> {
   try {
     const raw = await fs.readFile(REGISTRY_FILE, "utf-8");
-    return JSON.parse(raw) as AgentRegistryFile;
+    const parsed = JSON.parse(raw) as AgentRegistryFile;
+    // Lazy fill: pre-name records inherited from before this field existed.
+    // The JSON on disk only mutates on the next `mutateRegistry` write —
+    // safe to no-op into a read-only display path.
+    return { ...parsed, agents: fillNames(parsed) };
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return { agents: [] };
     throw err;
@@ -35,6 +40,11 @@ export async function mutateRegistry<T>(
       else throw err;
     }
     const reg = JSON.parse(raw) as AgentRegistryFile;
+    // Lazy migration: populate `name` on any pre-existing record before the
+    // mutation runs, so the persisted JSON accrues names without a one-shot
+    // migration script. The fn may add or rename agents; ensureAgent /
+    // createAgent themselves call pickName, so additions land with a name.
+    reg.agents = fillNames(reg);
     const result = await fn(reg);
     await atomicWriteJson(REGISTRY_FILE, reg);
     return result;
@@ -59,10 +69,45 @@ export function ensureAgent(reg: AgentRegistryFile, agentId: string): AgentRecor
       pushbackCount: 0,
       errorCount: 0,
       lastActiveAt: now,
+      name: pickName(agentId, takenNames(reg)),
     };
     reg.agents.push(rec);
+  } else if (!rec.name) {
+    // Lazy migration for pre-existing records: fill on next touch. The
+    // mutated record persists at the next `mutateRegistry` write.
+    rec.name = pickName(rec.agentId, takenNames(reg, rec.agentId));
   }
   return rec;
+}
+
+/**
+ * Lazy-fill names for every record currently lacking one. Called by callers
+ * that read the registry purely for display (e.g. `agents list`, setup
+ * preview) and don't want to mutate it. Returns a new array — does NOT
+ * persist. Pre-existing names are preserved.
+ */
+export function fillNames(reg: AgentRegistryFile): AgentRecord[] {
+  const taken = new Set(reg.agents.map((a) => a.name).filter((n): n is string => !!n));
+  const out: AgentRecord[] = [];
+  for (const a of reg.agents) {
+    if (a.name) {
+      out.push(a);
+      continue;
+    }
+    const name = pickName(a.agentId, taken);
+    taken.add(name);
+    out.push({ ...a, name });
+  }
+  return out;
+}
+
+function takenNames(reg: AgentRegistryFile, exceptAgentId?: string): string[] {
+  const out: string[] = [];
+  for (const a of reg.agents) {
+    if (a.agentId === exceptAgentId) continue;
+    if (a.name) out.push(a.name);
+  }
+  return out;
 }
 
 export function createAgent(reg: AgentRegistryFile): AgentRecord {

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,11 @@ export interface AgentRecord {
   pushbackCount: number;
   errorCount: number;
   lastActiveAt: string;
+  // Optional display label, lazy-filled by registry helpers when first
+  // touched. Display-only — agentId remains the canonical handle in branch
+  // names, agent dir paths, log events, lock keys, and the agent's own
+  // prompt header.
+  name?: string;
 }
 
 export interface AgentRegistryFile {


### PR DESCRIPTION
## Summary
- AgentRecord gains an optional `name` field, lazy-filled from a deterministic curated pool keyed off agentId.
- `agentId` stays the canonical handle everywhere (branches, dir paths, prompts, lock keys) — names are display-only.
- `loadRegistry` fills names on read; `mutateRegistry` persists them on the next write — no one-shot migration script.

Display surfaces showing names: `agents list`, `agents pick`, `agents specialties`, `status`, the setup preview, and the agent's own prompt header (`# CLAUDE.md (agent Erlang [agent-d396] — evolving specialization)`).

Names assigned to the existing 5-agent registry on first read:
- agent-d396 → Erlang
- agent-51e5 → Tesla
- agent-90e4 → Howard
- agent-08c4 → Khwarizmi
- agent-e287 → Floyd

This is PR 1 of 5 from the plan. Subsequent PRs (two-phase routing, --agents-as-cap, split detection, split apply) branch independently off main.

## Test plan
- [ ] `npm run typecheck && npm run build` clean (passing locally)
- [ ] `vp-dev agents list` includes the `name` column
- [ ] `vp-dev run --dry-run` setup preview shows `Erlang (agent-d396)` in the agents-to-summon list
- [ ] Existing `state/agents-registry.json` loads cleanly; names appear after first display read; on-disk JSON unchanged until next mutation

🤖 Generated with [Claude Code](https://claude.com/claude-code)