### PR TITLE
feat(triage): pre-dispatch issue triage filters not-ready issues

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,8 @@ import { createAgent, loadRegistry, mutateRegistry } from "./state/registry.js";
 import { parseRangeSpec, describeRange } from "./github/range.js";
 import { getIssue, resolveRangeToIssues } from "./github/gh.js";
 import { pickAgents, runOrchestrator } from "./orchestrator/orchestrator.js";
-import { approveSetup, buildSetupPreview } from "./orchestrator/setup.js";
+import { approveSetup, buildSetupPreview, type TriageSkipped } from "./orchestrator/setup.js";
+import { triageBatch } from "./orchestrator/triage.js";
 import { Logger } from "./log/logger.js";
 import { fetchOriginMain, pruneStaleAgentBranches, pruneWorktrees, resolveTargetRepoPath } from "./git/worktree.js";
 import { agentClaudeMdPath, forkClaudeMd } from "./agent/specialization.js";
@@ -54,6 +55,10 @@ export function buildCli(): Command {
     .option("--max-ticks <n>", "Safety cap on scheduling ticks", parsePositive, DEFAULT_MAX_TICKS)
     .option("--verbose", "Mirror a colorized subset of events to stderr")
     .option("--yes", "Auto-approve the setup preview (required for non-TTY environments)")
+    .option(
+      "--include-non-ready",
+      "Skip pre-dispatch triage and dispatch every open issue (per-run override; no env var)",
+    )
     .action(async (opts) => {
       await cmdRun(opts);
     });
@@ -149,6 +154,7 @@ interface RunOpts {
   maxTicks: number;
   verbose?: boolean;
   yes?: boolean;
+  includeNonReady?: boolean;
 }
 
 async function cmdRun(opts: RunOpts): Promise<void> {
@@ -192,17 +198,63 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     process.exit(2);
   }
 
+  // Pre-dispatch triage runs BEFORE the approval gate so the user sees the
+  // skipped set before y/N. Logger is opened early under a triage-prefixed id
+  // (the real runId is only minted after gate approval); the file lives
+  // alongside the eventual run log under logs/. --include-non-ready bypasses
+  // the haiku call entirely — no value in spending tokens on a result we're
+  // about to ignore.
+  const triageLogger = new Logger({
+    runId: `triage-${new Date().toISOString().replace(/[:.]/g, "-")}`,
+    verbose: !!opts.verbose,
+  });
+  await triageLogger.open();
+  let dispatchIssues = open;
+  let triageSkipped: TriageSkipped[] = [];
+  try {
+    if (opts.includeNonReady) {
+      triageLogger.info("triage.bypassed", { reason: "--include-non-ready", issueCount: open.length });
+    } else {
+      const triaged = await triageBatch({
+        targetRepo: opts.targetRepo,
+        issues: open,
+        logger: triageLogger,
+      });
+      dispatchIssues = triaged.filter((t) => t.result.ready).map((t) => t.issue);
+      triageSkipped = triaged
+        .filter((t) => !t.result.ready)
+        .map((t) => ({ issue: t.issue, reason: t.result.reason }));
+      triageLogger.info("triage.batch_completed", {
+        total: triaged.length,
+        ready: dispatchIssues.length,
+        skipped: triageSkipped.length,
+        cacheHits: triaged.filter((t) => t.fromCache).length,
+        totalCostUsd: triaged.reduce((sum, t) => sum + t.costUsd, 0),
+      });
+    }
+  } finally {
+    await triageLogger.close();
+  }
+
+  if (dispatchIssues.length === 0) {
+    console.error(
+      `ERROR: all ${open.length} open issue(s) filtered by triage as not-ready. Re-run with --include-non-ready to dispatch them anyway.`,
+    );
+    process.exit(2);
+  }
+
   const registry = await loadRegistry();
   const preview = await buildSetupPreview({
     targetRepo: opts.targetRepo,
     targetRepoPath: repoPath,
     rangeLabel: describeRange(range),
-    openIssues: open,
+    openIssues: dispatchIssues,
     closedSkipped: skippedClosed,
     parallelism: opts.agents,
     dryRun: !!opts.dryRun,
     resume: false,
     registry,
+    triageSkipped,
   });
   const approved = await approveSetup({ preview, yes: !!opts.yes });
   if (!approved) {
@@ -216,7 +268,7 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     targetRepo: opts.targetRepo,
     issueRange: range,
     parallelism: opts.agents,
-    issueIds: open.map((i) => i.id),
+    issueIds: dispatchIssues.map((i) => i.id),
     dryRun: !!opts.dryRun,
   });
   await saveRunState(state);
