### PR TITLE
chore(plans): seed feature-plans/ for #31-#36 + planning-mode #38

### DIFF
--- a/feature-plans/issue-31-merge-retire.md
+++ b/feature-plans/issue-31-merge-retire.md
@@ -1,0 +1,87 @@
+# Plan: counterpart to split — merge / retire stale or overlapping agents
+
+Tracks [#31](https://github.com/szhygulin/vaultpilot-development-agents/issues/31).
+
+## Context
+
+PR #27 / #26 added `split` — overloaded specialists fan out into child agents. The symmetric direction is unaddressed: two specialists drift into overlapping niches, or an agent stops getting picked. Without a cleanup path the roster only grows. Each extra agent adds prompt-seeding cost, summarizer cost, and routing ambiguity at every tick.
+
+Mirror split's UX: detect → emit proposal → human gate → apply.
+
+## Approach
+
+### Phase 1: detection (this PR)
+
+New module `src/agent/prune.ts` exposing:
+
+```ts
+export type PruneProposal =
+  | { kind: "merge"; survivor: string; absorbed: string; similarity: number; rationale: string }
+  | { kind: "retire"; agentId: string; reason: "stale" | "low-merge-rate"; metric: number };
+
+export async function detectPruneCandidates(opts: {
+  registry: AgentRegistry;
+  outcomes?: AgentOutcomes;
+}): Promise<PruneProposal[]>;
+```
+
+**Merge detection** — cosine similarity on tag vectors built from `AgentRecord.tags` (jaccard over tag sets is already in `src/orchestrator/routing.ts`'s `jaccard()`; reuse it). Threshold ≥ 0.75 emits a merge proposal. The higher-`issuesHandled` agent is the survivor. Stretch goal (deferred): LLM-judge over both `agents/<id>/CLAUDE.md` files.
+
+**Retire detection** — depends on outcome metrics from #36. If outcomes are absent, retire emits zero proposals (don't guess). With outcomes: agent has no successful run in N days (default 30) AND merge-rate < 0.5 AND `issuesHandled` ≥ 5 (avoid retiring fresh agents).
+
+### Phase 2: apply (this PR)
+
+```ts
+export async function applyPruneProposal(p: PruneProposal): Promise<void>;
+```
+
+**Merge apply path:**
+
+1. Concat `agents/<survivor>/CLAUDE.md` + `agents/<absorbed>/CLAUDE.md`.
+2. Re-run summarizer from `src/agent/summarizer.ts` against the concat (special prompt: "deduplicate; keep most-relevant lessons; ≤200 lines").
+3. Move `agents/<absorbed>/` → `agents/.archive/<absorbed>-merged-into-<survivor>-<ts>/`.
+4. Update `state/registry.json` via `mutateRegistry()` from `src/state/registry.ts`: mark absorbed agent `archived: true`, append `mergedInto: <survivor>` field on its record.
+
+**Retire apply path:**
+
+1. Move `agents/<id>/` → `agents/.archive/<id>-retired-<ts>/`.
+2. `mutateRegistry()` to set `archived: true`, `retiredAt: <iso>`, `retireReason: <reason>`.
+
+### CLI
+
+New subcommand in `src/cli.ts`:
+
+```
+vp-dev agents prune              # show pending proposals (read-only)
+vp-dev agents prune --apply      # interactive y/N per proposal, then apply
+vp-dev agents prune --yes        # apply all without prompt (CI only)
+```
+
+### Tick-time integration (deferred)
+
+Auto-fire detection at the end of each `runOrchestrator()` tick with a flag (`VP_DEV_AUTO_PRUNE=1`) — emit proposals only, never apply. Out of scope for this PR; landing detection + manual CLI first.
+
+## Critical files & integration points
+
+- `src/agent/split.ts` — UX template (detect → proposal → apply). Read this first; mirror its shape.
+- `src/agent/specialization.ts` — agent tag/specialty model.
+- `src/orchestrator/routing.ts` — `jaccard()` reusable for merge similarity.
+- `src/agent/summarizer.ts` — `summarize()` called for the merged CLAUDE.md.
+- `src/state/registry.ts` — `mutateRegistry()` for atomic registry updates; `AgentRecord` shape includes `archived?: boolean`.
+- `src/cli.ts` — new `prune` subcommand under the existing `agents` group.
+- `src/types.ts` — extend `AgentRecord` with optional `mergedInto`, `retiredAt`, `retireReason` fields.
+
+## Verification
+
+- Unit test `detectPruneCandidates()` against a fixture registry with two near-identical agents → emits exactly one merge proposal with the higher-`issuesHandled` agent as survivor.
+- Unit test against a fixture with one stale low-merge-rate agent (outcomes provided) → emits one retire proposal.
+- Integration test: `vp-dev agents prune --apply --yes` against a temp `state/` + `agents/` fixture → archive directory exists, registry updated, original agent dirs removed.
+- `vp-dev agents prune` (read-only) prints proposals without modifying anything; assert idempotency via `git diff` on state files.
+
+## Out of scope
+
+- Rebalancing in-flight work — prune runs between dispatch ticks only.
+- Auto-apply without human gate (even at high similarity).
+- Cross-target-repo merging.
+- LLM-judge similarity scoring.
+- Tick-time auto-fire (separate follow-up).

--- a/feature-plans/issue-32-failure-driven-learning.md
+++ b/feature-plans/issue-32-failure-driven-learning.md
@@ -1,0 +1,90 @@
+# Plan: failure-driven learning — extend summarizer to fire on terminal failure
+
+Tracks [#32](https://github.com/szhygulin/vaultpilot-development-agents/issues/32).
+
+## Context
+
+`src/agent/summarizer.ts` rewrites `agents/<id>/CLAUDE.md` only on successful runs. Failures — CI red after retry, PR closed unmerged, reviewer churn ≥ N rounds, agent gave up — carry the highest-signal lessons (what didn't work, what assumption broke, what tooling gap surfaced) and today they're discarded. A specialist with 60% merge-rate has 40% of its potential learning sitting on the floor.
+
+## Approach
+
+### Failure classification
+
+Distinguish genuine failures from infra flakes at the call site in `src/agent/runIssueCore.ts` (lines 84–125, where the summarizer fires today on success).
+
+Genuine failure (run summarizer with failure prompt):
+- Envelope `decision === "error"` with a non-empty `error` field.
+- Envelope `decision === "implement"` but workflow exit reports CI red after retries exhausted.
+- Envelope `decision === "pushback"` with a content classification of "agent gave up" (look for "I cannot" / "unable to determine").
+
+Infra flake (skip summarizer entirely):
+- SDK transport error (ECONNRESET, abort, timeout) — caught upstream in `codingAgent.ts`.
+- GitHub API 5xx surfaced via `src/github/gh.ts`.
+- Worktree creation failure (filesystem-level).
+
+### Failure-mode summarizer prompt
+
+Extend `src/agent/summarizer.ts` with a second exported entry point:
+
+```ts
+export async function summarizeFailure(input: {
+  agentId: string;
+  issueId: number;
+  envelope: ParsedEnvelope;
+  errorContext: string;
+  priorClaudeMd: string;
+}): Promise<{ updatedClaudeMd: string }>;
+```
+
+Prompt shape:
+- "What did the agent assume that turned out wrong?"
+- "What context or tooling was missing?"
+- "What guard rule, written tersely, would have prevented this?"
+
+Output gets prepended to `agents/<id>/CLAUDE.md` with sentinel:
+
+```markdown
+<!-- failure-lesson:run-<runId> -->
+<lesson body>
+<!-- /failure-lesson -->
+```
+
+The sentinel enables a separate prune cadence later (auto-expire after K subsequent successes) without affecting success-derived content.
+
+### Integration in runIssueCore.ts
+
+Inside `runIssueCore()` post-processing (current lines 84–125 fire `summarize()` only on success), add a sibling branch:
+
+```ts
+if (terminalState === "failed" && !isInfraFlake(error)) {
+  await summarizeFailure({ ... });
+} else if (terminalState === "succeeded") {
+  await summarize({ ... });   // existing path
+}
+// flakes: write nothing
+```
+
+`isInfraFlake()` is a small helper, also exported from `src/agent/summarizer.ts`, that pattern-matches error strings.
+
+## Critical files & integration points
+
+- `src/agent/summarizer.ts` — add `summarizeFailure()` export and `isInfraFlake()` helper. Existing `summarize()` unchanged.
+- `src/agent/runIssueCore.ts` — branch on terminal state at the existing summarizer fire-point (lines 84–125).
+- `src/agent/parseResult.ts` — `extractEnvelope()` shape provides `decision`, `error` fields the classifier reads.
+- `src/agent/prompt.ts` / `buildAgentSystemPrompt()` — no change; failure lessons land in the same `agents/<id>/CLAUDE.md` file already read on the next run.
+- `src/types.ts` — no change required; `IssueStatus` already has `"failed"`.
+
+## Verification
+
+- Unit test `isInfraFlake()` against representative error strings (transport, GitHub 5xx, filesystem) → all classify as flake.
+- Unit test `summarizeFailure()` with a stub envelope → returns updated CLAUDE.md with the sentinel-wrapped block prepended.
+- Integration: simulate a failed run by injecting `decision: "error"` into the envelope; confirm `agents/<id>/CLAUDE.md` gains a `<!-- failure-lesson -->` block; success runs in the same test suite still trigger the existing path.
+- Confirm flakes write nothing: inject a transport error, assert `agents/<id>/CLAUDE.md` is unchanged.
+
+## Out of scope
+
+- Auto-expire after K successes — sentinel enables it; implement in a follow-up if signal warrants.
+- Multi-failure aggregation ("3 similar failures across runs" → stronger lesson) — premature without observed signal.
+- Target-repo modifications (this writes only the agent's local memory).
+- Cross-agent failure sharing — covered by #33.
+- Reading reviewer-rework cycles as a failure signal — depends on #36.

--- a/feature-plans/issue-33-shared-lessons-pool.md
+++ b/feature-plans/issue-33-shared-lessons-pool.md
@@ -1,0 +1,73 @@
+# Plan: cross-agent shared lessons pool with curated promotion
+
+Tracks [#33](https://github.com/szhygulin/vaultpilot-development-agents/issues/33).
+
+## Context
+
+Each `agents/<id>/CLAUDE.md` is fully isolated per CLAUDE.md's "cross-agent writes corrupt parallel runs" rule. The boundary is correct for the WRITE path — agents must never reach into a sibling's directory. But the rule also blocks the READ path, so the same domain knowledge gets rediscovered N times across siblings (Solana RPC quirks, ERC-4626 semantics, ethers v5/v6 API drift).
+
+Today the only shared seed is the target repo's CLAUDE.md. That covers project-wide rules; it does not cover specialty knowledge that emerges from running.
+
+Solution: curated, read-only-at-runtime shared pool with the cross-agent boundary intact.
+
+## Approach
+
+### Layout
+
+```
+agents/.shared/lessons/<domain>.md
+```
+
+Gitignored — local memory, identical scope to `agents/`. One file per domain. Domain taxonomy is the existing specialty taxonomy from `src/agent/specialization.ts` — do not introduce a second one.
+
+### Read path (agent prompt seeding)
+
+In `src/agent/prompt.ts`'s `buildAgentSystemPrompt()`, after the agent's own CLAUDE.md is loaded:
+
+1. Identify the agent's primary domain via the existing tag-to-specialty resolver in `src/agent/specialization.ts`.
+2. Load `agents/.shared/lessons/<domain>.md` if it exists.
+3. Append between the agent CLAUDE.md and the rendered workflow, under a heading `## Shared lessons (<domain>)` so it's distinguishable in the seed.
+
+If the domain has no pool file, skip silently. No error.
+
+### Write path (curated promotion — orchestrator-side only)
+
+The cross-agent boundary holds because pool writes happen in the orchestrator process, never in an agent's tool calls.
+
+1. **Tagging at summarize-time**: extend `src/agent/summarizer.ts` to tag candidate lessons during the existing summarizer pass. The summarizer is told: "If this lesson would help a sibling agent in the same domain, wrap it in `<!-- promote-candidate:<domain> -->...<!-- /promote-candidate -->`."
+2. **Review CLI**: new `vp-dev lessons review` subcommand in `src/cli.ts`. Walks all `agents/<id>/CLAUDE.md` for `<!-- promote-candidate -->` blocks. For each: shows the block, the source agent, the proposed domain. User picks `accept | edit | reject | skip`.
+3. **Apply on accept**: orchestrator process appends accepted lessons to `agents/.shared/lessons/<domain>.md`. Removes the `<!-- promote-candidate -->` wrapping in the source CLAUDE.md (replaces with `<!-- promoted:<domain>:<ts> -->`).
+4. **Apply on reject**: replaces `<!-- promote-candidate -->` wrapping with `<!-- not-promoted:<reason>:<ts> -->`.
+
+### Pool size cap
+
+Each `agents/.shared/lessons/<domain>.md` capped at ~200 lines. On accept-when-full, CLI rejects with: "Pool full. Run `vp-dev lessons trim <domain>` first." (Trim CLI deferred — manual editing works for now.)
+
+### Boundary preservation — explicit checks
+
+- Coding agents NEVER write to `agents/.shared/`. The directory is read-only from a coding agent's perspective. Add this to the workflow text in `src/agent/workflow.ts` explicitly.
+- The orchestrator process writes via the review CLI only. No tick-time auto-promotion.
+
+## Critical files & integration points
+
+- `src/agent/prompt.ts` — `buildAgentSystemPrompt()` extended to read pool file.
+- `src/agent/specialization.ts` — domain taxonomy resolver (must already expose a "primary domain" for an agent's tag set, or extend it to).
+- `src/agent/summarizer.ts` — extended prompt to tag promotion candidates.
+- `src/agent/workflow.ts` — `renderWorkflow()` adds an explicit "do not write to agents/.shared/" guard rail.
+- `src/cli.ts` — new `vp-dev lessons review` (and `vp-dev lessons list`) subcommand.
+- `.gitignore` — confirm `agents/` already excludes `agents/.shared/` (it does, since `agents/` is gitignored wholesale).
+
+## Verification
+
+- Unit test: a CLAUDE.md with a `<!-- promote-candidate:solana -->` block surfaces in `vp-dev lessons review` listing.
+- Integration test: `accept` on a candidate appends to `agents/.shared/lessons/solana.md`, replaces source wrapping with `<!-- promoted -->`.
+- Integration test: a fresh dispatch in the `solana` domain shows the pool content in the prompt log (assert via captured prompt in dry-run).
+- Boundary check: dispatch a coding agent against a sandbox; assert it cannot write to `agents/.shared/` (filesystem ACL or `disallowedTools` on the path).
+- Pool cap: a 201st line on accept rejects with the trim instruction; pool file is unchanged.
+
+## Out of scope
+
+- Cross-target-repo lesson sharing — different blast radius, separate issue.
+- Auto-promotion without human gate — defeats the boundary.
+- LLM-driven trim — manual editing first.
+- Failure-derived candidates from #32 — the same tagging mechanism works for both, but ship #32 first to confirm the failure-summary path is stable before promoting from it.

--- a/feature-plans/issue-34-cost-ceiling.md
+++ b/feature-plans/issue-34-cost-ceiling.md
@@ -1,0 +1,127 @@
+# Plan: hard cost ceiling per run with graceful abort
+
+Tracks [#34](https://github.com/szhygulin/vaultpilot-development-agents/issues/34).
+
+## Context
+
+The approval gate surfaces a projected cost (`agent count × issue range × model tier`) per CLAUDE.md's "MUST surface the planned cost" rule. There is no enforcement — a coding agent that loops on a degenerate prompt, retries hard, or hits a tool-use storm can blow past the estimate before the user notices. The gate is a pre-flight check; this is the in-flight backstop.
+
+## Approach
+
+### Pricing module
+
+New file `src/agent/pricing.ts`:
+
+```ts
+type ModelId = "claude-opus-4-7" | "claude-sonnet-4-6" | "claude-haiku-4-5-20251001";
+
+const PRICE_PER_MTOK: Record<ModelId, { input: number; cachedInput: number; output: number }> = {
+  // Hardcoded as of <date>; refresh when Anthropic prices change.
+  // TODO: source: https://www.anthropic.com/pricing
+};
+
+export function costForUsage(model: ModelId, usage: AnthropicUsage): number;
+```
+
+`AnthropicUsage` is the `usage` field shape from the SDK response (`input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`).
+
+### Tracking — three call sites today
+
+Per the exploration, `query()` is invoked from:
+
+1. `src/agent/codingAgent.ts` — coding agent execution (largest cost driver).
+2. `src/orchestrator/dispatcher.ts` — LLM-driven assignment.
+3. `src/agent/split.ts` — split detection/proposal.
+
+(After other PRs land, add: `src/agent/summarizer.ts` for failure path, `src/orchestrator/triage.ts`, `src/agent/planner.ts`. Each gets the same shape.)
+
+Each call site reads `usage` off every response message and forwards `(model, usage)` to a singleton tracker:
+
+```ts
+// src/agent/costTracker.ts (new)
+class RunCostTracker {
+  private total = 0;
+  add(model: ModelId, usage: AnthropicUsage): void;
+  total(): number;
+  exceedsBudget(budgetUsd: number): boolean;
+}
+```
+
+The tracker is run-scoped — instantiated once in `cmdRun()` (`src/cli.ts`), passed through to the orchestrator and child queries via dependency injection (or a module-level singleton tied to `RunState.runId` if DI is too invasive).
+
+### Flags
+
+In `src/cli.ts`:
+
+```
+--max-cost-usd <N>    # hard ceiling, default unset
+```
+
+Env var `VP_DEV_MAX_COST_USD` as fallback. When unset, no enforcement (opt-in for v1).
+
+### Enforcement — in `runOrchestrator()`
+
+After each `Promise.race(inFlight.values())` resolution (`src/orchestrator/orchestrator.ts` line 114):
+
+```ts
+if (budgetUsd !== undefined && tracker.total() > budgetUsd) {
+  logger.warn(`Budget ceiling exceeded: $${tracker.total().toFixed(2)} > $${budgetUsd}.`);
+  // Stop dispatching new — let in-flight finish naturally.
+  break;
+}
+```
+
+In-flight tool calls are NOT killed — graceful abort means the current `query()` resolves on its own; only NEW dispatches stop.
+
+### New terminal state — `aborted-budget`
+
+Extend `IssueStatus` in `src/types.ts`:
+
+```ts
+export type IssueStatus = "pending" | "in-flight" | "done" | "failed" | "aborted-budget";
+```
+
+When the budget is exceeded mid-run, any issue still in `pending` at break-time is marked `aborted-budget` (new helper `markAborted()` in `src/state/runState.ts`, parallel to `markFailed()`).
+
+Issues already `in-flight` finish their run; their terminal state depends on the run's outcome (succeeded → `done`, failed → `failed`).
+
+### Skip summarizer write on `aborted-budget`
+
+In `src/agent/runIssueCore.ts` post-processing (lines 84–125), guard the summarizer call:
+
+```ts
+if (terminalState !== "aborted-budget") {
+  await summarize({ ... });
+}
+```
+
+Aborted runs MUST NOT update `agents/<id>/CLAUDE.md` — incomplete signal would mislead the next run.
+
+## Critical files & integration points
+
+- `src/agent/pricing.ts` — new, hardcoded price table.
+- `src/agent/costTracker.ts` — new, per-run accumulator.
+- `src/agent/codingAgent.ts` — read `usage`, forward to tracker.
+- `src/orchestrator/dispatcher.ts` — same.
+- `src/agent/split.ts` — same.
+- `src/orchestrator/orchestrator.ts` — `runOrchestrator()` checks budget after each tick race; sets break flag.
+- `src/state/runState.ts` — new `markAborted()`; extend `IssueStatus`.
+- `src/agent/runIssueCore.ts` — guard summarizer call on terminal state.
+- `src/cli.ts` — `--max-cost-usd` flag, env var fallback, tracker instantiation.
+- `src/types.ts` — extend `IssueStatus`.
+
+## Verification
+
+- Unit test `costForUsage()` against canonical usage objects → returns the right $ for each model.
+- Integration test: set `--max-cost-usd 0.10` against a 5-issue run; confirm exactly the in-flight issue at break-time finishes, remaining `pending` issues marked `aborted-budget`.
+- Confirm `agents/<id>/CLAUDE.md` is unchanged for any agent whose latest run was `aborted-budget`.
+- Confirm the run's final state log shows the total cost and the abort threshold.
+
+## Out of scope
+
+- Time-based timeouts (orthogonal).
+- Per-tool-call caps (too granular).
+- Cost forecasting from past runs — depends on #36.
+- Per-agent ceilings (per-run subsumes for v1).
+- Hard-killing in-flight `query()` — graceful abort only.
+- Auto-default ceiling — opt-in for v1; defaulting on invites surprise aborts.

--- a/feature-plans/issue-35-pre-dispatch-triage.md
+++ b/feature-plans/issue-35-pre-dispatch-triage.md
@@ -1,0 +1,121 @@
+# Plan: pre-dispatch issue triage to filter not-ready issues
+
+Tracks [#35](https://github.com/szhygulin/vaultpilot-development-agents/issues/35).
+
+## Context
+
+Some GitHub issues are not ready for a coding agent: discussion-only ("we should think about X"), ambiguous scope, duplicates of an open issue, or body/comments disagree on scope (per CLAUDE.md's Issue Analysis rule). Dispatching a coding agent at these wastes a run.
+
+A cheap haiku call before the approval gate, surfaced in the gate text, lets the user accept the filter or override.
+
+## Approach
+
+### Triage module
+
+New file `src/orchestrator/triage.ts`:
+
+```ts
+export type TriageResult = {
+  ready: boolean;
+  reason: string;          // one-line, surfaces in approval gate
+  suggestedSpecialty?: string;
+};
+
+export async function triageIssue(opts: {
+  issue: IssueSummary;
+  comments: IssueComment[];
+  cache: TriageCache;
+}): Promise<TriageResult>;
+```
+
+Model: `claude-haiku-4-5-20251001`. Single response, JSON output. Prompt rubric:
+
+- **Ready**: concrete bug with repro, or feature with explicit acceptance criteria.
+- **Not ready — ambiguous**: "we should think about" / "explore" / no acceptance criteria.
+- **Not ready — duplicate**: cross-reference with other open issues; if substantive overlap, mark dup.
+- **Not ready — body/comments conflict**: body and recent comments disagree on scope.
+
+### Cache
+
+`state/triage/<issue#>.json`, keyed on `(issue#, sha256(body + comments-concat))` so re-runs short-circuit when nothing changed:
+
+```jsonc
+{
+  "issueNumber": 162,
+  "contentHash": "sha256:abc...",
+  "result": { "ready": true, "reason": "concrete bug, repro included" },
+  "triagedAt": "2026-05-02T12:00:00Z"
+}
+```
+
+The cache is gitignored (under `state/`, already gitignored).
+
+### Integration in `cmdRun()`
+
+In `src/cli.ts`'s `cmdRun()`, between `resolveRangeToIssues()` and `buildSetupPreview()`:
+
+```ts
+const triageResults = await triageBatch(openIssues, cache);
+const readyIssues = triageResults.filter(r => r.ready).map(r => r.issue);
+const skippedIssues = triageResults.filter(r => !r.ready);
+```
+
+Pass both lists to `buildSetupPreview()`.
+
+### Approval gate surface
+
+Extend `SetupPreview` in `src/orchestrator/setup.ts`:
+
+```ts
+type SetupPreview = {
+  // existing fields ...
+  skippedIssues: { issue: IssueSummary; reason: string }[];
+};
+```
+
+`formatSetupPreview()` adds a section:
+
+```
+3 issues skipped by triage:
+  #443 — ambiguous scope: "we should think about caching"
+  #471 — duplicate of #468
+  #482 — body/comments conflict on scope
+Override with --include-non-ready.
+```
+
+### Override flag
+
+`--include-non-ready` in `src/cli.ts`. Per-run flag only, no env var — should be a deliberate decision each time.
+
+### Fail-open on triage error
+
+If the haiku call errors transiently, default to `ready: true` for that issue. The approval gate is the backstop. Log the error but do not abort the run.
+
+### Cost surfacing
+
+The cost of triage (1 haiku call per issue, even cached calls return `cost: 0`) is added to the projected-cost line in the gate so the user sees `triage: $X + dispatch: $Y = total $Z`.
+
+## Critical files & integration points
+
+- `src/orchestrator/triage.ts` — new module.
+- `src/cli.ts` — `cmdRun()` invokes `triageBatch()` between range resolution and setup preview; new `--include-non-ready` flag.
+- `src/orchestrator/setup.ts` — `SetupPreview` extended; `formatSetupPreview()` prints skipped section; `buildSetupPreview()` takes ready/skipped split.
+- `src/github/gh.ts` — needs an `issueComments(repo, issueNumber)` helper if not already present (used to fetch comments for the triage rubric).
+- `state/triage/` — new gitignored directory under existing `state/` tree.
+- `src/agent/costTracker.ts` (from #34, if landed) — triage cost feeds the same tracker.
+
+## Verification
+
+- Unit test: an obviously ambiguous issue body ("we should think about caching") returns `ready: false`.
+- Unit test: a concrete bug body returns `ready: true`.
+- Integration test: re-running triage on the same `(issue#, contentHash)` short-circuits — no new haiku call.
+- Integration test: `--include-non-ready` overrides the filter; all originally-skipped issues appear in the dispatched set.
+- Integration test: simulate a haiku transport error → triage returns `ready: true` for the failing issue, run proceeds.
+- Setup preview shows the skipped section with reasons.
+
+## Out of scope
+
+- Writing triage results back to GitHub as comments ("needs more detail").
+- Triage of issues outside the requested range.
+- LLM-driven dup detection beyond the in-batch issues — substantive cross-issue dup detection is its own problem.
+- Re-triage on cache hit when comments have new posts but body unchanged — the content hash includes comments, so this is covered automatically.

--- a/feature-plans/issue-36-outcome-metrics.md
+++ b/feature-plans/issue-36-outcome-metrics.md
@@ -1,0 +1,111 @@
+# Plan: outcome metrics — merge rate, rework cycles, cost-per-merge per agent
+
+Tracks [#36](https://github.com/szhygulin/vaultpilot-development-agents/issues/36).
+
+## Context
+
+The orchestrator has no feedback loop from "did this PR actually land cleanly." CI green is the only quality signal — and CI green ≠ issue resolved. A run that opened a PR which got closed-unmerged, or required 5 reviewer-rework cycles, looks identical to a clean one-shot success. This blocks #31 (merge/retire decisions need merge-rate), #34 (cost-ceiling defaults need cost-per-merge), and #35 (triage rubric tuning needs ground truth).
+
+## Approach
+
+### Storage
+
+`state/outcomes/<agent-id>.jsonl` — append-only JSONL, gitignored under `state/`. One line per terminal PR outcome:
+
+```jsonc
+{
+  "agent": "agent-90e4",
+  "issue": 162,
+  "pr": 446,
+  "terminalState": "merged",        // merged | closed-unmerged | stalled
+  "ciCycles": 2,                    // count of CI re-runs before final state
+  "reviewerRoundtrips": 1,          // changes_requested → push cycles
+  "daysOpen": 3,
+  "costUsd": null,                  // populated once #34 lands
+  "closedAt": "2026-05-12T14:22:00Z"
+}
+```
+
+### Polling — lazy, on each `vp-dev` invocation
+
+New file `src/state/outcomes.ts`:
+
+```ts
+export type Outcome = { /* matches schema above */ };
+
+export async function pollOutcomes(opts: {
+  registry: AgentRegistry;
+  staleThresholdDays: number;
+}): Promise<Outcome[]>;
+
+export function appendOutcome(agentId: string, outcome: Outcome): Promise<void>;
+```
+
+Logic:
+1. For each `AgentRecord` in registry, walk recent runs (from `runState` history files).
+2. For any PR not yet in `state/outcomes/<agent>.jsonl`, fetch its current GitHub state via `gh pr view <N> --json state,mergedAt,closedAt,reviews,statusCheckRollup`.
+3. If terminal (merged or closed): compute counters and append.
+4. If non-terminal but `daysOpen > staleThreshold`: mark `stalled`, append, stop polling for this PR.
+
+### Counter computation
+
+- **`ciCycles`** — count of `statusCheckRollup` entries with `conclusion === "FAILURE"` before the final state. Approximation: count of failed runs in the rollup history.
+- **`reviewerRoundtrips`** — count `reviews[].state === "CHANGES_REQUESTED"` events (each one implies a subsequent push to address).
+- **`daysOpen`** — `closedAt - createdAt` in days.
+
+These are approximations; refinement is a follow-up if signal is noisy.
+
+### Polling cadence
+
+In `src/cli.ts`'s `cmdRun()`, before `buildSetupPreview()`:
+
+```ts
+await pollOutcomes({ registry, staleThresholdDays: opts.stalledThresholdDays ?? 14 });
+```
+
+Cheap (one `gh pr view` per non-terminal PR in registry). Lazy — runs only when the user invokes `vp-dev`.
+
+### Stalled threshold
+
+`--stalled-threshold-days <N>` flag in `src/cli.ts`, default 14.
+
+### Rollup CLI
+
+New `vp-dev agents stats` subcommand in `src/cli.ts`:
+
+```
+$ vp-dev agents stats
+agent-90e4   solana-staking      runs:12  merge-rate:83%  median-rework:1  $/merge:$0.51
+agent-d396   evm-lending         runs:8   merge-rate:62%  median-rework:3  $/merge:$1.20
+agent-51e5   curve-pools         runs:3   merge-rate:33%  median-rework:4  $/merge:$2.10
+```
+
+Reads all `state/outcomes/<agent>.jsonl` files; computes per-agent rollup. Sort by merge-rate desc by default; flag for sort-by alternatives.
+
+### Cost integration
+
+`costUsd` is `null` until #34 lands. Once #34 lands, the run's `RunCostTracker` final total is split per-issue (proportional to issue's share of total tokens, simplest model) and stamped at outcome-append time.
+
+## Critical files & integration points
+
+- `src/state/outcomes.ts` — new module: `Outcome` type, `pollOutcomes`, `appendOutcome`.
+- `src/state/registry.ts` — outcome polling reads agent records here.
+- `src/state/runState.ts` — outcome polling reads PR numbers from completed run histories.
+- `src/github/gh.ts` — `gh pr view` wrapper; may need a new helper `prState(repo, prNumber)` if not already exposed.
+- `src/cli.ts` — `cmdRun()` invokes `pollOutcomes()` early; new `vp-dev agents stats` subcommand.
+- `state/outcomes/` — new gitignored directory.
+
+## Verification
+
+- Unit test: a PR fixture in state `merged` with 2 failed-then-passing CI runs and 1 changes_requested review → outcome record has `ciCycles: 2`, `reviewerRoundtrips: 1`, `terminalState: "merged"`.
+- Integration test: run `pollOutcomes` on a registry pointing at a real (or recorded) PR; assert JSONL append, idempotency on re-run.
+- Integration test: simulate a 14+ days-open PR with no activity → `terminalState: "stalled"`, no further polling.
+- `vp-dev agents stats` against a fixture with two agents → correct rollup, correct sort order.
+
+## Out of scope
+
+- Cross-agent leaderboards / rankings.
+- Cross-target-repo aggregation.
+- Trend graphs / dashboards (JSONL is enough; users can `jq` it).
+- Refining counter heuristics with reviewer-comment NLP — defer until rollup signal proves it matters.
+- Per-issue cost split via token-share heuristic until #34 lands.

--- a/feature-plans/issue-37-planning-mode.md
+++ b/feature-plans/issue-37-planning-mode.md
@@ -1,0 +1,192 @@
+# Plan: planning mode — Opus plans complex issues while small issues dispatch in parallel
+
+Tracks [#37](https://github.com/szhygulin/vaultpilot-development-agents/issues/37).
+
+## Context
+
+Coding agents today receive only the issue body, target-repo CLAUDE.md, and their own evolved CLAUDE.md as seed. Complex issues — multi-file refactors, design choices with multiple viable shapes, integrations that thread through several call sites — benefit from an explicit written plan before code starts. Trivial issues (typo fix, dependency bump, single-line bug) do not, and forcing a plan step on them adds latency and cost for no gain.
+
+This is the workflow the team just used in conversation: an Opus agent writes plans for complex issues to `feature-plans/issue-<N>-<slug>.md`, references the file from the issue body, and coding agents pick up that file as part of their seed. Small issues skip planning. Both flows run in parallel.
+
+## Approach
+
+### The convention
+
+Every issue body has a `## Plan` section in one of two shapes:
+
+```markdown
+## Plan
+
+[feature-plans/issue-<N>-<slug>.md](feature-plans/issue-<N>-<slug>.md)
+```
+
+```markdown
+## Plan
+
+Not needed — coding agent can start directly from the issue body.
+```
+
+Coding agents key off this section. Plan-mode infrastructure writes it; humans can write it manually too.
+
+### Workflow
+
+1. **Complexity gate** — cheap haiku call per issue returning `{ needsPlan: bool, reason: string }`. Folds with #35 triage if both land (same call, two flags).
+2. **Planning branch** — issues with `needsPlan: true` enter status `"planning"`. The Opus planner (`src/agent/planner.ts`, model `claude-opus-4-7`) reads issue body + comments + target repo's CLAUDE.md + recent commits in relevant areas, then writes `feature-plans/issue-<N>-<slug>.md` and `gh issue edit`s the body to append the `## Plan` link. Status transitions to `"pending"`.
+3. **Direct branch** — issues with `needsPlan: false` skip planning; the gate appends the "Not needed" sentinel to the issue body and the issue stays at `"pending"`.
+4. **Dispatch loop** — unchanged; picks `pending` issues only, never `planning`. Dispatch and planning run in parallel because `runOrchestrator()` is already async-per-issue.
+5. **Coding agent seed** — `buildAgentSystemPrompt()` parses the `## Plan` section; if a file is linked, its content is appended to the seed.
+
+### Implementation — file-by-file
+
+#### `src/agent/planner.ts` (new)
+
+```ts
+export type PlanResult = {
+  needsPlan: boolean;
+  planPath?: string;       // feature-plans/issue-<N>-<slug>.md, set when needsPlan
+  reason: string;
+};
+
+export async function classifyComplexity(issue: IssueSummary, comments: IssueComment[]): Promise<{ needsPlan: boolean; reason: string }>;
+
+export async function generatePlan(opts: {
+  issue: IssueSummary;
+  comments: IssueComment[];
+  targetRepoPath: string;
+  targetRepoClaudeMd: string;
+}): Promise<{ planPath: string; planContent: string }>;
+```
+
+`classifyComplexity` uses `claude-haiku-4-5-20251001`. Rubric:
+- Multi-file change spanning ≥3 files OR multiple modules → needs plan.
+- New module / new abstraction / cross-cutting integration → needs plan.
+- New external dependency / SDK adoption → needs plan.
+- Single-file fix / typo / dep bump / one-line behavior tweak → no plan.
+
+`generatePlan` uses `claude-opus-4-7`. Output template matches the format of plan files in this PR (Context / Approach / Critical files / Verification / Out of scope).
+
+#### `src/agent/planner.ts` — plan-file writing & issue-body editing
+
+After plan content is generated:
+1. Slug from issue title (kebab-case, ≤6 words).
+2. Write `feature-plans/issue-<N>-<slug>.md` in the worktree.
+3. `gh issue view <N> --json body -q .body` → append `## Plan` section → `gh issue edit <N> --body-file -`.
+4. Commit + push the plan file on the orchestrator's branch (or the per-agent branch — design decision below).
+
+**Branch question**: where do plan files live during a run?
+- Option A: orchestrator commits plan files to the target repo's default branch directly (requires push permission to default branch — violates push-protection layers per CLAUDE.md).
+- **Option B (chosen)**: plan files commit to the planning agent's own feature branch alongside any other changes. Coding agents reading the plan from the issue body's link will see the file once that branch lands. For pre-merge access, the coding agent reads `feature-plans/<file>` from its own worktree (which branched off the same base). Synchronization detail: planner runs first on the target repo, opens its plan-PR; coding agents wait for plan-PR merge before dispatching. Or, the plan file is written to a shared `feature-plans/` location read out-of-band (no commit required during the run — the file lives in `state/plans/<run>/issue-<N>-<slug>.md` AND gets persisted to the target repo as a follow-up PR).
+- **Final design**: write plan to `state/plans/<runId>/issue-<N>-<slug>.md` for in-run consumption; the planner ALSO opens a plan-PR in the target repo with the same content under `feature-plans/`. Coding agents read from the in-run state path during dispatch; humans read the merged file for context. Decouples in-run read from PR-merge timing.
+
+#### `src/types.ts`
+
+Extend `IssueStatus`:
+
+```ts
+export type IssueStatus = "pending" | "planning" | "in-flight" | "done" | "failed";
+```
+
+Add `planPath?: string` to `RunIssueEntry` for runtime plan reference.
+
+#### `src/state/runState.ts`
+
+New helper `markPlanning(runState, issueId)` parallel to `markInFlight()`. Transition `planning → pending` happens at planner completion via direct mutation + `saveState()`.
+
+#### `src/orchestrator/orchestrator.ts`
+
+`runOrchestrator()` gains a parallel branch alongside the existing dispatch loop:
+
+```ts
+// At each tick:
+const planningQueue = state.issues.filter(i => i.status === "pending" && needsPlan(i));
+const directQueue = state.issues.filter(i => i.status === "pending" && !needsPlan(i));
+
+// Fire planner for planning queue (Opus, parallel slot pool separate from dispatch)
+// Fire dispatcher for direct queue (existing path, unchanged)
+```
+
+Planning has its own `inFlightPlanning` Map, parallel to `inFlight`. Both Maps drain via `Promise.race(...)` selecting whichever resolves first.
+
+#### `src/agent/prompt.ts`
+
+`buildAgentSystemPrompt()` reads the issue's `planPath` from `RunIssueEntry`:
+
+```ts
+if (issueEntry.planPath) {
+  const planContent = await readFile(issueEntry.planPath, "utf8");
+  promptParts.push(`## Plan\n\n${planContent}`);
+}
+```
+
+Append between agent CLAUDE.md and rendered workflow.
+
+#### `src/orchestrator/setup.ts`
+
+`SetupPreview` extended:
+
+```ts
+type SetupPreview = {
+  // existing fields ...
+  planningCount: number;       // issues that will go through Opus planning
+  directDispatchCount: number; // issues that skip planning
+  estimatedPlanningCostUsd: number;
+};
+```
+
+`formatSetupPreview()` adds:
+
+```
+3 issues will be planned (Opus, ~$0.45)
+12 issues dispatch directly (Sonnet, ~$2.10)
+```
+
+User can refuse at the gate.
+
+#### `src/cli.ts`
+
+New subcommand:
+
+```
+vp-dev plan <issue#>             # ad-hoc plan generation, outside a run
+vp-dev plan <issue#> --no-edit   # write plan file but don't edit issue body
+```
+
+Existing `vp-dev run` invokes the planner automatically per the complexity gate.
+
+### Boundary preservation
+
+- Coding agents NEVER write plan files. The planner is its own module, runs in the orchestrator process.
+- Coding agents READ plan files only — from `state/plans/<runId>/...` during dispatch, from the merged `feature-plans/` for human review.
+
+## Critical files & integration points
+
+- `src/agent/planner.ts` — new: complexity classification + Opus plan generation + issue body edit.
+- `src/orchestrator/orchestrator.ts` — `runOrchestrator()` gains the parallel planning branch.
+- `src/agent/prompt.ts` — `buildAgentSystemPrompt()` injects plan content from `issueEntry.planPath`.
+- `src/types.ts` — extend `IssueStatus` with `"planning"`; add `planPath?` to `RunIssueEntry`.
+- `src/state/runState.ts` — `markPlanning()` helper.
+- `src/orchestrator/setup.ts` — `SetupPreview` extended with planning count + cost; `formatSetupPreview()` displays both.
+- `src/cli.ts` — `vp-dev plan` subcommand; complexity gate invocation in `cmdRun()`.
+- `src/github/gh.ts` — `gh issue edit` wrapper if not present.
+- `state/plans/<runId>/` — new directory under `state/`, gitignored.
+- `feature-plans/` — TARGET repo path where the planner opens a plan-PR; tracked.
+- `src/orchestrator/triage.ts` (from #35, if landed) — fold complexity gate into the same haiku call.
+
+## Verification
+
+- Unit test `classifyComplexity()` against canonical fixtures: a typo fix returns `needsPlan: false`; a multi-file refactor returns `needsPlan: true`.
+- Integration test: dry-run on a complex fixture issue produces `state/plans/<runId>/issue-<N>-<slug>.md` and updates the issue body via `gh issue edit`.
+- Integration test: dry-run on a trivial issue appends "Not needed" sentinel to the issue body, no plan file created.
+- Integration test: a coding agent dispatched against an issue with a `planPath` shows the plan content in its prompt log.
+- Integration test: planning and dispatch run in parallel — start a 5-issue run with 2 planning + 3 direct; assert both `inFlight` Maps populate before either drains.
+- Approval gate displays the planning vs. direct split with cost breakdown.
+
+## Out of scope
+
+- Regenerating plans on PR-review feedback.
+- Plan revision when coding agent finds the plan wrong on contact with code (default: agent leaves a comment on the issue noting divergence; human re-plans manually).
+- Plan staleness detection (plan-generated-at vs issue-updated-at).
+- Multi-step plan execution / one-plan-many-PRs (one plan, one PR).
+- Recursive planning (plans for sub-tasks within a plan).
+- Plans for issues outside the requested range.
+- Auto-applying the planner output as a code-PR (planner outputs ONLY the plan markdown).

--- a/feature-plans/issue-38-planning-mode.md
+++ b/feature-plans/issue-38-planning-mode.md
@@ -36,6 +36,20 @@ Coding agents key off this section. Plan-mode infrastructure writes it; humans c
 4. **Dispatch loop** — unchanged; picks `pending` issues only, never `planning`. Dispatch and planning run in parallel because `runOrchestrator()` is already async-per-issue.
 5. **Coding agent seed** — `buildAgentSystemPrompt()` parses the `## Plan` section; if a file is linked, its content is appended to the seed.
 
+### Idempotency: skip if a plan is already referenced
+
+The complexity gate (step 1 above) MUST first check the issue body for an existing `## Plan` section. If the section exists with non-empty content — either a `feature-plans/...` link **or** the "Not needed" sentinel — the planner skips that issue entirely. No haiku complexity call, no Opus generation, no body edit.
+
+Rationale: plan files are checked in and human-reviewed; they should not be silently regenerated. A human who chose "Not needed" should not have that choice overridden by a complexity reclassification on a re-run. A human who hand-wrote a plan should not have it overwritten.
+
+Applies to every entry point:
+- **`vp-dev run`** — the in-loop complexity gate skips issues with a populated `## Plan` section.
+- **`vp-dev plan <issue#>`** — the ad-hoc CLI fails fast with `plan already referenced for #<N> (feature-plans/<file>.md)` when the section is already populated. A `--force` override is deferred (ship without it first; users can hand-edit the issue body to clear the section if they want to re-plan).
+
+**Edge case** — section exists but the linked file is missing on disk: treat the section as authoritative, skip planning, surface a warning at the approval gate (`issue #<N> references feature-plans/<X>.md but file not found — manual fix needed`). Do not silently regenerate; that path overwrites human intent.
+
+**Implementation note** — the check is a pure read: `gh api repos/<...>/issues/<N> --jq '.body'` then a regex for `(?m)^## Plan$\n+\S`. It runs before any LLM call so the cost of skipping is zero.
+
 ### Implementation — file-by-file
 
 #### `src/agent/planner.ts` (new)

--- a/feature-plans/issue-38-planning-mode.md
+++ b/feature-plans/issue-38-planning-mode.md
@@ -1,6 +1,6 @@
 # Plan: planning mode — Opus plans complex issues while small issues dispatch in parallel
 
-Tracks [#37](https://github.com/szhygulin/vaultpilot-development-agents/issues/37).
+Tracks [#38](https://github.com/szhygulin/vaultpilot-development-agents/issues/38).
 
 ## Context
 


### PR DESCRIPTION
## Summary

- Adds plan files for the 6 just-filed feature requests (#31–#36) and a new planning-mode feature request #38 whose plan is included.
- Each plan follows the **Context / Approach / Critical files & integration points / Verification / Out of scope** shape so a coding agent can pick up implementation directly without re-doing the design work.
- Establishes the **plan-reference convention**: every issue body gets a `## Plan` section pointing either at a `feature-plans/` file or saying "plan not needed". Coding agents key off this section when seeding their prompt.

## Files

| Issue | Plan |
|-------|------|
| #31 — merge / retire | `feature-plans/issue-31-merge-retire.md` |
| #32 — failure-driven learning | `feature-plans/issue-32-failure-driven-learning.md` |
| #33 — shared lessons pool | `feature-plans/issue-33-shared-lessons-pool.md` |
| #34 — cost ceiling | `feature-plans/issue-34-cost-ceiling.md` |
| #35 — pre-dispatch triage | `feature-plans/issue-35-pre-dispatch-triage.md` |
| #36 — outcome metrics | `feature-plans/issue-36-outcome-metrics.md` |
| #38 — planning mode | `feature-plans/issue-38-planning-mode.md` |

## Out of scope (this PR)

- No source changes under `src/**`. Implementation lands in follow-up PRs against each issue.
- The planning-mode feature itself is not implemented here — only its plan and issue land.

## Test plan

- [ ] All 7 plan files render on GitHub with no broken sections.
- [ ] Issue bodies for #31–#36 + #38 reference their plan files (added post-merge so links resolve on `main`).
- [ ] CI passes (`npm ci && npm run typecheck && npm run build` — should pass since no source changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
