### PR TITLE
feat(summarizer): fire failure-mode lesson on terminal failure

### DIFF
--- a/src/agent/runIssueCore.ts
+++ b/src/agent/runIssueCore.ts
@@ -2,7 +2,7 @@ import { promises as fs } from "node:fs";
 import { ensureAgent, mutateRegistry } from "../state/registry.js";
 import { runCodingAgent } from "./codingAgent.js";
 import { appendBlock, forkClaudeMd, type AppendOutcome } from "./specialization.js";
-import { summarizeRun } from "./summarizer.js";
+import { isInfraFlake, summarizeFailureRun, summarizeRun, type SummarizerOutput } from "./summarizer.js";
 import {
   createWorktree,
   removeWorktree,
@@ -81,51 +81,78 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
       applyTagUpdate(input.agent, envelope);
 
       if (!input.skipSummary) {
-        const summary = await summarizeRun({
+        // Failure-mode branch: agent emitted decision="error" — fire the
+        // failure summarizer (different prompt, biased toward extracting a
+        // lesson). Success/pushback paths stay on summarizeRun.
+        const isAgentFailure = envelope.decision === "error";
+        const summary: SummarizerOutput = isAgentFailure
+          ? await summarizeFailureRun({
+              agent: input.agent,
+              issue: input.issue,
+              envelope,
+              errorReason: result.errorReason,
+              toolUseTrace: result.toolUseTrace,
+              finalText: result.finalText,
+              logger: input.logger,
+            })
+          : await summarizeRun({
+              agent: input.agent,
+              issue: input.issue,
+              envelope,
+              toolUseTrace: result.toolUseTrace,
+              finalText: result.finalText,
+              logger: input.logger,
+            });
+
+        const outcomeTag = isAgentFailure ? "failure-lesson" : envelope.decision;
+        const appendResult = await maybeAppendSummary({
+          summary,
           agent: input.agent,
           issue: input.issue,
-          envelope,
-          toolUseTrace: result.toolUseTrace,
-          finalText: result.finalText,
+          runId: input.runId,
+          outcome: outcomeTag,
+          targetRepoPath: input.targetRepoPath,
           logger: input.logger,
         });
+        appendOutcome = appendResult.appendOutcome;
+        summarySkipReason = appendResult.summarySkipReason;
+      }
+    } else {
+      input.agent.errorCount += 1;
 
-        if (summary.skip || !summary.heading || !summary.body) {
-          summarySkipReason = summary.skipReason ?? "no body";
+      // No envelope — the SDK or the agent crashed before emitting one. Fire
+      // the failure summarizer unless the cause is an infra flake (transport
+      // error, GitHub 5xx, worktree creation fail) where there's no lesson.
+      if (!input.skipSummary) {
+        if (isInfraFlake(result.errorReason)) {
+          summarySkipReason = `infra flake skipped: ${result.errorReason}`;
           input.logger.info("specialization.skipped", {
             agentId: input.agent.agentId,
             issueId: input.issue.id,
             reason: summarySkipReason,
           });
-        } else {
-          appendOutcome = await appendBlock({
-            agentId: input.agent.agentId,
-            runId: input.runId,
-            issueId: input.issue.id,
-            outcome: envelope.decision,
-            heading: summary.heading,
-            body: summary.body,
-            targetRepoPath: input.targetRepoPath,
+        } else if (result.errorReason || result.parseError || result.finalText) {
+          const summary = await summarizeFailureRun({
+            agent: input.agent,
+            issue: input.issue,
+            errorReason: result.errorReason ?? result.parseError,
+            toolUseTrace: result.toolUseTrace,
+            finalText: result.finalText,
+            logger: input.logger,
           });
-          if (appendOutcome.kind === "appended") {
-            input.logger.info("specialization.appended", {
-              agentId: input.agent.agentId,
-              issueId: input.issue.id,
-              heading: summary.heading,
-              bytesAppended: appendOutcome.bytesAppended,
-              totalBytes: appendOutcome.totalBytes,
-            });
-          } else {
-            input.logger.warn("specialization.cap", {
-              agentId: input.agent.agentId,
-              issueId: input.issue.id,
-              totalBytes: appendOutcome.totalBytes,
-            });
-          }
+          const appendResult = await maybeAppendSummary({
+            summary,
+            agent: input.agent,
+            issue: input.issue,
+            runId: input.runId,
+            outcome: "failure-lesson",
+            targetRepoPath: input.targetRepoPath,
+            logger: input.logger,
+          });
+          appendOutcome = appendResult.appendOutcome;
+          summarySkipReason = appendResult.summarySkipReason;
         }
       }
-    } else {
-      input.agent.errorCount += 1;
     }
 
     await mutateRegistry((reg) => {
@@ -176,4 +203,56 @@ function applyTagUpdate(agent: AgentRecord, env: ResultEnvelope): void {
   for (const t of env.memoryUpdate.removeTags ?? []) tags.delete(t.toLowerCase());
   if (tags.size === 0) tags.add("general");
   agent.tags = [...tags].sort();
+}
+
+interface AppendArgs {
+  summary: SummarizerOutput;
+  agent: AgentRecord;
+  issue: IssueSummary;
+  runId: string;
+  outcome: string;
+  targetRepoPath: string;
+  logger: Logger;
+}
+
+async function maybeAppendSummary(args: AppendArgs): Promise<{
+  appendOutcome?: AppendOutcome;
+  summarySkipReason?: string;
+}> {
+  if (args.summary.skip || !args.summary.heading || !args.summary.body) {
+    const summarySkipReason = args.summary.skipReason ?? "no body";
+    args.logger.info("specialization.skipped", {
+      agentId: args.agent.agentId,
+      issueId: args.issue.id,
+      reason: summarySkipReason,
+    });
+    return { summarySkipReason };
+  }
+
+  const appendOutcome = await appendBlock({
+    agentId: args.agent.agentId,
+    runId: args.runId,
+    issueId: args.issue.id,
+    outcome: args.outcome,
+    heading: args.summary.heading,
+    body: args.summary.body,
+    targetRepoPath: args.targetRepoPath,
+  });
+  if (appendOutcome.kind === "appended") {
+    args.logger.info("specialization.appended", {
+      agentId: args.agent.agentId,
+      issueId: args.issue.id,
+      heading: args.summary.heading,
+      outcome: args.outcome,
+      bytesAppended: appendOutcome.bytesAppended,
+      totalBytes: appendOutcome.totalBytes,
+    });
+  } else {
+    args.logger.warn("specialization.cap", {
+      agentId: args.agent.agentId,
+      issueId: args.issue.id,
+      totalBytes: appendOutcome.totalBytes,
+    });
+  }
+  return { appendOutcome };
 }

--- a/src/agent/summarizer.ts
+++ b/src/agent/summarizer.ts
@@ -32,15 +32,85 @@ export interface SummarizerInput {
 }
 
 export async function summarizeRun(input: SummarizerInput): Promise<SummarizerOutput> {
-  const userPrompt = buildPrompt(input);
+  return runSummarizerQuery({
+    agent: input.agent,
+    issue: input.issue,
+    systemPrompt: SUMMARIZER_SYSTEM_PROMPT,
+    userPrompt: buildPrompt(input),
+    logger: input.logger,
+  });
+}
 
+export interface FailureSummarizerInput {
+  agent: AgentRecord;
+  issue: IssueSummary;
+  // Optional — when the SDK or the agent crashed before producing an
+  // envelope, only errorReason is populated.
+  envelope?: ResultEnvelope;
+  errorReason?: string;
+  toolUseTrace: { tool: string; input: string }[];
+  finalText: string;
+  logger: Logger;
+}
+
+export async function summarizeFailureRun(
+  input: FailureSummarizerInput,
+): Promise<SummarizerOutput> {
+  return runSummarizerQuery({
+    agent: input.agent,
+    issue: input.issue,
+    systemPrompt: FAILURE_SUMMARIZER_SYSTEM_PROMPT,
+    userPrompt: buildFailurePrompt(input),
+    logger: input.logger,
+  });
+}
+
+// Pattern-match SDK / GitHub / filesystem transport errors that have no
+// learning value. Anything that doesn't match here is treated as a genuine
+// failure worth distilling into a lesson.
+const INFRA_FLAKE_PATTERNS: RegExp[] = [
+  /\bECONNRESET\b/i,
+  /\bECONNREFUSED\b/i,
+  /\bENOTFOUND\b/i,
+  /\bEPIPE\b/i,
+  /\bETIMEDOUT\b/i,
+  /\baborted?\b/i,
+  /\btimed out\b/i,
+  /\btimeout\b/i,
+  /\bsocket hang up\b/i,
+  /\bnetwork error\b/i,
+  /\bfetch failed\b/i,
+  // GitHub API 5xx surfaces from gh / api wrappers.
+  /\bHTTP 5\d\d\b/,
+  /\bstatus(?:Code)?[:\s]+5\d\d\b/i,
+  // Worktree / filesystem-level failures.
+  /\bworktree\b[\s\S]{0,80}\b(?:fail|create|init|exists|locked)\b/i,
+  /\bENOENT\b/,
+  /\bEACCES\b/,
+  /\bENOSPC\b/,
+];
+
+export function isInfraFlake(reason: string | undefined | null): boolean {
+  if (!reason) return false;
+  return INFRA_FLAKE_PATTERNS.some((re) => re.test(reason));
+}
+
+interface SummarizerQueryArgs {
+  agent: AgentRecord;
+  issue: IssueSummary;
+  systemPrompt: string;
+  userPrompt: string;
+  logger: Logger;
+}
+
+async function runSummarizerQuery(args: SummarizerQueryArgs): Promise<SummarizerOutput> {
   let raw = "";
   try {
     const stream = query({
-      prompt: userPrompt,
+      prompt: args.userPrompt,
       options: {
         model: SUMMARIZER_MODEL,
-        systemPrompt: SUMMARIZER_SYSTEM_PROMPT,
+        systemPrompt: args.systemPrompt,
         tools: [],
         permissionMode: "default",
         env: process.env,
@@ -53,9 +123,9 @@ export async function summarizeRun(input: SummarizerInput): Promise<SummarizerOu
       if (msg.type === "result") {
         if (msg.subtype === "success") raw = msg.result;
         else {
-          input.logger.warn("specialization.summarizer_failed", {
-            agentId: input.agent.agentId,
-            issueId: input.issue.id,
+          args.logger.warn("specialization.summarizer_failed", {
+            agentId: args.agent.agentId,
+            issueId: args.issue.id,
             subtype: msg.subtype,
           });
           return { skip: true, skipReason: `summarizer query failed: ${msg.subtype}` };
@@ -63,9 +133,9 @@ export async function summarizeRun(input: SummarizerInput): Promise<SummarizerOu
       }
     }
   } catch (err) {
-    input.logger.warn("specialization.summarizer_failed", {
-      agentId: input.agent.agentId,
-      issueId: input.issue.id,
+    args.logger.warn("specialization.summarizer_failed", {
+      agentId: args.agent.agentId,
+      issueId: args.issue.id,
       err: (err as Error).message,
     });
     return { skip: true, skipReason: `summarizer exception: ${(err as Error).message}` };
@@ -73,9 +143,9 @@ export async function summarizeRun(input: SummarizerInput): Promise<SummarizerOu
 
   const json = parseJsonLoose(raw);
   if (!json) {
-    input.logger.warn("summarizer.malformed_payload", {
-      agentId: input.agent.agentId,
-      issueId: input.issue.id,
+    args.logger.warn("summarizer.malformed_payload", {
+      agentId: args.agent.agentId,
+      issueId: args.issue.id,
       raw: raw.slice(0, 4000),
     });
     return { skip: true, skipReason: "summarizer output not valid JSON" };
@@ -85,13 +155,13 @@ export async function summarizeRun(input: SummarizerInput): Promise<SummarizerOu
   // validation so the entire summary isn't discarded just because the LLM
   // ignored the prompt's length directive. The schema's max bounds still
   // act as a hard ceiling — clamping happens against those same constants.
-  const clamped = clampLengths(json, input);
+  const clamped = clampLengthsCompat(json, args.logger, args.agent.agentId, args.issue.id);
 
   const parsed = SummarizerOutputSchema.safeParse(clamped);
   if (!parsed.success) {
-    input.logger.warn("summarizer.malformed_payload", {
-      agentId: input.agent.agentId,
-      issueId: input.issue.id,
+    args.logger.warn("summarizer.malformed_payload", {
+      agentId: args.agent.agentId,
+      issueId: args.issue.id,
       raw: raw.slice(0, 4000),
       zodError: parsed.error.message.replace(/\s+/g, " "),
     });
@@ -103,15 +173,20 @@ export async function summarizeRun(input: SummarizerInput): Promise<SummarizerOu
   return parsed.data;
 }
 
-function clampLengths(json: unknown, input: SummarizerInput): unknown {
+function clampLengthsCompat(
+  json: unknown,
+  logger: Logger,
+  agentId: string,
+  issueId: number,
+): unknown {
   if (!json || typeof json !== "object") return json;
   const obj = json as Record<string, unknown>;
   const out: Record<string, unknown> = { ...obj };
   if (typeof obj.heading === "string" && obj.heading.length > HEADING_MAX) {
     out.heading = obj.heading.slice(0, HEADING_MAX - 3) + "...";
-    input.logger.warn("summarizer.clamped", {
-      agentId: input.agent.agentId,
-      issueId: input.issue.id,
+    logger.warn("summarizer.clamped", {
+      agentId,
+      issueId,
       field: "heading",
       originalLength: obj.heading.length,
       max: HEADING_MAX,
@@ -119,9 +194,9 @@ function clampLengths(json: unknown, input: SummarizerInput): unknown {
   }
   if (typeof obj.body === "string" && obj.body.length > BODY_MAX) {
     out.body = obj.body.slice(0, BODY_MAX - 16) + "\n[…truncated]";
-    input.logger.warn("summarizer.clamped", {
-      agentId: input.agent.agentId,
-      issueId: input.issue.id,
+    logger.warn("summarizer.clamped", {
+      agentId,
+      issueId,
       field: "body",
       originalLength: obj.body.length,
       max: BODY_MAX,
@@ -144,6 +219,67 @@ Hard rules:
 
 Output: a single JSON object, no fences, no prose. The \`skip\` field is MANDATORY in every response. Use \`{"skip": false, "heading": "...", "body": "..."}\` when there is a lesson worth saving, and \`{"skip": true, "skipReason": "..."}\` otherwise. Schema:
   {"skip": boolean, "skipReason"?: string, "heading"?: string, "body"?: string}`;
+
+const FAILURE_SUMMARIZER_SYSTEM_PROMPT = `You are a distillation agent. A coding agent JUST FAILED on a single GitHub issue — CI red after retry, agent gave up, envelope decision="error", or the SDK crashed mid-run after producing partial work. Your job is to extract the highest-signal failure lesson worth committing to the agent's CLAUDE.md.
+
+Failure-mode bias: lean toward EMITTING a lesson, not skipping. The whole point of this path is that today these signals are discarded — assume there is something worth saying unless the failure is genuinely opaque.
+
+Three questions to anchor the body:
+1. What did the agent ASSUME that turned out wrong?
+2. What CONTEXT or TOOLING was missing — what would have unblocked it?
+3. What GUARD RULE, written tersely, would have prevented this on the next similar issue?
+
+Style: match the dense rule-form of an existing CLAUDE.md section. Lead with the rule itself in bold. Then a **Why:** line (the failure mode this targets). Then a **How to apply:** line (when this guidance kicks in). Use **Tells:** sparingly. Markdown hyperlinks (\`[label](url)\`) over raw URLs.
+
+Hard rules:
+- If the failure was genuinely uninformative (single ambiguous error string, no agent reasoning, no clear missed assumption), emit \`{"skip": true, "skipReason": "<one short sentence>"}\`. Wrong-lesson risk beats noisy-lesson risk.
+- Heading: ≤ 120 chars, no trailing colon, no markdown prefix (no leading "##"). The append step prepends "##".
+- Body: ≤ 2000 chars. 2–8 short lines. No prose paragraphs.
+- Do NOT mention the specific issue number, PR number, or run id — that's in the provenance comment. Talk about the class of failure, not this instance.
+- Inside heading / body / skipReason string values: escape every double-quote as \\" and every literal newline as \\n. Do NOT escape apostrophes — \\' is INVALID JSON. Write apostrophes as a plain ': don't, isn't, can't.
+
+Output: a single JSON object, no fences, no prose. The \`skip\` field is MANDATORY in every response. Schema:
+  {"skip": boolean, "skipReason"?: string, "heading"?: string, "body"?: string}`;
+
+function buildFailurePrompt(input: FailureSummarizerInput): string {
+  const trace = input.toolUseTrace
+    .slice(-12)
+    .map((t) => `- ${t.tool}: ${t.input}`)
+    .join("\n");
+
+  const decisionLine = input.envelope
+    ? `Decision: ${input.envelope.decision}`
+    : "Decision: <no envelope — agent crashed before emitting one>";
+  const reasonLine = input.envelope ? `Reason: ${input.envelope.reason}` : "";
+  const errorLine = input.errorReason ? `SDK / runtime error: ${input.errorReason}` : "";
+  const tagsAdded = input.envelope ? JSON.stringify(input.envelope.memoryUpdate.addTags) : "[]";
+  const tagsRemoved = input.envelope
+    ? JSON.stringify(input.envelope.memoryUpdate.removeTags ?? [])
+    : "[]";
+
+  return `Agent ${input.agent.agentId} just FAILED work on an issue. Distill the lesson.
+
+Issue:
+  number: ${input.issue.id}
+  title: ${input.issue.title}
+  labels: ${JSON.stringify(input.issue.labels)}
+
+Pre-run agent tags: ${JSON.stringify(input.agent.tags)}
+Tags added this run: ${tagsAdded}
+Tags removed this run: ${tagsRemoved}
+
+${decisionLine}
+${reasonLine}
+${errorLine}
+
+Last tool calls (most recent ${Math.min(12, input.toolUseTrace.length)}):
+${trace || "(none captured)"}
+
+Agent's final reasoning text (truncated):
+${truncate(input.finalText, 4000)}
+
+Decide: is there a generalizable failure lesson worth committing to this agent's CLAUDE.md? Lean toward yes — failure-mode runs exist to capture signal that success-mode discards. If yes, emit {"skip": false, "heading": "...", "body": "..."}. If the failure is genuinely opaque, emit {"skip": true, "skipReason": "..."}. The skip field is mandatory in both shapes. JSON only — escape every \\" inside string values.`;
+}
 
 function buildPrompt(input: SummarizerInput): string {
   const trace = input.toolUseTrace


### PR DESCRIPTION
Closes #32

## Summary

`summarizeRun` only fires on envelopes today and biases toward skipping when `decision === "error"` — terminal-failure signal is discarded. This PR adds a parallel `summarizeFailureRun` path with a different prompt and an `isInfraFlake` classifier to drop transport / 5xx / filesystem errors that carry no learning value.

`runIssueCore` now branches:

- `envelope.decision === "error"` → `summarizeFailureRun`, sentinel tagged `outcome:failure-lesson`.
- No envelope + non-flake `errorReason`/`parseError`/`finalText` → `summarizeFailureRun` (synthetic context, envelope-less), same tag.
- No envelope + infra flake → skip with `specialization.skipped` log.
- `envelope.decision ∈ {implement, pushback}` → existing `summarizeRun` path, untouched.

## Design notes

- **Sentinel reuse over new tag format.** The plan proposed `<!-- failure-lesson:run-<id> --> … <!-- /failure-lesson -->` to enable a separate prune cadence. Existing sentinel `<!-- run:R issue:#N outcome:O ts:TS -->` already carries `outcome` — passing `failure-lesson` as the value gives a future prune step the same filter handle without introducing a second sentinel shape. Smaller delta, identical observable property.
- **Failure prompt biases toward emitting, not skipping.** The success prompt's "If the agent failed, default to skip" rule is removed in the failure variant — the whole point of this path is to capture signal the success path drops. `wrong-lesson risk beats noisy-lesson risk` still gates: opaque failures (single error string, no agent reasoning) still get `skip:true`.
- **`isInfraFlake` patterns** match the plan's listed signals (transport, 5xx, worktree/fs) plus a few common Node error codes (`ECONNRESET`, `ETIMEDOUT`, `ENOENT`, etc.). Anything not matched falls through to the failure summarizer.
- **No envelope path** picks the best available context: `errorReason` then `parseError` then `finalText`. If all three are empty there's nothing to distill — silent skip.
- **`maybeAppendSummary` helper** factors the `summary → appendBlock + log` boilerplate that was duplicated when adding the second branch. Pure dedup; no behavior change on the success path.

## Verification

- `npm run build` clean.
- `npm run typecheck` clean.
- No test runner in repo (no `test` script in `package.json`); the plan's "unit test" verification step has no infrastructure to land against. Filing test scaffolding belongs to a separate scoped issue.

## Out of scope (per plan)

- Auto-expire after K successes — sentinel `outcome:failure-lesson` enables this; implement when prune cadence is tackled.
- Multi-failure aggregation across runs.
- Target-repo modifications.
- Cross-agent failure sharing (#33).
- CI-red / reviewer-rework signals (depends on #36).

— Rogue-MCP Trust Boundary (agent-5ade)
