### PR TITLE
feat(split): apply path — mint children, archive parent

### DIFF
--- a/src/agent/split.ts
+++ b/src/agent/split.ts
@@ -1,7 +1,9 @@
 import { promises as fs } from "node:fs";
 import { z } from "zod";
 import { query } from "@anthropic-ai/claude-agent-sdk";
-import { agentClaudeMdPath } from "./specialization.js";
+import { agentClaudeMdPath, agentDir } from "./specialization.js";
+import { mutateRegistry, newAgentId } from "../state/registry.js";
+import { ensureDir } from "../state/locks.js";
 import type { AgentRecord } from "../types.js";
 
 // Thresholds for "this agent is overloaded enough to warrant splitting".
@@ -288,6 +290,134 @@ export function formatProposal(p: SplitProposal): string {
   lines.push("");
   lines.push("To apply this split (creates child agents, archives parent):");
   lines.push(`  vp-dev agents split ${p.agentId} --apply`);
-  lines.push("(--apply not yet implemented; this PR ships read-only detection.)");
   return lines.join("\n");
 }
+
+export interface ApplySplitInput {
+  proposal: SplitProposal;
+  /** Original CLAUDE.md content used to source per-cluster sections. */
+  parentClaudeMd: string;
+}
+
+export interface ApplySplitResult {
+  parentAgentId: string;
+  childIds: string[];
+}
+
+/**
+ * Apply a split proposal: mint child agents (one per cluster), partition
+ * the parent's CLAUDE.md sections into each child's CLAUDE.md, and mark
+ * the parent as archived. One-way mutation. Caller is responsible for
+ * having gathered explicit user confirmation upstream.
+ *
+ * Counters (issuesHandled, implementCount, pushbackCount, errorCount) are
+ * divided evenly across children, rounded down. The remainder is silently
+ * dropped — clean per-issue attribution would require tracking outcome
+ * per CLAUDE.md section, which we don't, so even-division is the
+ * auditable choice.
+ */
+export async function applySplit(input: ApplySplitInput): Promise<ApplySplitResult> {
+  const proposal = input.proposal;
+  if (proposal.clusters.length < 2) {
+    throw new Error(
+      `applySplit requires at least 2 clusters; proposal has ${proposal.clusters.length}.`,
+    );
+  }
+
+  const sections = parseClaudeMdSections(input.parentClaudeMd);
+  const sectionById = new Map(sections.map((s) => [s.sectionId, s]));
+  const seedPart = extractSeedPart(input.parentClaudeMd);
+
+  const result = await mutateRegistry(async (reg) => {
+    const parent = reg.agents.find((a) => a.agentId === proposal.agentId);
+    if (!parent) throw new Error(`parent agent ${proposal.agentId} not found in registry`);
+    if (parent.archived) throw new Error(`parent agent ${proposal.agentId} is already archived`);
+
+    const childIds: string[] = [];
+    const N = proposal.clusters.length;
+    const splitInt = (total: number) => Math.floor(total / N);
+
+    const takenAgentIds = new Set(reg.agents.map((a) => a.agentId));
+    // Forward-compat: pre-PR-1 AgentRecord lacks `name`. Read defensively
+    // through `unknown` so this PR can land before/after PR 1.
+    const takenNames = new Set(
+      reg.agents
+        .map((a) => (a as unknown as { name?: string }).name)
+        .filter((n): n is string => !!n),
+    );
+
+    for (const cluster of proposal.clusters) {
+      let childId = newAgentId();
+      while (takenAgentIds.has(childId)) childId = newAgentId();
+      takenAgentIds.add(childId);
+
+      let name = cluster.proposedName;
+      if (takenNames.has(name)) {
+        // Append the new agentId hex tail to disambiguate. Same pattern
+        // pickName uses for pool exhaustion in the names module.
+        name = `${cluster.proposedName}-${childId.replace(/^agent-/, "")}`;
+      }
+      takenNames.add(name);
+
+      const now = new Date().toISOString();
+      const child: AgentRecord = {
+        agentId: childId,
+        createdAt: now,
+        tags: dedupeStrings([...cluster.proposedTags]),
+        issuesHandled: splitInt(parent.issuesHandled),
+        implementCount: splitInt(parent.implementCount),
+        pushbackCount: splitInt(parent.pushbackCount),
+        errorCount: splitInt(parent.errorCount),
+        lastActiveAt: parent.lastActiveAt,
+        parentAgentId: parent.agentId,
+      };
+      // Forward-compat: only attach `name` if the field exists on the type.
+      // Older clones without the names PR ignore the extra field at JSON
+      // round-trip; the type itself accepts unknown keys via JSON parse.
+      (child as AgentRecord & { name?: string }).name = name;
+
+      reg.agents.push(child);
+      childIds.push(childId);
+
+      // Materialize the child's CLAUDE.md: seed + each cluster section.
+      const dir = agentDir(childId);
+      await ensureDir(dir);
+      const childMdParts: string[] = [];
+      if (seedPart.trim().length > 0) childMdParts.push(seedPart.trim());
+      for (const sid of cluster.sectionIds) {
+        const sec = sectionById.get(sid);
+        if (!sec) continue;
+        const provenance = `<!-- run:${sec.runId ?? "?"} issue:#${sec.issueId ?? "?"} outcome:${sec.outcome ?? "?"} ts:${now} -->`;
+        childMdParts.push(`${provenance}\n## ${sec.heading}\n\n${sec.body}`);
+      }
+      const childMd = childMdParts.join("\n\n") + "\n";
+      const dest = agentClaudeMdPath(childId);
+      const tmp = `${dest}.tmp.${process.pid}`;
+      await fs.writeFile(tmp, childMd);
+      await fs.rename(tmp, dest);
+    }
+
+    parent.archived = true;
+
+    return { parentAgentId: parent.agentId, childIds };
+  });
+
+  return result;
+}
+
+function dedupeStrings(arr: string[]): string[] {
+  return Array.from(new Set(arr));
+}
+
+/**
+ * Everything in the agent's CLAUDE.md before the first summarizer-appended
+ * section (i.e. before the first `<!-- run:... -->` provenance comment).
+ * That preamble is the seed copied at fork time — re-use it as the seed
+ * for every child.
+ */
+function extractSeedPart(md: string): string {
+  const idx = md.search(/<!--\s*run:/);
+  return idx < 0 ? md : md.slice(0, idx);
+}
+
+

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,7 @@ import { agentClaudeMdPath, forkClaudeMd } from "./agent/specialization.js";
 import { promises as fs } from "node:fs";
 import { runIssueCore } from "./agent/runIssueCore.js";
 import {
+  applySplit,
   detectOverload,
   formatProposal,
   proposeSplit,
@@ -104,10 +105,12 @@ export function buildCli(): Command {
     )
     .addCommand(
       new Command("split")
-        .description("Detect overload + emit a proposed split into 2-3 sub-specialists. Read-only — does NOT mutate (--apply not yet supported).")
+        .description("Detect overload + emit a proposed split into 2-3 sub-specialists. Pass --apply to mutate the registry.")
         .argument("<agentId>", "Agent to inspect (e.g. agent-d396)")
         .option("--json", "Print machine-readable JSON")
         .option("--force", "Run the proposal even if the agent has not crossed an overload threshold")
+        .option("--apply", "Apply the proposal: mint child agents, partition CLAUDE.md sections, archive parent. ONE-WAY mutation.")
+        .option("--yes", "Skip the apply confirmation prompt (required for non-TTY environments).")
         .action(async (agentId, opts) => {
           await cmdAgentsSplit(agentId, opts);
         }),
@@ -422,6 +425,8 @@ function extractSummarizerLessons(md: string): string[] {
 interface AgentsSplitOpts {
   json?: boolean;
   force?: boolean;
+  apply?: boolean;
+  yes?: boolean;
 }
 
 async function cmdAgentsSplit(agentId: string, opts: AgentsSplitOpts): Promise<void> {
@@ -429,6 +434,10 @@ async function cmdAgentsSplit(agentId: string, opts: AgentsSplitOpts): Promise<v
   const agent = reg.agents.find((a) => a.agentId === agentId);
   if (!agent) {
     process.stderr.write(`ERROR: agent '${agentId}' not found in registry.\n`);
+    process.exit(2);
+  }
+  if (agent.archived) {
+    process.stderr.write(`ERROR: agent '${agentId}' is already archived (already split).\n`);
     process.exit(2);
   }
   const { md, bytes } = await readAgentClaudeMdBytes(agentId);
@@ -447,26 +456,86 @@ async function cmdAgentsSplit(agentId: string, opts: AgentsSplitOpts): Promise<v
   process.stdout.write(`Generating split proposal for ${agentId}...\n`);
   const proposal = await proposeSplit({ agent, claudeMd: md });
 
-  if (opts.json) {
-    process.stdout.write(
-      JSON.stringify(
-        {
-          agentId,
-          overloaded: !!verdict,
-          overloadReasons: verdict?.reasons ?? [],
-          proposal,
-        },
-        null,
-        2,
-      ) + "\n",
-    );
+  if (!opts.apply) {
+    if (opts.json) {
+      process.stdout.write(
+        JSON.stringify(
+          {
+            agentId,
+            overloaded: !!verdict,
+            overloadReasons: verdict?.reasons ?? [],
+            proposal,
+          },
+          null,
+          2,
+        ) + "\n",
+      );
+      return;
+    }
+    if (verdict) {
+      process.stdout.write(`\nOverload verdict: ${verdict.reasons.join(", ")}\n\n`);
+    }
+    process.stdout.write(formatProposal(proposal) + "\n");
     return;
   }
 
-  if (verdict) {
-    process.stdout.write(`\nOverload verdict: ${verdict.reasons.join(", ")}\n\n`);
+  // --apply path: confirm with user, then mutate.
+  if (proposal.clusters.length < 2) {
+    process.stderr.write(
+      `ERROR: cannot apply — proposal has ${proposal.clusters.length} cluster(s), need >= 2.\n${proposal.notes ?? ""}\n`,
+    );
+    process.exit(2);
   }
-  process.stdout.write(formatProposal(proposal) + "\n");
+  process.stdout.write(formatProposal(proposal) + "\n\n");
+  const confirmed = await confirmApply({
+    agentId,
+    childCount: proposal.clusters.length,
+    yes: !!opts.yes,
+  });
+  if (!confirmed) {
+    process.stdout.write("Aborted — no mutation.\n");
+    return;
+  }
+
+  const result = await applySplit({ proposal, parentClaudeMd: md });
+  if (opts.json) {
+    process.stdout.write(JSON.stringify({ agentId, applied: true, ...result }, null, 2) + "\n");
+    return;
+  }
+  process.stdout.write(
+    `Applied. Created ${result.childIds.length} children from ${result.parentAgentId}: ${result.childIds.join(", ")}\nParent archived.\n`,
+  );
+}
+
+async function confirmApply(input: {
+  agentId: string;
+  childCount: number;
+  yes: boolean;
+}): Promise<boolean> {
+  if (input.yes) {
+    process.stdout.write("Auto-confirmed (--yes).\n");
+    return true;
+  }
+  if (!process.stdin.isTTY) {
+    process.stderr.write(
+      "ERROR: stdin is not a TTY and --yes was not passed. Re-run with --yes to skip confirmation.\n",
+    );
+    return false;
+  }
+  const { createInterface } = await import("node:readline/promises");
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = (
+      await rl.question(
+        `Apply split: archive ${input.agentId} and create ${input.childCount} children? [y/N] `,
+      )
+    )
+      .trim()
+      .toLowerCase();
+    return answer === "y" || answer === "yes";
+  } finally {
+    rl.close();
+  }
 }
 
 async function cmdAgentsList(): Promise<void> {

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -148,8 +148,12 @@ export function pickAgents(input: PickAgentsInput): PickResult {
   const cap = input.maxParallelism;
   const issueCount = input.pendingIssues.length;
 
+  // Archived agents (post-split parents) are kept in the registry for
+  // history but never summoned again — their work has been redistributed
+  // to children.
+  const live = input.reg.agents.filter((a) => !a.archived);
   // Score every agent against the issue set, then bucket by rationale.
-  const scored = input.reg.agents
+  const scored = live
     .map((a) => ({ agent: a, score: agentSetScore(a, input.pendingIssues) }))
     .sort(
       (p, q) =>


### PR DESCRIPTION
## Summary
Build on the read-only detection from #26 with a confirmed-mutation `--apply` path.

- `src/agent/split.ts:applySplit()` — for each cluster, mint a child agent (`parentAgentId` set, tags from `proposedTags`, name from `proposedName` with hex-suffix collision fallback). Each child's CLAUDE.md is materialized as `{ parent's seed preamble + cluster's sections }` with regenerated provenance comments. Counters split evenly across children. Parent flagged `archived: true`.
- `pickAgents` filters out `archived` agents — they survive in the registry for history but never get summoned.
- `vp-dev agents split <agentId> --apply` mutates after a TTY y/N prompt (`--yes` for non-TTY, mirroring the run approval gate). `--json` returns `{applied: true, parentAgentId, childIds}`.

Three layers of guard: threshold detection (or `--force`), proposal must have ≥2 clusters, y/N prompt.

This PR is **PR 5 of 5** from the plan. It includes the detection commit from #26 since #26 is not yet merged. Once #26 lands, this branch rebases — that commit becomes a no-op in the rebase.

## Test plan
- [x] `npm run typecheck && npm run build` clean
- [ ] `vp-dev agents split agent-d396 --apply` against a copy of `state/agents-registry.json` produces 2-3 child agents with distinct names, each child's CLAUDE.md contains the partitioned sections, parent has `archived: true`
- [ ] `vp-dev agents split <archived-agent>` errors out (already split)
- [ ] `vp-dev run` after a split routes work to children, never to the archived parent
- [ ] `--json` mode returns `{applied: true, parentAgentId, childIds: [...]}`

## Depends on
- #26 (split detection — content included here, will be a no-op in rebase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)