### PR TITLE
feat(agents): add `prune` to merge overlapping specialists

### DIFF
--- a/src/agent/prune.ts
+++ b/src/agent/prune.ts
@@ -1,0 +1,242 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { agentClaudeMdPath, agentDir, AGENTS_ROOT } from "./specialization.js";
+import { mutateRegistry } from "../state/registry.js";
+import { jaccard } from "../orchestrator/routing.js";
+import { ensureDir } from "../state/locks.js";
+import type { AgentRecord, AgentRegistryFile } from "../types.js";
+
+// Tag-set Jaccard floor that promotes a pair of specialists from "incidental
+// overlap" to "merge candidate". Tuned to match the reverse direction of
+// SPECIALIST_THRESHOLD (0.25 routes an issue to an agent) — at 0.75 the two
+// agents share roughly three quarters of their tag vocabulary, signalling
+// they cover the same niche.
+export const MERGE_SIMILARITY_THRESHOLD = 0.75;
+
+export const ARCHIVE_DIR_NAME = ".archive";
+
+export type PruneProposal = {
+  kind: "merge";
+  survivor: string;
+  absorbed: string;
+  survivorName?: string;
+  absorbedName?: string;
+  similarity: number;
+  rationale: string;
+};
+
+// Retire proposals are deferred until outcome metrics from #36 land. The
+// detection function intentionally never emits them today — the plan
+// explicitly forbids guessing without merge-rate / staleness data.
+
+export interface DetectInput {
+  registry: AgentRegistryFile;
+}
+
+/**
+ * Pairwise tag-set Jaccard similarity over live (non-archived) agents.
+ * Pairs with similarity >= MERGE_SIMILARITY_THRESHOLD become merge
+ * proposals. Greedy: each agent appears in at most one proposal per call —
+ * higher-similarity pairs win.
+ */
+export function detectPruneCandidates(input: DetectInput): PruneProposal[] {
+  const live = input.registry.agents.filter((a) => !a.archived);
+  if (live.length < 2) return [];
+
+  type Candidate = { a: AgentRecord; b: AgentRecord; sim: number };
+  const candidates: Candidate[] = [];
+  for (let i = 0; i < live.length; i++) {
+    for (let j = i + 1; j < live.length; j++) {
+      const sim = jaccard(live[i].tags, live[j].tags);
+      if (sim >= MERGE_SIMILARITY_THRESHOLD) {
+        candidates.push({ a: live[i], b: live[j], sim });
+      }
+    }
+  }
+  // Highest similarity first; deterministic tiebreak on the lower agentId
+  // of the pair so re-running over the same registry produces the same
+  // ordering.
+  candidates.sort((x, y) => {
+    if (y.sim !== x.sim) return y.sim - x.sim;
+    const lx = x.a.agentId < x.b.agentId ? x.a.agentId : x.b.agentId;
+    const ly = y.a.agentId < y.b.agentId ? y.a.agentId : y.b.agentId;
+    return lx.localeCompare(ly);
+  });
+
+  const used = new Set<string>();
+  const out: PruneProposal[] = [];
+  for (const c of candidates) {
+    if (used.has(c.a.agentId) || used.has(c.b.agentId)) continue;
+    const [survivor, absorbed] = pickSurvivor(c.a, c.b);
+    out.push({
+      kind: "merge",
+      survivor: survivor.agentId,
+      absorbed: absorbed.agentId,
+      survivorName: survivor.name,
+      absorbedName: absorbed.name,
+      similarity: c.sim,
+      rationale: `tag-set Jaccard=${c.sim.toFixed(2)} >= ${MERGE_SIMILARITY_THRESHOLD}; survivor issuesHandled=${survivor.issuesHandled}, absorbed=${absorbed.issuesHandled}`,
+    });
+    used.add(survivor.agentId);
+    used.add(absorbed.agentId);
+  }
+  return out;
+}
+
+/**
+ * Survivor selection: higher `issuesHandled` wins. Ties break to the older
+ * `createdAt`, then to the lower `agentId`. Deterministic so the same
+ * registry produces the same result on every detection pass.
+ */
+function pickSurvivor(
+  a: AgentRecord,
+  b: AgentRecord,
+): [survivor: AgentRecord, absorbed: AgentRecord] {
+  if (a.issuesHandled !== b.issuesHandled) {
+    return a.issuesHandled > b.issuesHandled ? [a, b] : [b, a];
+  }
+  const ta = Date.parse(a.createdAt);
+  const tb = Date.parse(b.createdAt);
+  if (Number.isFinite(ta) && Number.isFinite(tb) && ta !== tb) {
+    return ta < tb ? [a, b] : [b, a];
+  }
+  return a.agentId < b.agentId ? [a, b] : [b, a];
+}
+
+export interface ApplyResult {
+  archivedTo: string;
+  survivorClaudeMdBytes: number;
+}
+
+/**
+ * Apply a prune proposal. One-way mutation. Caller is responsible for
+ * having gathered explicit user confirmation upstream.
+ *
+ * Merge: survivor's CLAUDE.md absorbs the absorbed agent's
+ * summarizer-attributable sections under a `<!-- merged from ... -->`
+ * banner; survivor's tag set + counters absorb the absorbed agent's; the
+ * absorbed agent's directory moves to `agents/.archive/<id>-merged-into-<survivor>-<ts>/`
+ * and its registry record gains `archived: true` + `mergedInto: <survivor>`.
+ */
+export async function applyPruneProposal(p: PruneProposal): Promise<ApplyResult> {
+  return await applyMerge(p);
+}
+
+async function applyMerge(
+  p: Extract<PruneProposal, { kind: "merge" }>,
+): Promise<ApplyResult> {
+  const survivorMd = await readMd(p.survivor);
+  const absorbedMd = await readMd(p.absorbed);
+  const merged = concatForMerge({
+    survivorMd,
+    absorbedMd,
+    survivorId: p.survivor,
+    absorbedId: p.absorbed,
+  });
+
+  return await mutateRegistry(async (reg) => {
+    const survivor = reg.agents.find((a) => a.agentId === p.survivor);
+    if (!survivor) throw new Error(`survivor agent ${p.survivor} not found in registry`);
+    if (survivor.archived) throw new Error(`survivor agent ${p.survivor} is archived`);
+    const absorbed = reg.agents.find((a) => a.agentId === p.absorbed);
+    if (!absorbed) throw new Error(`absorbed agent ${p.absorbed} not found in registry`);
+    if (absorbed.archived) throw new Error(`absorbed agent ${p.absorbed} is already archived`);
+
+    survivor.tags = dedupeStrings([...survivor.tags, ...absorbed.tags]);
+    survivor.issuesHandled += absorbed.issuesHandled;
+    survivor.implementCount += absorbed.implementCount;
+    survivor.pushbackCount += absorbed.pushbackCount;
+    survivor.errorCount += absorbed.errorCount;
+    if (Date.parse(absorbed.lastActiveAt) > Date.parse(survivor.lastActiveAt)) {
+      survivor.lastActiveAt = absorbed.lastActiveAt;
+    }
+
+    absorbed.archived = true;
+    absorbed.mergedInto = p.survivor;
+
+    const survivorPath = agentClaudeMdPath(p.survivor);
+    await ensureDir(path.dirname(survivorPath));
+    const tmp = `${survivorPath}.tmp.${process.pid}`;
+    await fs.writeFile(tmp, merged);
+    await fs.rename(tmp, survivorPath);
+
+    const archiveTo = path.join(
+      AGENTS_ROOT,
+      ARCHIVE_DIR_NAME,
+      `${p.absorbed}-merged-into-${p.survivor}-${tsSlug()}`,
+    );
+    await ensureDir(path.dirname(archiveTo));
+    try {
+      await fs.rename(agentDir(p.absorbed), archiveTo);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") throw err;
+      // Absorbed agent's dir may not exist if the agent never had a
+      // CLAUDE.md forked. Drop a marker so the archive path is observable.
+      await ensureDir(archiveTo);
+    }
+
+    return {
+      archivedTo: archiveTo,
+      survivorClaudeMdBytes: Buffer.byteLength(merged, "utf-8"),
+    };
+  });
+}
+
+async function readMd(agentId: string): Promise<string> {
+  try {
+    return await fs.readFile(agentClaudeMdPath(agentId), "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+function dedupeStrings(arr: string[]): string[] {
+  return Array.from(new Set(arr));
+}
+
+function tsSlug(): string {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+interface ConcatInput {
+  survivorMd: string;
+  absorbedMd: string;
+  survivorId: string;
+  absorbedId: string;
+}
+
+/**
+ * Append the absorbed agent's summarizer-attributable sections (everything
+ * from the first `<!-- run:` provenance comment onward) to the survivor's
+ * CLAUDE.md under a single banner comment. Survivor's seed + body are
+ * preserved verbatim. The banner uses a `<!-- merged from ... -->` shape
+ * that's distinct from `<!-- run: -->` so parseClaudeMdSections() in
+ * split.ts ignores it.
+ */
+export function concatForMerge(input: ConcatInput): string {
+  const idx = input.absorbedMd.search(/<!--\s*run:/);
+  const absorbedAttributable = idx < 0 ? "" : input.absorbedMd.slice(idx);
+  if (absorbedAttributable.trim().length === 0) {
+    return input.survivorMd;
+  }
+  const banner = `<!-- merged from ${input.absorbedId} into ${input.survivorId} ts:${new Date().toISOString()} -->`;
+  const tail = input.survivorMd.endsWith("\n") ? input.survivorMd : input.survivorMd + "\n";
+  return `${tail}\n${banner}\n\n${absorbedAttributable.trim()}\n`;
+}
+
+export function formatPruneProposals(proposals: PruneProposal[]): string {
+  if (proposals.length === 0) {
+    return "No prune candidates — registry is healthy.\n";
+  }
+  const lines: string[] = [`${proposals.length} prune proposal(s):`, ""];
+  for (const p of proposals) {
+    const sLabel = p.survivorName ? `${p.survivorName} (${p.survivor})` : p.survivor;
+    const aLabel = p.absorbedName ? `${p.absorbedName} (${p.absorbed})` : p.absorbed;
+    lines.push(`  merge: keep ${sLabel}, absorb ${aLabel}  similarity=${p.similarity.toFixed(2)}`);
+    lines.push(`    why: ${p.rationale}`);
+  }
+  lines.push("");
+  lines.push("To apply: vp-dev agents prune --apply");
+  return lines.join("\n") + "\n";
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,13 @@ import {
   proposeSplit,
   readAgentClaudeMdBytes,
 } from "./agent/split.js";
+import {
+  applyPruneProposal,
+  detectPruneCandidates,
+  formatPruneProposals,
+  type PruneProposal,
+  type ApplyResult as PruneApplyResult,
+} from "./agent/prune.js";
 import type { AgentRecord, IssueRangeSpec, IssueSummary } from "./types.js";
 
 const DEFAULT_MAX_TICKS = 200;
@@ -113,6 +120,16 @@ export function buildCli(): Command {
         .option("--yes", "Skip the apply confirmation prompt (required for non-TTY environments).")
         .action(async (agentId, opts) => {
           await cmdAgentsSplit(agentId, opts);
+        }),
+    )
+    .addCommand(
+      new Command("prune")
+        .description("Detect overlapping specialists and emit merge proposals. Pass --apply to mutate the registry.")
+        .option("--json", "Print machine-readable JSON")
+        .option("--apply", "Apply proposals: concat CLAUDE.md, archive absorbed agent, update registry. ONE-WAY mutation.")
+        .option("--yes", "Skip the apply confirmation prompt (required for non-TTY environments).")
+        .action(async (opts) => {
+          await cmdAgentsPrune(opts);
         }),
     );
   program.addCommand(agentsCmd);
@@ -529,6 +546,83 @@ async function confirmApply(input: {
       await rl.question(
         `Apply split: archive ${input.agentId} and create ${input.childCount} children? [y/N] `,
       )
+    )
+      .trim()
+      .toLowerCase();
+    return answer === "y" || answer === "yes";
+  } finally {
+    rl.close();
+  }
+}
+
+interface AgentsPruneOpts {
+  json?: boolean;
+  apply?: boolean;
+  yes?: boolean;
+}
+
+async function cmdAgentsPrune(opts: AgentsPruneOpts): Promise<void> {
+  const reg = await loadRegistry();
+  const proposals = detectPruneCandidates({ registry: reg });
+
+  if (!opts.apply) {
+    if (opts.json) {
+      process.stdout.write(JSON.stringify({ proposals }, null, 2) + "\n");
+      return;
+    }
+    process.stdout.write(formatPruneProposals(proposals));
+    return;
+  }
+
+  if (proposals.length === 0) {
+    if (opts.json) {
+      process.stdout.write(JSON.stringify({ applied: [] }, null, 2) + "\n");
+      return;
+    }
+    process.stdout.write("No prune candidates — nothing to apply.\n");
+    return;
+  }
+
+  process.stdout.write(formatPruneProposals(proposals) + "\n");
+  const confirmed = await confirmPruneApply({ count: proposals.length, yes: !!opts.yes });
+  if (!confirmed) {
+    process.stdout.write("Aborted — no mutation.\n");
+    return;
+  }
+
+  const applied: Array<{ proposal: PruneProposal; result: PruneApplyResult }> = [];
+  for (const p of proposals) {
+    const result = await applyPruneProposal(p);
+    applied.push({ proposal: p, result });
+  }
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify({ applied }, null, 2) + "\n");
+    return;
+  }
+  for (const a of applied) {
+    process.stdout.write(
+      `merged ${a.proposal.absorbed} -> ${a.proposal.survivor}; archived to ${a.result.archivedTo}\n`,
+    );
+  }
+}
+
+async function confirmPruneApply(input: { count: number; yes: boolean }): Promise<boolean> {
+  if (input.yes) {
+    process.stdout.write("Auto-confirmed (--yes).\n");
+    return true;
+  }
+  if (!process.stdin.isTTY) {
+    process.stderr.write(
+      "ERROR: stdin is not a TTY and --yes was not passed. Re-run with --yes to skip confirmation.\n",
+    );
+    return false;
+  }
+  const { createInterface } = await import("node:readline/promises");
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = (
+      await rl.question(`Apply ${input.count} prune proposal(s)? [y/N] `)
     )
       .trim()
       .toLowerCase();

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,10 @@ export interface AgentRecord {
   // Parent agentId, populated on a child minted by `vp-dev agents split`.
   // Optional for back-compat.
   parentAgentId?: string;
+  // Set on the absorbed agent when `vp-dev agents prune --apply` merges two
+  // overlapping specialists. Points at the surviving agent. Optional for
+  // back-compat with pre-prune records.
+  mergedInto?: string;
 }
 
 export interface AgentRegistryFile {


### PR DESCRIPTION
Closes #31.

## Summary

Counterpart to `vp-dev agents split` from #26/#27. The roster only grew until now — fresh agents fanned out via `split`, but two specialists could drift into the same niche with no cleanup path.

`vp-dev agents prune` detects pairs of live specialists with tag-set Jaccard similarity ≥ 0.75 and emits merge proposals. `--apply` (with `--yes` for non-TTY) executes:

- Concatenates the absorbed agent's summarizer-attributable sections (everything from the first `<!-- run: -->` provenance comment) into the survivor's `CLAUDE.md` under a `<!-- merged from … -->` banner. Survivor's seed + body are preserved.
- Folds the absorbed agent's tag set + counters into the survivor; takes the most-recent `lastActiveAt`.
- Marks the absorbed agent `archived: true` + `mergedInto: <survivor>` in `state/agents-registry.json`.
- Moves `agents/<absorbed>/` to `agents/.archive/<absorbed>-merged-into-<survivor>-<ts>/`.

Routing already filters by `archived` (orchestrator.ts:154), so the absorbed agent stops getting picked the moment the merge lands.

## Scope

Per the [plan](feature-plans/issue-31-merge-retire.md): merge only. **Retire** (stale / low-merge-rate detection) is gated on outcome metrics from #36 and is intentionally not emitted today — the plan forbids guessing without those signals. The retire path will be added in the PR that lands #36's metrics.

## Files

- `src/agent/prune.ts` — `detectPruneCandidates`, `applyPruneProposal`, `concatForMerge`, `formatPruneProposals`. Mirrors `split.ts`'s shape (detect → propose → apply with caller-side confirmation).
- `src/types.ts` — adds optional `mergedInto?: string` on `AgentRecord`.
- `src/cli.ts` — new `vp-dev agents prune` subcommand (`--json`, `--apply`, `--yes`).

## Verification

- `npm run typecheck` ✓
- `npm run build` ✓
- `node dist/bin/vp-dev.js agents prune` → "No prune candidates — registry is healthy." (current 14-agent registry has no pair ≥ 0.75 Jaccard)
- `node dist/bin/vp-dev.js agents prune --json` → `{"proposals": []}`
- `node dist/bin/vp-dev.js agents prune --help` → prints subcommand options as expected.

## Test plan

- [ ] On a fixture registry with two near-identical agents (overlapping tag sets ≥ 0.75), confirm `prune` emits exactly one proposal naming the higher-`issuesHandled` agent as survivor.
- [ ] `prune --apply --yes` against a fixture: archive directory exists at `agents/.archive/<absorbed>-merged-into-<survivor>-<ts>/`, registry record gains `archived: true` + `mergedInto`, survivor's `CLAUDE.md` contains the banner + absorbed sections.
- [ ] Read-only `prune` is idempotent — `git diff` shows no state mutation.

— Rogue Oracle (agent-72c6)