@@ -230,7 +282,8 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     targetRepoPath: repoPath,
     parallelism: opts.agents,
     range: opts.issues,
-    issueCount: open.length,
+    issueCount: dispatchIssues.length,
+    triageSkippedCount: triageSkipped.length,
     dryRun: !!opts.dryRun,
   });
 
@@ -239,7 +292,7 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     await pruneStaleAgentBranches(repoPath, opts.targetRepo, logger);
     await runOrchestrator({
       state,
-      issues: open,
+      issues: dispatchIssues,
       parallelism: opts.agents,
       maxTicks: opts.maxTicks,
       logger,
@@ -249,7 +302,7 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     logger.info("run.completed", {
       runId,
       complete: isRunComplete(state),
-      issueCount: open.length,
+      issueCount: dispatchIssues.length,
     });
     if (isRunComplete(state)) await clearCurrentRunId();
   } finally {

--- a/src/github/gh.ts
+++ b/src/github/gh.ts
@@ -11,6 +11,22 @@ interface GhIssueRecord {
   labels: { name: string }[];
 }
 
+interface GhIssueDetailRecord extends GhIssueRecord {
+  body: string;
+  comments: { author?: { login?: string }; body: string; createdAt: string }[];
+}
+
+export interface IssueComment {
+  author: string;
+  body: string;
+  createdAt: string;
+}
+
+export interface IssueDetail extends IssueSummary {
+  body: string;
+  comments: IssueComment[];
+}
+
 export async function listOpenIssues(targetRepo: string): Promise<IssueSummary[]> {
   const { stdout } = await execFile(
     "gh",
@@ -61,6 +77,37 @@ function toSummary(rec: GhIssueRecord): IssueSummary {
     labels: rec.labels.map((l) => l.name),
     state,
   };
+}
+
+export async function getIssueDetail(targetRepo: string, number: number): Promise<IssueDetail | null> {
+  try {
+    const { stdout } = await execFile(
+      "gh",
+      [
+        "issue",
+        "view",
+        String(number),
+        "--repo",
+        targetRepo,
+        "--json",
+        "number,title,state,labels,body,comments",
+      ],
+      { maxBuffer: 50 * 1024 * 1024 },
+    );
+    const rec = JSON.parse(stdout) as GhIssueDetailRecord;
+    const summary = toSummary(rec);
+    return {
+      ...summary,
+      body: rec.body ?? "",
+      comments: (rec.comments ?? []).map((c) => ({
+        author: c.author?.login ?? "",
+        body: c.body ?? "",
+        createdAt: c.createdAt ?? "",
+      })),
+    };
+  } catch {
+    return null;
+  }
 }
 
 export async function resolveRangeToIssues(

--- a/src/orchestrator/setup.ts
+++ b/src/orchestrator/setup.ts
@@ -7,6 +7,11 @@ import {
   type OverloadVerdict,
 } from "../agent/split.js";
 
+export interface TriageSkipped {
+  issue: IssueSummary;
+  reason: string;
+}
+
 export interface SetupPreview {
   targetRepo: string;
   targetRepoPath: string;
@@ -23,6 +28,10 @@ export interface SetupPreview {
   specialistCount: number;
   generalCount: number;
   overloadWarnings: OverloadVerdict[];
+  // Issues filtered out by pre-dispatch triage (haiku rubric). Surfaced in
+  // the gate so the user can see what is being dropped before y/N. When
+  // --include-non-ready is passed, triage is skipped and this is empty.
+  triageSkipped: TriageSkipped[];
 }
 
 export interface BuildPreviewInput {
@@ -35,6 +44,7 @@ export interface BuildPreviewInput {
   dryRun: boolean;
   resume: boolean;
   registry: AgentRegistryFile;
+  triageSkipped?: TriageSkipped[];
 }
 
 export async function buildSetupPreview(input: BuildPreviewInput): Promise<SetupPreview> {
@@ -68,6 +78,7 @@ export async function buildSetupPreview(input: BuildPreviewInput): Promise<Setup
     specialistCount: pick.specialistCount,
     generalCount: pick.generalCount,
     overloadWarnings,
+    triageSkipped: input.triageSkipped ?? [],
   };
 }
 
@@ -117,6 +128,15 @@ export function formatSetupPreview(p: SetupPreview): string {
       lines.push(`  WARNING: ${w.agentId} crossed split threshold — ${w.reasons.join(", ")}`);
       lines.push(`    Run \`vp-dev agents split ${w.agentId}\` to view a split proposal.`);
     }
+    lines.push("");
+  }
+
+  if (p.triageSkipped.length > 0) {
+    lines.push(`${p.triageSkipped.length} issue(s) skipped by triage:`);
+    for (const s of p.triageSkipped) {
+      lines.push(`  #${s.issue.id} — ${s.reason}`);
+    }
+    lines.push("  Override with --include-non-ready.");
     lines.push("");
   }
 

--- a/src/orchestrator/triage.ts
+++ b/src/orchestrator/triage.ts
@@ -1,0 +1,321 @@
+import { promises as fs } from "node:fs";
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { z } from "zod";
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { ensureDir } from "../state/locks.js";
+import { getIssueDetail, type IssueComment, type IssueDetail } from "../github/gh.js";
+import type { IssueSummary } from "../types.js";
+import type { Logger } from "../log/logger.js";
+
+const TRIAGE_MODEL = "claude-haiku-4-5-20251001";
+const REASON_MAX = 240;
+
+export const TRIAGE_DIR = path.resolve(process.cwd(), "state", "triage");
+
+export const TriageResultSchema = z.object({
+  ready: z.boolean(),
+  reason: z.string().min(1).max(REASON_MAX),
+  suggestedSpecialty: z.string().max(80).optional(),
+});
+export type TriageResult = z.infer<typeof TriageResultSchema>;
+
+export interface TriagedIssue {
+  issue: IssueSummary;
+  result: TriageResult;
+  fromCache: boolean;
+  costUsd: number;
+}
+
+interface CacheEntry {
+  targetRepo: string;
+  issueNumber: number;
+  contentHash: string;
+  result: TriageResult;
+  triagedAt: string;
+}
+
+export interface TriageBatchInput {
+  targetRepo: string;
+  issues: IssueSummary[];
+  logger: Logger;
+}
+
+export async function triageBatch(input: TriageBatchInput): Promise<TriagedIssue[]> {
+  // Sequential: keeps log output ordered and avoids hammering the gh CLI +
+  // Anthropic API for ranges of 50+ issues. Triage is a short-lived
+  // pre-flight; serial execution costs ~1-2s per issue and keeps the gate
+  // text predictable.
+  const out: TriagedIssue[] = [];
+  for (const issue of input.issues) {
+    const triaged = await triageOne({
+      targetRepo: input.targetRepo,
+      issue,
+      logger: input.logger,
+    });
+    out.push(triaged);
+  }
+  return out;
+}
+
+interface TriageOneInput {
+  targetRepo: string;
+  issue: IssueSummary;
+  logger: Logger;
+}
+
+async function triageOne(input: TriageOneInput): Promise<TriagedIssue> {
+  const detail = await getIssueDetail(input.targetRepo, input.issue.id);
+  if (!detail) {
+    // Issue disappeared between range resolve and triage — fail-open.
+    return {
+      issue: input.issue,
+      result: { ready: true, reason: "triage skipped: issue detail unavailable" },
+      fromCache: false,
+      costUsd: 0,
+    };
+  }
+
+  const contentHash = computeContentHash(detail);
+  const cached = await readCache(input.targetRepo, input.issue.id, contentHash);
+  if (cached) {
+    input.logger.info("triage.cache_hit", {
+      issueId: input.issue.id,
+      contentHash,
+      ready: cached.ready,
+    });
+    return {
+      issue: input.issue,
+      result: cached,
+      fromCache: true,
+      costUsd: 0,
+    };
+  }
+
+  const fresh = await callTriageModel(detail, input.logger);
+  await writeCache(input.targetRepo, input.issue.id, contentHash, fresh.result);
+  input.logger.info("triage.evaluated", {
+    issueId: input.issue.id,
+    contentHash,
+    ready: fresh.result.ready,
+    reason: fresh.result.reason,
+    costUsd: fresh.costUsd,
+  });
+  return {
+    issue: input.issue,
+    result: fresh.result,
+    fromCache: false,
+    costUsd: fresh.costUsd,
+  };
+}
+
+interface ModelOutcome {
+  result: TriageResult;
+  costUsd: number;
+}
+
+async function callTriageModel(detail: IssueDetail, logger: Logger): Promise<ModelOutcome> {
+  const userPrompt = buildPrompt(detail);
+  let raw = "";
+  let costUsd = 0;
+  try {
+    const stream = query({
+      prompt: userPrompt,
+      options: {
+        model: TRIAGE_MODEL,
+        systemPrompt: TRIAGE_SYSTEM_PROMPT,
+        tools: [],
+        permissionMode: "default",
+        env: process.env,
+        maxTurns: 1,
+        settingSources: [],
+        persistSession: false,
+      },
+    });
+    for await (const msg of stream) {
+      if (msg.type === "result") {
+        if (msg.subtype === "success") {
+          raw = msg.result;
+          costUsd = msg.total_cost_usd ?? 0;
+        } else {
+          // Fail-open: model failure should not block the run.
+          logger.warn("triage.model_failed", {
+            issueId: detail.id,
+            subtype: msg.subtype,
+          });
+          return failOpen(`triage model failed: ${msg.subtype}`);
+        }
+      }
+    }
+  } catch (err) {
+    logger.warn("triage.model_failed", {
+      issueId: detail.id,
+      err: (err as Error).message,
+    });
+    return failOpen(`triage exception: ${(err as Error).message}`);
+  }
+
+  const json = parseJsonLoose(raw);
+  if (!json) {
+    logger.warn("triage.malformed_payload", {
+      issueId: detail.id,
+      raw: raw.slice(0, 4000),
+    });
+    return failOpen("triage output not valid JSON");
+  }
+  const clamped = clampReason(json);
+  const parsed = TriageResultSchema.safeParse(clamped);
+  if (!parsed.success) {
+    logger.warn("triage.malformed_payload", {
+      issueId: detail.id,
+      raw: raw.slice(0, 4000),
+      zodError: parsed.error.message.replace(/\s+/g, " "),
+    });
+    return failOpen(`triage schema invalid: ${parsed.error.message.replace(/\s+/g, " ").slice(0, 160)}`);
+  }
+  return { result: parsed.data, costUsd };
+}
+
+function failOpen(reason: string): ModelOutcome {
+  return {
+    result: { ready: true, reason: `fail-open: ${reason}`.slice(0, REASON_MAX) },
+    costUsd: 0,
+  };
+}
+
+function clampReason(json: unknown): unknown {
+  if (!json || typeof json !== "object") return json;
+  const obj = json as Record<string, unknown>;
+  if (typeof obj.reason === "string" && obj.reason.length > REASON_MAX) {
+    return { ...obj, reason: obj.reason.slice(0, REASON_MAX - 3) + "..." };
+  }
+  return obj;
+}
+
+const TRIAGE_SYSTEM_PROMPT = `You are a triage agent. Given a single GitHub issue's body and comments, decide whether it is ready to be picked up by an autonomous coding agent.
+
+Rubric:
+- Ready: a concrete bug with a repro, or a feature with explicit acceptance criteria, or a clearly-scoped refactor.
+- NOT ready — ambiguous: "we should think about", "explore", "investigate", "discuss", or no acceptance criteria.
+- NOT ready — duplicate: the issue body or comments explicitly say it is a duplicate of another open issue.
+- NOT ready — body/comments conflict: the comments redirect to a different scope than the body, and a coding agent reading body-only would do the wrong thing.
+
+The "Issue Analysis" rule from the agent's CLAUDE.md REQUIRES reading comments — body and comments together form the spec. Prefer comments when they correct or override the body.
+
+Output: a single JSON object, no fences, no prose.
+  {"ready": boolean, "reason": "<one short sentence, ≤240 chars>", "suggestedSpecialty"?: "<short hint, optional>"}
+
+Hard rules:
+- Default to ready: true when uncertain (the approval gate is the human backstop).
+- The "reason" must explain WHY in one short sentence. For ready: cite the concrete signal ("explicit acceptance criteria", "bug with repro"). For not-ready: cite the disqualifier ("ambiguous scope", "duplicate of #N", "body/comments conflict").
+- No markdown in the reason. No newlines inside the reason — write a single sentence.
+- If the body is empty AND there are no comments, return ready: true with reason "empty body — fail open".`;
+
+function buildPrompt(detail: IssueDetail): string {
+  const commentBlocks = detail.comments
+    .map((c) => `--- comment by ${c.author} at ${c.createdAt}\n${c.body}`)
+    .join("\n\n");
+  return `Issue ${detail.id} — ${detail.title}
+Labels: ${JSON.stringify(detail.labels)}
+
+Body:
+${truncate(detail.body || "(empty)", 6000)}
+
+Comments (${detail.comments.length}):
+${truncate(commentBlocks || "(none)", 6000)}
+
+Decide ready/not-ready per the rubric. JSON only.`;
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 3) + "...";
+}
+
+function computeContentHash(detail: IssueDetail): string {
+  const h = createHash("sha256");
+  h.update(detail.body ?? "");
+  h.update("\n--comments--\n");
+  for (const c of detail.comments) {
+    h.update(commentKey(c));
+    h.update("\n");
+  }
+  return "sha256:" + h.digest("hex").slice(0, 32);
+}
+
+function commentKey(c: IssueComment): string {
+  // createdAt + author + body — author/timestamp shifts mean a different
+  // comment even if body is identical (rare but real for "+1" threads).
+  return `${c.createdAt}|${c.author}|${c.body}`;
+}
+
+function repoCacheDir(targetRepo: string): string {
+  // owner/repo -> owner__repo so it's a single safe path segment.
+  return path.join(TRIAGE_DIR, targetRepo.replace("/", "__"));
+}
+
+function cacheFilePath(targetRepo: string, issueNumber: number): string {
+  return path.join(repoCacheDir(targetRepo), `${issueNumber}.json`);
+}
+
+async function readCache(
+  targetRepo: string,
+  issueNumber: number,
+  contentHash: string,
+): Promise<TriageResult | null> {
+  try {
+    const raw = await fs.readFile(cacheFilePath(targetRepo, issueNumber), "utf-8");
+    const entry = JSON.parse(raw) as CacheEntry;
+    if (entry.contentHash !== contentHash) return null;
+    const parsed = TriageResultSchema.safeParse(entry.result);
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeCache(
+  targetRepo: string,
+  issueNumber: number,
+  contentHash: string,
+  result: TriageResult,
+): Promise<void> {
+  const entry: CacheEntry = {
+    targetRepo,
+    issueNumber,
+    contentHash,
+    result,
+    triagedAt: new Date().toISOString(),
+  };
+  const filePath = cacheFilePath(targetRepo, issueNumber);
+  await ensureDir(path.dirname(filePath));
+  const tmp = `${filePath}.tmp.${process.pid}`;
+  await fs.writeFile(tmp, JSON.stringify(entry, null, 2));
+  await fs.rename(tmp, filePath);
+}
+
+function parseJsonLoose(raw: string): unknown {
+  const trimmed = raw.trim();
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    const match = /```(?:json)?\s*\n([\s\S]*?)\n```/i.exec(trimmed);
+    if (match) {
+      try {
+        return JSON.parse(match[1]);
+      } catch {
+        return null;
+      }
+    }
+    const start = trimmed.indexOf("{");
+    const end = trimmed.lastIndexOf("}");
+    if (start >= 0 && end > start) {
+      try {
+        return JSON.parse(trimmed.slice(start, end + 1));
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #35.

## Summary

Adds a haiku-driven pre-flight that classifies each open issue in the requested range as ready / not-ready and surfaces the filter in the approval gate before dispatch.

- **`src/orchestrator/triage.ts`** — `triageBatch()` calls `claude-haiku-4-5-20251001` once per issue with a rubric covering ambiguous scope, duplicate, and body/comments conflict (the latter directly enforces the agent's "Issue Analysis" rule). Results land in `state/triage/<owner>__<repo>/<N>.json` keyed on `sha256(body + comments-concat)` so re-runs short-circuit on unchanged content. Model failures, malformed JSON, and Zod-invalid payloads all fail open to `ready: true` with a `fail-open: <reason>` marker — the human gate is the backstop.
- **`src/github/gh.ts`** — adds `getIssueDetail()` returning body + comments via `gh issue view --json body,comments`.
- **`src/orchestrator/setup.ts`** — `SetupPreview` extended with `triageSkipped`; `formatSetupPreview()` renders a `N issue(s) skipped by triage` block listing each `#N — <reason>` and the override hint.
- **`src/cli.ts`** — `cmdRun()` triages between range resolution and gate; only ready issues thread through to `runOrchestrator`. New `--include-non-ready` flag (per-run only, no env var) bypasses triage entirely so the user is never paying for haiku calls whose verdict will be ignored. Run state's `issueIds` and the orchestrator dispatch list both use the post-triage `dispatchIssues` set so resume is consistent.

## What's deferred

- No tests (project has no test runner — CI is `typecheck + build`).
- Triage cost is logged per-issue (`triage.evaluated.costUsd`) and aggregated in `triage.batch_completed.totalCostUsd` but not surfaced in the gate text. The current preview has no projected-cost line for the dispatch itself, so adding a triage-only cost line would be inconsistent. Easy follow-up once the gate gains an overall cost surface.
- Resume path is unchanged — it reuses the prior run's issue IDs (which already reflect the original triage decision), so no re-triage is needed.

## Test plan

- [ ] `npm run typecheck && npm run build` — green locally.
- [ ] Live `vp-dev run` against a small range with mixed-quality issues — verify the gate lists the ambiguous ones with reasons.
- [ ] `--include-non-ready` skips the haiku call entirely (no `triage.evaluated` events, only `triage.bypassed`).
- [ ] Re-running the same range emits `triage.cache_hit` events for unchanged issues.
- [ ] Force a triage failure (revoke API key mid-batch) — run continues with `fail-open` marker in skipped reasons.

— Issue Lifecycle Hygiene (agent-ef41)
