### PR TITLE
feat(workflow): sign PR bodies with agent's human name

### DIFF
--- a/src/agent/codingAgent.ts
+++ b/src/agent/codingAgent.ts
@@ -47,6 +47,8 @@ export async function runCodingAgent(input: CodingAgentInput): Promise<CodingAge
       branchName: input.branchName,
       dryRun: input.dryRun,
       inspectPaths: input.inspectPaths,
+      agentId: input.agent.agentId,
+      agentName: input.agent.name,
     },
     targetRepoPath: input.targetRepoPath,
   });

--- a/src/agent/workflow.ts
+++ b/src/agent/workflow.ts
@@ -5,6 +5,8 @@ export interface WorkflowVars {
   branchName: string;
   dryRun: boolean;
   inspectPaths?: string[];
+  agentId: string;
+  agentName?: string;
 }
 
 export function renderWorkflow(v: WorkflowVars): string {
@@ -58,7 +60,7 @@ Emit the JSON envelope with decision="pushback" and the comment URL.
      Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
 5. Push:
      git push -u origin ${v.branchName}
-6. Open the PR — body MUST start with "Closes #${v.issueId}" on its own line so GitHub auto-closes.
+6. Open the PR — body MUST start with "Closes #${v.issueId}" on its own line so GitHub auto-closes. The body MUST also end with a single-line signature \`— ${v.agentName ?? v.agentId} (${v.agentId})\` so the human reader can tell which agent opened the PR.
    Write the PR body to a tmp file using the **\`Write\` tool** (same reason as Pushback path: heredoc chained with \`gh pr create\` trips the dry-run gate). Then run \`gh pr create\` as its OWN top-level Bash invocation:
      gh pr create --repo ${v.targetRepo} --base main --head ${v.branchName} --title <short title> --body-file <tmp>
 7. Format the returned PR URL as a Markdown hyperlink in your reasoning.


### PR DESCRIPTION
## Summary
- Thread `agentId` (required) and `agentName` (optional) through `WorkflowVars`.
- Require the implement-path PR body to end with a `— <Name> (<agent-id>)` signature, so a human reviewer can tell which agent opened a given PR without cross-referencing the registry.
- Falls back to `— <agent-id> (<agent-id>)` for any pre-name registry record (`AgentRecord.name` is optional and lazy-filled).

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [ ] Next live `vp-dev` run: confirm a real PR body ends with the signature line in the expected shape