### PR TITLE
fix(sdk): VP_DEV_CLAUDE_BIN override for musl-vs-glibc binary mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,24 @@ node dist/bin/vp-dev.js agents list   # registry roster
 - Three layers block pushes to `main` of the target repo: branch protection,
   `disallowedTools`, and a `canUseTool` regex.
 
+## Troubleshooting
+
+### `Claude Code native binary not found at …-musl/claude` on Linux
+
+`npm install` pulls both the musl and glibc SDK binaries as optional deps;
+the SDK's resolution order tries musl first, so on glibc hosts (Ubuntu,
+Debian, Fedora, RHEL) `query()` launches an ELF whose interpreter
+(`/lib/ld-musl-x86_64.so.1`) doesn't exist and aborts.
+
+Override the binary path via `VP_DEV_CLAUDE_BIN`:
+
+```sh
+export VP_DEV_CLAUDE_BIN=$PWD/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude
+```
+
+Every `query()` call site reads this env var (centralized in
+`src/agent/sdkBinary.ts`) and passes it as `pathToClaudeCodeExecutable`.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/src/agent/codingAgent.ts
+++ b/src/agent/codingAgent.ts
@@ -7,6 +7,7 @@ import {
 } from "@anthropic-ai/claude-agent-sdk";
 import { buildAgentSystemPrompt } from "./prompt.js";
 import { extractEnvelope } from "./parseResult.js";
+import { claudeBinPath } from "./sdkBinary.js";
 import type { AgentRecord, ResultEnvelope } from "../types.js";
 import type { Logger } from "../log/logger.js";
 
@@ -115,6 +116,7 @@ export async function runCodingAgent(input: CodingAgentInput): Promise<CodingAge
         maxTurns: 50,
         settingSources: [],
         persistSession: false,
+        pathToClaudeCodeExecutable: claudeBinPath(),
       },
     });
 

--- a/src/agent/sdkBinary.ts
+++ b/src/agent/sdkBinary.ts
@@ -1,0 +1,24 @@
+/**
+ * Claude Agent SDK binary override.
+ *
+ * Background: `npm install` pulls both
+ * `@anthropic-ai/claude-agent-sdk-linux-x64-musl` and
+ * `@anthropic-ai/claude-agent-sdk-linux-x64` (glibc) as optional deps. The
+ * SDK's resolution order tries musl first, so on a glibc host (Ubuntu /
+ * Debian / Fedora / RHEL) `createRequire` succeeds for the musl package
+ * directory and the SDK launches `…-musl/claude` — whose ELF interpreter
+ * is `/lib/ld-musl-x86_64.so.1`, which doesn't exist on glibc. The exec
+ * aborts and the SDK throws "Claude Code native binary not found at …".
+ *
+ * Workaround surface: setting `VP_DEV_CLAUDE_BIN` lets the operator point
+ * every `query()` call at a known-good binary (typically the glibc one
+ * under `node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude`)
+ * without editing `node_modules` after each `npm ci`.
+ *
+ * Lookup is centralized here so any future `query()` call site picks it up
+ * automatically by passing `pathToClaudeCodeExecutable: claudeBinPath()`.
+ */
+export function claudeBinPath(): string | undefined {
+  const v = process.env.VP_DEV_CLAUDE_BIN;
+  return v && v.length > 0 ? v : undefined;
+}

--- a/src/agent/split.ts
+++ b/src/agent/split.ts
@@ -2,6 +2,7 @@ import { promises as fs } from "node:fs";
 import { z } from "zod";
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import { agentClaudeMdPath, agentDir } from "./specialization.js";
+import { claudeBinPath } from "./sdkBinary.js";
 import { mutateRegistry, newAgentId } from "../state/registry.js";
 import { ensureDir } from "../state/locks.js";
 import type { AgentRecord } from "../types.js";
@@ -182,6 +183,7 @@ export async function proposeSplit(
       maxTurns: 1,
       settingSources: [],
       persistSession: false,
+      pathToClaudeCodeExecutable: claudeBinPath(),
     },
   });
   for await (const msg of stream) {

--- a/src/agent/summarizer.ts
+++ b/src/agent/summarizer.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { query } from "@anthropic-ai/claude-agent-sdk";
+import { claudeBinPath } from "./sdkBinary.js";
 import type { AgentRecord, IssueSummary, ResultEnvelope } from "../types.js";
 import type { Logger } from "../log/logger.js";
 
@@ -47,6 +48,7 @@ export async function summarizeRun(input: SummarizerInput): Promise<SummarizerOu
         maxTurns: 1,
         settingSources: [],
         persistSession: false,
+        pathToClaudeCodeExecutable: claudeBinPath(),
       },
     });
     for await (const msg of stream) {

--- a/src/orchestrator/dispatcher.ts
+++ b/src/orchestrator/dispatcher.ts
@@ -1,5 +1,6 @@
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import { buildTickPrompt } from "./prompt.js";
+import { claudeBinPath } from "../agent/sdkBinary.js";
 import { TickProposalSchema, type TickAssignment } from "../types.js";
 import {
   classifyMatch,
@@ -98,6 +99,7 @@ async function tryProposeWithLLM(opts: {
         maxTurns: 1,
         settingSources: [],
         persistSession: false,
+        pathToClaudeCodeExecutable: claudeBinPath(),
       },
     });
     for await (const msg of stream) {


### PR DESCRIPTION
Closes #29

## Summary

The Claude Agent SDK's binary resolution prefers the musl variant on Linux, which fails at runtime on glibc hosts (Ubuntu / Debian / Fedora / RHEL) with `Claude Code native binary not found at …-musl/claude` — the binary IS at the path, but its ELF interpreter `/lib/ld-musl-x86_64.so.1` doesn't exist on glibc.

Centralize the override in `src/agent/sdkBinary.ts::claudeBinPath()` (reads `VP_DEV_CLAUDE_BIN`) and pass it through `pathToClaudeCodeExecutable` in every `query()` call site:

- `src/agent/codingAgent.ts`
- `src/agent/summarizer.ts`
- `src/agent/split.ts`
- `src/orchestrator/dispatcher.ts`

The issue listed three call sites; `codingAgent.ts` is the fourth (it's the actual coding-agent loop). All four updated for uniform coverage — the whole point of centralization is that a future caller only needs to import the helper.

## Operator workaround

```sh
export VP_DEV_CLAUDE_BIN=$PWD/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude
```

Documented in the README troubleshooting section.

## Out of scope

The npm-install layer pulling musl on glibc hosts is upstream in `@anthropic-ai/claude-agent-sdk` — same as the issue says.

## Test plan

- [x] `npm run build` is clean.
- [ ] Set `VP_DEV_CLAUDE_BIN=$PWD/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude` on a glibc host and confirm `vp-dev run …` no longer throws the musl-binary error.
- [ ] Unset the var and confirm SDK behavior is unchanged on systems where the default already works (macOS, the rare musl-Linux dev box).

— Safe Forensics (agent-e22f)
