### PR TITLE
feat(routing): two-phase specialist + general fallback (env-flagged)

### DIFF
--- a/src/orchestrator/dispatcher.ts
+++ b/src/orchestrator/dispatcher.ts
@@ -1,7 +1,12 @@
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import { buildTickPrompt } from "./prompt.js";
 import { TickProposalSchema, type TickAssignment } from "../types.js";
-import { deterministicFallback } from "./routing.js";
+import {
+  classifyMatch,
+  deterministicFallback,
+  isGeneralist,
+  isTwoPhaseRoutingEnabled,
+} from "./routing.js";
 import type { AgentRecord, IssueSummary } from "../types.js";
 import type { Logger } from "../log/logger.js";
 
@@ -160,15 +165,23 @@ function validateProposal(input: ValidateInput): string[] {
   if (input.proposal.length > input.cap) {
     errors.push(`Too many assignments: ${input.proposal.length} > cap ${input.cap}`);
   }
-  // Under-dispatch wastes parallelism: when cap > 0 the dispatcher must fill
-  // every available slot. Past incident 2026-05-01: dispatcher returned 1
-  // assignment at tick 2 with cap=2 (both agents idle, both issues pending),
-  // costing a 10-min wall-clock gap before the next tick re-tried. Treating
-  // under-dispatch as a validation error triggers the retry → deterministic
-  // fallback path which always fills cap.
-  if (input.cap > 0 && input.proposal.length < input.cap) {
+
+  // The "true cap" — how many assignments are ACTUALLY dispatchable, given
+  // matching constraints. In single-phase mode this equals input.cap (any
+  // agent×issue pair is acceptable). In two-phase mode we count specialist
+  // pairs first, then generalist seats for unmatched issues — empty slots
+  // beyond that are correct, not a bug.
+  const trueCap = computeTrueCap(input);
+
+  // Under-dispatch wastes parallelism: when assignments < trueCap the
+  // dispatcher left a dispatchable slot empty. Past incident 2026-05-01:
+  // dispatcher returned 1 assignment at tick 2 with cap=2 (both agents
+  // idle, both issues pending), costing a 10-min wall-clock gap before the
+  // next tick re-tried. Treating under-dispatch as a validation error
+  // triggers the retry → deterministic fallback path which always fills.
+  if (trueCap > 0 && input.proposal.length < trueCap) {
     errors.push(
-      `Under-dispatch: ${input.proposal.length} assignments < cap ${input.cap}. Fill every available slot — the cap reflects what's actually dispatchable.`,
+      `Under-dispatch: ${input.proposal.length} assignments < trueCap ${trueCap}. Fill every dispatchable slot — empty slots beyond what specialists+generalists can cover are fine.`,
     );
   }
 
@@ -183,4 +196,39 @@ function validateProposal(input: ValidateInput): string[] {
     seenIssues.add(a.issueId);
   }
   return errors;
+}
+
+/**
+ * In single-phase mode (legacy), every agent×issue pair is dispatchable so
+ * the true cap is just input.cap. In two-phase mode, count how many issues
+ * have a specialist match; the remainder need a generalist agent. The
+ * dispatchable count is bounded by both.
+ */
+function computeTrueCap(input: ValidateInput): number {
+  const cap = Math.min(input.cap, input.idleAgents.length, input.pendingIssues.length);
+  if (!isTwoPhaseRoutingEnabled()) return cap;
+
+  const specialistAgents = new Set<string>();
+  const matchedIssues = new Set<number>();
+  for (const a of input.idleAgents) {
+    for (const i of input.pendingIssues) {
+      if (classifyMatch(a, i) === "specialist") {
+        specialistAgents.add(a.agentId);
+        matchedIssues.add(i.id);
+      }
+    }
+  }
+  // Specialist seats: each specialist agent can take at most one issue per
+  // tick, but only if at least one of its specialty issues is still available
+  // — bound by min(specialistAgents, matchedIssues).
+  const specialistSeats = Math.min(specialistAgents.size, matchedIssues.size);
+
+  // Generalist seats: idle generalists × unmatched issues.
+  const generalistAgents = input.idleAgents.filter(
+    (a) => !specialistAgents.has(a.agentId) && isGeneralist(a),
+  );
+  const unmatchedIssues = input.pendingIssues.filter((i) => !matchedIssues.has(i.id));
+  const generalistSeats = Math.min(generalistAgents.length, unmatchedIssues.length);
+
+  return Math.min(cap, specialistSeats + generalistSeats);
 }

--- a/src/orchestrator/prompt.ts
+++ b/src/orchestrator/prompt.ts
@@ -1,3 +1,4 @@
+import { isTwoPhaseRoutingEnabled, SPECIALIST_THRESHOLD } from "./routing.js";
 import type { AgentRecord, IssueSummary } from "../types.js";
 
 export interface TickPromptInput {
@@ -23,13 +24,21 @@ export function buildTickPrompt(input: TickPromptInput): string {
     ? `\n\nYour PRIOR proposal failed validation. Fix these and re-emit:\n${input.errorsFromPrior.map((e) => `- ${e}`).join("\n")}\n`
     : "";
 
-  return `You are the dispatcher for vp-dev. You assign idle agents to pending issues for ONE scheduling tick.
-
-Routing rule:
+  const routingRule = isTwoPhaseRoutingEnabled()
+    ? `Routing rule (two-phase):
+- Phase A — specialists first. For each issue, prefer an agent whose tags overlap the issue's labels with Jaccard >= ${SPECIALIST_THRESHOLD}. Pick the highest-scoring agent x issue pair first; don't double-book a specialist if another also fits.
+- Phase B — fall back to a general agent (tags includes "general", <=3 tags total). General agents pick up issues with no specialist match.
+- Each agent gets at most ONE issue per tick. Each issue is assigned to at most ONE agent.
+- Emit AT MOST ${input.cap} assignment${input.cap === 1 ? "" : "s"}. Leaving slots empty is acceptable when no specialist OR general agent fits the remaining issues. If a specialist OR general agent IS available for an unmatched issue, you must assign it.`
+    : `Routing rule:
 - Prefer specialists by Jaccard overlap between agent.tags and issue.labels.
 - Brand-new general agents (tags == ["general"]) should pick up issues with no obvious specialist match.
 - Each agent gets at most ONE issue per tick. Each issue is assigned to at most ONE agent.
-- Emit EXACTLY ${input.cap} assignment${input.cap === 1 ? "" : "s"}. The cap reflects how many idle-agent × pending-issue pairs are available — leaving slots empty wastes parallelism. If the routing fit is weak, still assign — Jaccard overlap of 0 is acceptable when no better match exists.
+- Emit EXACTLY ${input.cap} assignment${input.cap === 1 ? "" : "s"}. The cap reflects how many idle-agent x pending-issue pairs are available — leaving slots empty wastes parallelism. If the routing fit is weak, still assign — Jaccard overlap of 0 is acceptable when no better match exists.`;
+
+  return `You are the dispatcher for vp-dev. You assign idle agents to pending issues for ONE scheduling tick.
+
+${routingRule}
 
 Inputs (JSON):
 ${JSON.stringify({ pending, idle, cap: input.cap }, null, 2)}${errorBlock}

--- a/src/orchestrator/routing.ts
+++ b/src/orchestrator/routing.ts
@@ -6,6 +6,18 @@ export interface ScoredPair {
   score: number;
 }
 
+// Jaccard floor that promotes an agent from "weak" to "specialist" for an
+// issue. Hand-tuned: at 0.25, an issue with 4 labels needs an agent whose
+// tag set overlaps on at least 1 of them while the union stays compact —
+// the natural threshold for a "fits the topic" signal.
+export const SPECIALIST_THRESHOLD = 0.25;
+
+// Two-phase routing is opt-in for now to allow shadow comparison against the
+// legacy single-Jaccard-sort. Flip default when confidence is high.
+export function isTwoPhaseRoutingEnabled(): boolean {
+  return process.env.VP_DEV_TWO_PHASE_ROUTING === "1";
+}
+
 export function jaccard(a: Iterable<string>, b: Iterable<string>): number {
   const setA = new Set(toLowerSet(a));
   const setB = new Set(toLowerSet(b));
@@ -27,6 +39,115 @@ export function scoreAgentIssue(agent: AgentRecord, issue: IssueSummary): number
   return j + 0.05 * Math.log(1 + agent.issuesHandled);
 }
 
+export type MatchClass = "specialist" | "weak" | "miss";
+
+export function classifyMatch(agent: AgentRecord, issue: IssueSummary): MatchClass {
+  const j = jaccard(agent.tags, issue.labels);
+  if (j >= SPECIALIST_THRESHOLD) return "specialist";
+  if (j > 0) return "weak";
+  return "miss";
+}
+
+/** True if an agent has not yet drifted into a specialty. */
+export function isGeneralist(agent: AgentRecord): boolean {
+  if (agent.tags.length === 0) return true;
+  if (agent.tags.length === 1 && agent.tags[0].toLowerCase() === "general") return true;
+  // Allow a small tag set with "general" present — accumulates a few tags
+  // before the agent is considered specialized.
+  const hasGeneral = agent.tags.some((t) => t.toLowerCase() === "general");
+  return hasGeneral && agent.tags.length <= 3;
+}
+
+export interface TwoPhasePickInput {
+  idleAgents: AgentRecord[];
+  pendingIssues: IssueSummary[];
+  cap: number;
+}
+
+export interface TwoPhasePickResult {
+  assignments: ScoredPair[];
+  unmatchedIssueIds: number[];
+  reasons: Array<{
+    issueId: number;
+    agentId: string;
+    phase: "specialist" | "general";
+    score: number;
+  }>;
+}
+
+/**
+ * Two-phase picker:
+ *
+ *  Phase A (specialist): for each issue, find idle agents with Jaccard ≥
+ *  SPECIALIST_THRESHOLD. Greedy match highest-scoring (score, agentId,
+ *  issueId) pair first; don't double-book an agent.
+ *
+ *  Phase B (general fallback): unmatched issues route to a generalist
+ *  (agent with `general` tag and ≤3 total tags). Tiebreak on
+ *  least-recently-active to spread load — opposite of the legacy
+ *  `0.05*log(issuesHandled)` bonus that pushed work toward the busiest
+ *  agent.
+ */
+export function twoPhasePick(input: TwoPhasePickInput): TwoPhasePickResult {
+  const cap = Math.min(input.cap, input.idleAgents.length, input.pendingIssues.length);
+  const assignments: ScoredPair[] = [];
+  const reasons: TwoPhasePickResult["reasons"] = [];
+  if (cap <= 0) {
+    return { assignments, unmatchedIssueIds: input.pendingIssues.map((i) => i.id), reasons };
+  }
+
+  const usedAgents = new Set<string>();
+  const usedIssues = new Set<number>();
+
+  // Phase A: collect specialist pairs and sort.
+  const specialistPairs: ScoredPair[] = [];
+  for (const a of input.idleAgents) {
+    for (const i of input.pendingIssues) {
+      if (classifyMatch(a, i) === "specialist") {
+        specialistPairs.push({
+          agentId: a.agentId,
+          issueId: i.id,
+          score: scoreAgentIssue(a, i),
+        });
+      }
+    }
+  }
+  specialistPairs.sort(
+    (p, q) => q.score - p.score || p.agentId.localeCompare(q.agentId) || p.issueId - q.issueId,
+  );
+  for (const p of specialistPairs) {
+    if (assignments.length >= cap) break;
+    if (usedAgents.has(p.agentId) || usedIssues.has(p.issueId)) continue;
+    assignments.push(p);
+    usedAgents.add(p.agentId);
+    usedIssues.add(p.issueId);
+    reasons.push({ issueId: p.issueId, agentId: p.agentId, phase: "specialist", score: p.score });
+  }
+
+  // Phase B: route remaining issues to generalists.
+  if (assignments.length < cap) {
+    const generalists = input.idleAgents
+      .filter((a) => !usedAgents.has(a.agentId) && isGeneralist(a))
+      .sort((x, y) => Date.parse(x.lastActiveAt) - Date.parse(y.lastActiveAt));
+    for (const i of input.pendingIssues) {
+      if (assignments.length >= cap) break;
+      if (usedIssues.has(i.id)) continue;
+      const next = generalists.find((g) => !usedAgents.has(g.agentId));
+      if (!next) break;
+      const score = scoreAgentIssue(next, i);
+      assignments.push({ agentId: next.agentId, issueId: i.id, score });
+      usedAgents.add(next.agentId);
+      usedIssues.add(i.id);
+      reasons.push({ issueId: i.id, agentId: next.agentId, phase: "general", score });
+    }
+  }
+
+  const unmatchedIssueIds = input.pendingIssues
+    .map((i) => i.id)
+    .filter((id) => !usedIssues.has(id));
+  return { assignments, unmatchedIssueIds, reasons };
+}
+
 export interface FallbackInput {
   idleAgents: AgentRecord[];
   pendingIssues: IssueSummary[];
@@ -39,6 +160,9 @@ export interface FallbackAssignment {
 }
 
 export function deterministicFallback(input: FallbackInput): FallbackAssignment[] {
+  if (isTwoPhaseRoutingEnabled()) {
+    return twoPhasePick(input).assignments.map(({ agentId, issueId }) => ({ agentId, issueId }));
+  }
   const cap = Math.min(input.cap, input.idleAgents.length, input.pendingIssues.length);
   if (cap <= 0) return [];
 


### PR DESCRIPTION
## Summary
Behind `VP_DEV_TWO_PHASE_ROUTING=1`, replace the legacy single-Jaccard sort with explicit phase separation:

- **Phase A — specialist match**: Jaccard(agent.tags, issue.labels) ≥ `SPECIALIST_THRESHOLD` (0.25). Greedy best-pair-first match; no double-booking.
- **Phase B — general fallback**: unmatched issues route to a generalist (tags includes \`general\`, ≤3 tags). Tiebreak on least-recently-active — spreads load across generalists, opposite of the legacy `0.05*log(issuesHandled)` bonus that pushed work TOWARD the busiest agent.
- **Validation relaxed**: dispatcher previously required every cap slot filled. Two-phase mode computes `trueCap = specialistSeats + generalistSeats`; under-dispatch only fires when assignments < trueCap. Empty slots beyond what specialists + generalists can cover are correct.
- LLM dispatcher prompt mirrors the phase semantics when the flag is on.

This is PR 2 of 5 from the plan. Default OFF in this PR for shadow comparison; PR 3 flips it on.

## Test plan
- [x] `npm run typecheck && npm run build` clean
- [ ] `VP_DEV_TWO_PHASE_ROUTING=1 vp-dev run --agents 3 --dry-run --issues <mixed-label set>` — confirm specialist agents claim matching-label issues, generalists pick up the rest
- [ ] Default-off path: same behavior as before (legacy single-phase fallback unchanged)
- [ ] Under-dispatch error fires when specialists/generalists ARE available but unused

🤖 Generated with [Claude Code](https://claude.com/claude-code)