### PR TITLE
feat(orchestrator): --agents N becomes a hard cap on team size

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -546,7 +546,7 @@ async function cmdAgentsPick(opts: PickOpts): Promise<void> {
   const result = pickAgents({
     reg,
     pendingIssues: issues,
-    desiredParallelism: opts.parallelism,
+    maxParallelism: opts.parallelism,
   });
 
   if (opts.json) {

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -48,7 +48,7 @@ export async function runOrchestrator(input: OrchestratorInput): Promise<void> {
       .filter((i): i is IssueSummary => i !== undefined);
 
     const summonedAgents = await summonAgents({
-      desiredParallelism: input.parallelism,
+      maxParallelism: input.parallelism,
       state: input.state,
       pendingIssues: pending,
       targetRepoPath: repoPath,
@@ -121,21 +121,34 @@ export async function runOrchestrator(input: OrchestratorInput): Promise<void> {
 export interface PickAgentsInput {
   reg: AgentRegistryFile;
   pendingIssues: IssueSummary[];
-  desiredParallelism: number;
+  /** User-authorized maximum: hard cap on team size. */
+  maxParallelism: number;
 }
 
 export interface PickedAgent {
   agent: AgentRecord;
   score: number;
+  /** Why this agent was picked: matched a specialty, or fills a generalist seat. */
+  rationale: "specialist" | "general" | "fresh-general";
 }
 
 export interface PickResult {
   reusedAgents: PickedAgent[];
   newAgentsToMint: number;
+  /** Authorized cap (input.maxParallelism). Surfaced in the setup preview. */
+  authorized: number;
+  /** Derived team size: reusedAgents.length + newAgentsToMint, ≤ authorized. */
+  planned: number;
+  specialistCount: number;
+  generalCount: number;
 }
 
 /** Pure scoring: no registry mutation, no file I/O. Reusable for setup preview + runtime. */
 export function pickAgents(input: PickAgentsInput): PickResult {
+  const cap = input.maxParallelism;
+  const issueCount = input.pendingIssues.length;
+
+  // Score every agent against the issue set, then bucket by rationale.
   const scored = input.reg.agents
     .map((a) => ({ agent: a, score: agentSetScore(a, input.pendingIssues) }))
     .sort(
@@ -146,27 +159,49 @@ export function pickAgents(input: PickAgentsInput): PickResult {
   const reused: PickedAgent[] = [];
   const takenIds = new Set<string>();
 
+  // Pass 1 — pick specialists (positive score = some Jaccard overlap or a
+  // recency bonus on a previously-used agent). Keep going until the cap is
+  // hit OR we've covered enough issues that adding more agents has nothing
+  // to chew on.
   for (const s of scored) {
-    if (reused.length >= input.desiredParallelism) break;
+    if (reused.length >= cap) break;
+    if (reused.length >= issueCount) break;
     if (s.score <= 0) break;
-    reused.push(s);
+    reused.push({ agent: s.agent, score: s.score, rationale: "specialist" });
     takenIds.add(s.agent.agentId);
   }
-  if (reused.length < input.desiredParallelism) {
+  const specialistCount = reused.length;
+
+  // Pass 2 — fill remaining seats with general agents from the registry,
+  // bounded by issue count. Don't summon more than there are issues.
+  const generalReserveTarget = Math.min(cap - reused.length, issueCount - reused.length);
+  if (generalReserveTarget > 0) {
     for (const s of scored) {
-      if (reused.length >= input.desiredParallelism) break;
+      if (reused.length - specialistCount >= generalReserveTarget) break;
       if (takenIds.has(s.agent.agentId)) continue;
-      reused.push(s);
+      reused.push({ agent: s.agent, score: s.score, rationale: "general" });
       takenIds.add(s.agent.agentId);
     }
   }
+  const generalCount = reused.length - specialistCount;
 
-  const newAgentsToMint = Math.max(0, input.desiredParallelism - reused.length);
-  return { reusedAgents: reused, newAgentsToMint };
+  // Mint fresh agents only to fill remaining seats — capped by issue count
+  // (a 10-issue cap with 3 issues + 0 registry agents → 3 fresh, not 10).
+  const newAgentsToMint = Math.max(0, Math.min(cap, issueCount) - reused.length);
+
+  const planned = reused.length + newAgentsToMint;
+  return {
+    reusedAgents: reused,
+    newAgentsToMint,
+    authorized: cap,
+    planned,
+    specialistCount,
+    generalCount,
+  };
 }
 
 async function summonAgents(opts: {
-  desiredParallelism: number;
+  maxParallelism: number;
   state: RunState;
   pendingIssues: IssueSummary[];
   targetRepoPath: string;
@@ -177,7 +212,7 @@ async function summonAgents(opts: {
     const pick = pickAgents({
       reg,
       pendingIssues: opts.pendingIssues,
-      desiredParallelism: opts.desiredParallelism,
+      maxParallelism: opts.maxParallelism,
     });
     const taken: AgentRecord[] = pick.reusedAgents.map((p) => p.agent);
 

--- a/src/orchestrator/setup.ts
+++ b/src/orchestrator/setup.ts
@@ -13,6 +13,10 @@ export interface SetupPreview {
   resume: boolean;
   reusedAgents: PickedAgent[];
   newAgentsToMint: number;
+  authorized: number;
+  planned: number;
+  specialistCount: number;
+  generalCount: number;
 }
 
 export interface BuildPreviewInput {
@@ -31,7 +35,7 @@ export function buildSetupPreview(input: BuildPreviewInput): SetupPreview {
   const pick = pickAgents({
     reg: input.registry,
     pendingIssues: input.openIssues,
-    desiredParallelism: input.parallelism,
+    maxParallelism: input.parallelism,
   });
   return {
     targetRepo: input.targetRepo,
@@ -44,6 +48,10 @@ export function buildSetupPreview(input: BuildPreviewInput): SetupPreview {
     resume: input.resume,
     reusedAgents: pick.reusedAgents,
     newAgentsToMint: pick.newAgentsToMint,
+    authorized: pick.authorized,
+    planned: pick.planned,
+    specialistCount: pick.specialistCount,
+    generalCount: pick.generalCount,
   };
 }
 
@@ -58,7 +66,14 @@ export function formatSetupPreview(p: SetupPreview): string {
     `  Open issues:    ${p.openIssues.length}` +
       (p.closedSkipped.length > 0 ? `  (closed skipped: ${p.closedSkipped.length})` : ""),
   );
-  lines.push(`  Parallelism:    ${p.parallelism}`);
+  lines.push(`  Authorized:     ${p.authorized} (--agents)`);
+  // The "planned" line is the single most informative cost-surface number
+  // — it's what will actually consume API budget, vs. the headroom the user
+  // authorized. Kept on its own line so eyes lock on it before y/N.
+  const freshNote = p.newAgentsToMint > 0 ? ` + ${p.newAgentsToMint} fresh` : "";
+  lines.push(
+    `  Planned:        ${p.planned} (${p.specialistCount} specialist, ${p.generalCount} general${freshNote})`,
+  );
   lines.push(`  Dry run:        ${p.dryRun ? "yes" : "no"}`);
   lines.push(`  Resume:         ${p.resume ? "yes" : "no"}`);
   lines.push("");
@@ -71,7 +86,7 @@ export function formatSetupPreview(p: SetupPreview): string {
       const tagStr = r.agent.tags.length > 0 ? r.agent.tags.join(",") : "general";
       const label = r.agent.name ? `${r.agent.name} (${r.agent.agentId})` : r.agent.agentId;
       lines.push(
-        `  ${label}  tags=[${tagStr}]  issuesHandled=${r.agent.issuesHandled}  score=${r.score.toFixed(3)}`,
+        `  ${label}  rationale=${r.rationale}  tags=[${tagStr}]  issuesHandled=${r.agent.issuesHandled}  score=${r.score.toFixed(3)}`,
       );
     }
   }


### PR DESCRIPTION
## Summary
Replace verbatim N=team-size with a derived plan. `--agents N` becomes the user-authorized **maximum**; the orchestrator may summon FEWER when fewer specialists fit or the issue count is small.

- `pickAgents` input: `desiredParallelism` → `maxParallelism`. Output adds `{authorized, planned, specialistCount, generalCount}`.
- `PickedAgent` gains a `rationale` field (`specialist | general | fresh-general`).
- Fresh mints are bounded by issue count, never by the cap alone — `--agents 10 --issues 3` plans 3, not 10.
- Setup preview surfaces both numbers explicitly:
  ```
  Authorized:     10 (--agents)
  Planned:        3 (1 specialist, 2 general + 0 fresh)
  ```
- Each agent line includes `rationale=` so the user sees WHY it's on the planned roster.

This is PR 3 of 5 from the plan. Depends on PR 2 (#24) being merged first if interaction with two-phase routing is desired; this PR keeps `pickAgents` independent of routing flag.

## Test plan
- [x] `npm run typecheck && npm run build` clean
- [ ] `vp-dev run --agents 10 --dry-run --issues <3-issue set>` shows `Planned: 3` (≤ Authorized 10)
- [ ] `vp-dev run --agents 5 --dry-run --issues <8-issue set>` shows `Planned: 5` (cap binds)
- [ ] `vp-dev agents pick --parallelism 10 --issues …` returns ≤ 10 agents
- [ ] CI green (typecheck + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)