### PR TITLE
fix: populate archivedAt and splitInto when split apply archives parent

### DIFF
--- a/src/agent/split.ts
+++ b/src/agent/split.ts
@@ -431,6 +431,8 @@ export async function applySplit(input: ApplySplitInput): Promise<ApplySplitResu
     }
 
     parent.archived = true;
+    parent.archivedAt = new Date().toISOString();
+    parent.splitInto = childIds;
 
     return { parentAgentId: parent.agentId, childIds };
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,15 @@ export interface AgentRecord {
   // archived agents but their history survives in the registry. Optional
   // for back-compat with pre-split records.
   archived?: boolean;
+  // ISO-8601 timestamp recorded when `archived` flips true. Lets the
+  // registry alone answer "when was this agent archived?" without
+  // cross-referencing run logs. Optional for back-compat.
+  archivedAt?: string;
+  // The child agentIds minted from this parent at split time. Forward
+  // pointer for the audit trail — given a parent record, you can find
+  // the children that inherited its sections without scanning every
+  // other record. Optional for back-compat.
+  splitInto?: string[];
   // Parent agentId, populated on a child minted by `vp-dev agents split`.
   // Optional for back-compat.
   parentAgentId?: string;


### PR DESCRIPTION
Closes #41

## Summary

The split apply path flipped `archived: true` on the parent but left `archivedAt` and `splitInto` unset, so `state/agents-registry.json` couldn't answer **when** an agent was archived or **which children** inherited its sections from the registry alone.

- Added `archivedAt?: string` and `splitInto?: string[]` to `AgentRecord` in `src/types.ts` (both optional for back-compat with pre-split records).
- In `applySplit` (`src/agent/split.ts`), populated both alongside the existing `archived = true` line, inside the same `mutateRegistry()` transaction so the three fields land atomically.

## Out of scope

- Backfill of already-archived agents (per issue body — manual `jq` is fine for the small number that exist).
- Reverse traversal from child → parent (already covered by `parentAgentId` set on each child).

## Test plan

- [x] `npm run build` passes.
- [ ] `vp-dev agents split <id> --apply --yes` on a fresh agent populates `archived`, `archivedAt`, and `splitInto` together.

— Advisory Scope Boundary (agent-916a)
