### PR TITLE
feat(outcomes): track per-agent merge rate, rework cycles, $/merge (#36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,21 @@ for `y/N` confirmation before launching agents. Pass `--yes` to auto-approve
 | `--resume` | Resume the most recent unfinished run. |
 | `--yes` | Skip the approval gate. |
 | `--max-ticks <n>` | Safety cap on scheduling ticks (default 200). |
+| `--stalled-threshold-days <n>` | Mark an open PR as stalled after N days (default 14). |
 | `--verbose` | Mirror a colorized event subset to stderr. |
 
 ### Other commands
 
 ```sh
-node dist/bin/vp-dev.js status        # current run summary
-node dist/bin/vp-dev.js agents list   # registry roster
+node dist/bin/vp-dev.js status         # current run summary
+node dist/bin/vp-dev.js agents list    # registry roster
+node dist/bin/vp-dev.js agents stats   # merge-rate / median-rework / $/merge per agent
 ```
+
+`agents stats` polls each non-terminal PR via `gh pr view` once, then
+appends terminal records to `state/outcomes/<agent>.jsonl`. Pass
+`--no-poll` to skip the GitHub round-trip and report only what's already
+on disk.
 
 ## How it works
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import {
   writeCurrentRunId,
 } from "./state/runState.js";
 import { createAgent, loadRegistry, mutateRegistry } from "./state/registry.js";
+import { loadAllAgentStats, pollOutcomes } from "./state/outcomes.js";
 import { parseRangeSpec, describeRange } from "./github/range.js";
 import { getIssue, resolveRangeToIssues } from "./github/gh.js";
 import { pickAgents, runOrchestrator } from "./orchestrator/orchestrator.js";
@@ -30,6 +31,7 @@ import {
 import type { AgentRecord, IssueRangeSpec, IssueSummary } from "./types.js";
 
 const DEFAULT_MAX_TICKS = 200;
+const DEFAULT_STALLED_THRESHOLD_DAYS = 14;
 
 export function buildCli(): Command {
   const program = new Command();
@@ -45,6 +47,12 @@ export function buildCli(): Command {
     .option("--resume", "Resume the most recent unfinished run")
     .option("--dry-run", "Intercept comment / PR / push tools with synthetic responses")
     .option("--max-ticks <n>", "Safety cap on scheduling ticks", parsePositive, DEFAULT_MAX_TICKS)
+    .option(
+      "--stalled-threshold-days <n>",
+      "Mark an open PR as stalled after N days of inactivity (default 14)",
+      parsePositive,
+      DEFAULT_STALLED_THRESHOLD_DAYS,
+    )
     .option("--verbose", "Mirror a colorized subset of events to stderr")
     .option("--yes", "Auto-approve the setup preview (required for non-TTY environments)")
     .action(async (opts) => {
@@ -104,6 +112,23 @@ export function buildCli(): Command {
         }),
     )
     .addCommand(
+      new Command("stats")
+        .description(
+          "Per-agent outcome rollup: merge rate, median rework, $/merge — sourced from state/outcomes/<agent>.jsonl. Polls non-terminal PRs first.",
+        )
+        .option(
+          "--stalled-threshold-days <n>",
+          "Mark an open PR as stalled after N days of inactivity (default 14)",
+          parsePositive,
+          DEFAULT_STALLED_THRESHOLD_DAYS,
+        )
+        .option("--no-poll", "Skip the GitHub poll; report only what's already on disk")
+        .option("--json", "Print machine-readable JSON")
+        .action(async (opts) => {
+          await cmdAgentsStats(opts);
+        }),
+    )
+    .addCommand(
       new Command("split")
         .description("Detect overload + emit a proposed split into 2-3 sub-specialists. Pass --apply to mutate the registry.")
         .argument("<agentId>", "Agent to inspect (e.g. agent-d396)")
@@ -128,6 +153,7 @@ interface RunOpts {
   resume?: boolean;
   dryRun?: boolean;
   maxTicks: number;
+  stalledThresholdDays: number;
   verbose?: boolean;
   yes?: boolean;
 }
@@ -172,6 +198,8 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     console.error("ERROR: no open issues in range.");
     process.exit(2);
   }
+
+  await pollOutcomesQuietly({ staleThresholdDays: opts.stalledThresholdDays });
 
   const registry = await loadRegistry();
   const preview = await buildSetupPreview({
@@ -255,6 +283,8 @@ async function runResume(opts: RunOpts): Promise<void> {
   const { open, skippedClosed } = await resolveRangeToIssues(state.targetRepo, state.issueRange);
   const tracked = new Set(Object.keys(state.issues).map(Number));
   const issues = open.filter((i) => tracked.has(i.id));
+
+  await pollOutcomesQuietly({ staleThresholdDays: opts.stalledThresholdDays });
 
   const registry = await loadRegistry();
   const preview = await buildSetupPreview({
@@ -741,4 +771,67 @@ function parsePositive(value: string): number {
     throw new Error(`Expected positive integer, got "${value}"`);
   }
   return n;
+}
+
+async function pollOutcomesQuietly(opts: { staleThresholdDays: number }): Promise<void> {
+  // Failures here must never block the run: outcome metrics are advisory.
+  // The user sees a one-liner on stderr if anything was appended.
+  try {
+    const result = await pollOutcomes({ staleThresholdDays: opts.staleThresholdDays });
+    if (result.appended.length > 0) {
+      const merged = result.appended.filter((o) => o.terminalState === "merged").length;
+      const closed = result.appended.filter((o) => o.terminalState === "closed-unmerged").length;
+      const stalled = result.appended.filter((o) => o.terminalState === "stalled").length;
+      process.stderr.write(
+        `outcomes: appended ${result.appended.length} (merged=${merged} closed=${closed} stalled=${stalled})\n`,
+      );
+    }
+  } catch (err) {
+    process.stderr.write(`outcomes: poll skipped (${(err as Error).message})\n`);
+  }
+}
+
+interface AgentsStatsOpts {
+  stalledThresholdDays: number;
+  poll?: boolean;
+  json?: boolean;
+}
+
+async function cmdAgentsStats(opts: AgentsStatsOpts): Promise<void> {
+  if (opts.poll !== false) {
+    await pollOutcomesQuietly({ staleThresholdDays: opts.stalledThresholdDays });
+  }
+  const stats = await loadAllAgentStats();
+  const reg = await loadRegistry();
+  const nameOf = new Map(reg.agents.map((a) => [a.agentId, a.name]));
+  const tagsOf = new Map(reg.agents.map((a) => [a.agentId, a.tags]));
+
+  const enriched = stats.map((s) => ({
+    ...s,
+    name: nameOf.get(s.agentId),
+    tags: tagsOf.get(s.agentId) ?? [],
+  }));
+  // Sort by merge-rate desc; tiebreaker = runs desc.
+  enriched.sort((x, y) => y.mergeRate - x.mergeRate || y.runs - x.runs);
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify({ agents: enriched }, null, 2) + "\n");
+    return;
+  }
+
+  if (enriched.length === 0) {
+    process.stdout.write("No outcomes recorded yet. Run `vp-dev run` to accumulate signal.\n");
+    return;
+  }
+
+  const headers = ["agent", "tags", "runs", "merge-rate", "median-rework", "$/merge"];
+  const rows = enriched.map((s) => [
+    s.name ? `${s.name} (${s.agentId})` : s.agentId,
+    s.tags.length > 0 ? s.tags.join(",") : "general",
+    String(s.runs),
+    `${Math.round(s.mergeRate * 100)}%`,
+    s.medianRework == null ? "-" : String(s.medianRework),
+    s.costPerMerge == null ? "-" : `$${s.costPerMerge.toFixed(2)}`,
+  ]);
+  printTable(headers, rows);
 }

--- a/src/state/outcomes.ts
+++ b/src/state/outcomes.ts
@@ -1,0 +1,342 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+import { execFile as execFileCb } from "node:child_process";
+import { ensureDir, withFileLock } from "./locks.js";
+import { STATE_DIR } from "./runState.js";
+import type { RunState } from "../types.js";
+
+const execFile = promisify(execFileCb);
+
+export const OUTCOMES_DIR = path.join(STATE_DIR, "outcomes");
+
+export type TerminalState = "merged" | "closed-unmerged" | "stalled";
+
+/**
+ * One JSONL record per terminal PR outcome. Persisted to
+ * `state/outcomes/<agent>.jsonl`. Append-only — the polling loop dedupes
+ * by (agent, targetRepo, pr) before fetching GitHub, so re-runs of
+ * `pollOutcomes` are idempotent.
+ *
+ * `costUsd` stays `null` until #34 (cost ceilings) lands.
+ */
+export interface Outcome {
+  agent: string;
+  issue: number;
+  pr: number;
+  prUrl: string;
+  targetRepo: string;
+  terminalState: TerminalState;
+  ciCycles: number | null;
+  reviewerRoundtrips: number | null;
+  daysOpen: number;
+  costUsd: number | null;
+  closedAt: string;
+}
+
+export function outcomesFilePath(agentId: string): string {
+  return path.join(OUTCOMES_DIR, `${agentId}.jsonl`);
+}
+
+/** Parse `https://github.com/owner/repo/pull/123` into `{ targetRepo, pr }`.
+ *  Dry-run URLs (`https://dry-run/...`) and other shapes return `null`. */
+export function parsePrUrl(prUrl: string): { targetRepo: string; pr: number } | null {
+  const m = prUrl.match(/^https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)$/);
+  if (!m) return null;
+  return { targetRepo: m[1], pr: Number(m[2]) };
+}
+
+export async function appendOutcome(outcome: Outcome): Promise<void> {
+  const filePath = outcomesFilePath(outcome.agent);
+  await ensureDir(path.dirname(filePath));
+  await withFileLock(filePath, async () => {
+    await fs.appendFile(filePath, JSON.stringify(outcome) + "\n");
+  });
+}
+
+export async function readOutcomes(agentId: string): Promise<Outcome[]> {
+  try {
+    const raw = await fs.readFile(outcomesFilePath(agentId), "utf-8");
+    return raw
+      .split("\n")
+      .filter((l) => l.trim().length > 0)
+      .map((l) => JSON.parse(l) as Outcome);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+}
+
+export async function listOutcomeAgents(): Promise<string[]> {
+  try {
+    const files = await fs.readdir(OUTCOMES_DIR);
+    return files.filter((f) => f.endsWith(".jsonl")).map((f) => f.replace(/\.jsonl$/, ""));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+}
+
+interface GhPrView {
+  state: string; // "OPEN" | "MERGED" | "CLOSED"
+  mergedAt: string | null;
+  closedAt: string | null;
+  createdAt: string;
+  reviews: { state: string }[];
+  statusCheckRollup: { conclusion?: string }[] | null;
+}
+
+/** Visible for testing — the polling fetcher. Returns `null` on any error
+ *  (network, gh-not-installed, PR-not-found, dry-run URL, etc). */
+export type FetchPrView = (targetRepo: string, pr: number) => Promise<GhPrView | null>;
+
+const defaultFetchPrView: FetchPrView = async (targetRepo, pr) => {
+  try {
+    const { stdout } = await execFile(
+      "gh",
+      [
+        "pr",
+        "view",
+        String(pr),
+        "--repo",
+        targetRepo,
+        "--json",
+        "state,mergedAt,closedAt,createdAt,reviews,statusCheckRollup",
+      ],
+      { maxBuffer: 5 * 1024 * 1024 },
+    );
+    return JSON.parse(stdout) as GhPrView;
+  } catch {
+    return null;
+  }
+};
+
+interface PendingPr {
+  agent: string;
+  issue: number;
+  pr: number;
+  prUrl: string;
+  targetRepo: string;
+}
+
+export interface PollOutcomesOpts {
+  staleThresholdDays: number;
+  /** Override `now` for deterministic tests / replay. Defaults to wall clock. */
+  now?: Date;
+  /** Override the gh fetcher for tests. */
+  fetchPrView?: FetchPrView;
+}
+
+export interface PollOutcomesResult {
+  appended: Outcome[];
+  /** PRs that GitHub still reports as open and haven't crossed the stale threshold. */
+  stillPending: number;
+  /** PRs the fetcher couldn't read (network error, gone, dry-run URL we couldn't parse — though those skip earlier). */
+  fetchErrors: number;
+}
+
+/**
+ * Walk every `state/run-*.json` file, find issues whose `outcome` was
+ * `implement` and have a parseable github.com PR URL not yet recorded,
+ * fetch each PR's current state via `gh pr view`, and append a terminal
+ * outcome record if the PR has merged / closed / stalled past
+ * `staleThresholdDays`.
+ *
+ * Cheap (one `gh pr view` per non-terminal PR per `vp-dev` invocation) and
+ * lazy. Failures are swallowed and reported via `result.fetchErrors`; the
+ * caller never aborts a `vp-dev run` over a flaky polling step.
+ */
+export async function pollOutcomes(opts: PollOutcomesOpts): Promise<PollOutcomesResult> {
+  const fetchPrView = opts.fetchPrView ?? defaultFetchPrView;
+  const now = opts.now ?? new Date();
+  const result: PollOutcomesResult = { appended: [], stillPending: 0, fetchErrors: 0 };
+
+  const pendingPrs = await collectPendingPrs();
+  for (const p of pendingPrs) {
+    const view = await fetchPrView(p.targetRepo, p.pr);
+    if (!view) {
+      result.fetchErrors += 1;
+      continue;
+    }
+    const outcome = computeOutcome(p, view, opts.staleThresholdDays, now);
+    if (!outcome) {
+      result.stillPending += 1;
+      continue;
+    }
+    await appendOutcome(outcome);
+    result.appended.push(outcome);
+  }
+  return result;
+}
+
+function computeOutcome(
+  p: PendingPr,
+  view: GhPrView,
+  staleDays: number,
+  now: Date,
+): Outcome | null {
+  const created = new Date(view.createdAt);
+  const stateUp = (view.state ?? "").toUpperCase();
+  let terminalState: TerminalState | null = null;
+  let closedAt: string | null = null;
+
+  if (stateUp === "MERGED") {
+    terminalState = "merged";
+    closedAt = view.mergedAt ?? view.closedAt ?? now.toISOString();
+  } else if (stateUp === "CLOSED") {
+    terminalState = "closed-unmerged";
+    closedAt = view.closedAt ?? now.toISOString();
+  } else {
+    const daysOpenLive = (now.getTime() - created.getTime()) / (1000 * 60 * 60 * 24);
+    if (daysOpenLive > staleDays) {
+      terminalState = "stalled";
+      closedAt = now.toISOString();
+    } else {
+      return null;
+    }
+  }
+
+  const closedDate = new Date(closedAt);
+  const daysOpen =
+    Math.round(
+      ((closedDate.getTime() - created.getTime()) / (1000 * 60 * 60 * 24)) * 10,
+    ) / 10;
+
+  const ciCycles = view.statusCheckRollup
+    ? view.statusCheckRollup.filter(
+        (c) => (c.conclusion ?? "").toUpperCase() === "FAILURE",
+      ).length
+    : null;
+  const reviewerRoundtrips = Array.isArray(view.reviews)
+    ? view.reviews.filter((r) => r.state === "CHANGES_REQUESTED").length
+    : null;
+
+  return {
+    agent: p.agent,
+    issue: p.issue,
+    pr: p.pr,
+    prUrl: p.prUrl,
+    targetRepo: p.targetRepo,
+    terminalState,
+    ciCycles,
+    reviewerRoundtrips,
+    daysOpen: Math.max(0, daysOpen),
+    costUsd: null,
+    closedAt,
+  };
+}
+
+async function collectPendingPrs(): Promise<PendingPr[]> {
+  const recorded = await loadRecordedPrSet();
+  const seen = new Set<string>();
+  const pending: PendingPr[] = [];
+  let entries: string[];
+  try {
+    entries = await fs.readdir(STATE_DIR);
+  } catch {
+    return pending;
+  }
+  for (const name of entries) {
+    if (!name.startsWith("run-") || !name.endsWith(".json")) continue;
+    const filePath = path.join(STATE_DIR, name);
+    let state: RunState;
+    try {
+      const raw = await fs.readFile(filePath, "utf-8");
+      state = JSON.parse(raw) as RunState;
+    } catch {
+      continue;
+    }
+    for (const [issueIdStr, entry] of Object.entries(state.issues)) {
+      if (entry.outcome !== "implement") continue;
+      if (!entry.prUrl || !entry.agentId) continue;
+      const parsed = parsePrUrl(entry.prUrl);
+      if (!parsed) continue; // dry-run URL, malformed link, etc.
+      const issueId = Number(issueIdStr);
+      const key = pendingKey(entry.agentId, parsed.targetRepo, parsed.pr);
+      if (recorded.has(key) || seen.has(key)) continue;
+      seen.add(key);
+      pending.push({
+        agent: entry.agentId,
+        issue: issueId,
+        pr: parsed.pr,
+        prUrl: entry.prUrl,
+        targetRepo: parsed.targetRepo,
+      });
+    }
+  }
+  return pending;
+}
+
+function pendingKey(agent: string, targetRepo: string, pr: number): string {
+  return `${agent}|${targetRepo}|${pr}`;
+}
+
+async function loadRecordedPrSet(): Promise<Set<string>> {
+  const set = new Set<string>();
+  const agents = await listOutcomeAgents();
+  for (const agentId of agents) {
+    const outcomes = await readOutcomes(agentId);
+    for (const o of outcomes) set.add(pendingKey(o.agent, o.targetRepo, o.pr));
+  }
+  return set;
+}
+
+/** Per-agent rollup over `state/outcomes/<agent>.jsonl`. */
+export interface AgentStats {
+  agentId: string;
+  runs: number;
+  merged: number;
+  closedUnmerged: number;
+  stalled: number;
+  mergeRate: number; // 0..1
+  medianRework: number | null;
+  costPerMerge: number | null;
+}
+
+export function rollupOutcomes(outcomes: Outcome[]): Omit<AgentStats, "agentId"> {
+  const runs = outcomes.length;
+  let merged = 0;
+  let closedUnmerged = 0;
+  let stalled = 0;
+  const reworks: number[] = [];
+  let totalCost = 0;
+  let costSamples = 0;
+  for (const o of outcomes) {
+    if (o.terminalState === "merged") merged += 1;
+    else if (o.terminalState === "closed-unmerged") closedUnmerged += 1;
+    else if (o.terminalState === "stalled") stalled += 1;
+    const rework = (o.ciCycles ?? 0) + (o.reviewerRoundtrips ?? 0);
+    if (o.ciCycles != null || o.reviewerRoundtrips != null) reworks.push(rework);
+    if (o.costUsd != null) {
+      totalCost += o.costUsd;
+      costSamples += 1;
+    }
+  }
+  return {
+    runs,
+    merged,
+    closedUnmerged,
+    stalled,
+    mergeRate: runs === 0 ? 0 : merged / runs,
+    medianRework: median(reworks),
+    costPerMerge: merged === 0 || costSamples === 0 ? null : totalCost / merged,
+  };
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) return (sorted[mid - 1] + sorted[mid]) / 2;
+  return sorted[mid];
+}
+
+export async function loadAllAgentStats(): Promise<AgentStats[]> {
+  const agents = await listOutcomeAgents();
+  const out: AgentStats[] = [];
+  for (const agentId of agents) {
+    const outcomes = await readOutcomes(agentId);
+    out.push({ agentId, ...rollupOutcomes(outcomes) });
+  }
+  return out;
+}


### PR DESCRIPTION
Closes #36.

## Summary

Salvage of orphan branch `vp-dev/agent-75a0/issue-36`: agent-75a0 pushed this branch during `run-2026-05-02T06-32-08-433Z` but the orchestrator hit the parse-error class tracked in #49 (`No fenced \`\`\`json\`\`\` block`) before `gh pr create` ran. The single commit on the branch is well-scoped and matches the issue plan.

## What landed (from `7890ce2`)

- New `src/state/outcomes.ts`: `Outcome` schema, `pollOutcomes` (walks `state/run-*.json` for `implement` outcomes with parseable github.com PR URLs, fetches each PR's state once via `gh pr view`, appends merged / closed-unmerged / stalled records to `state/outcomes/<agent>.jsonl`), and `rollupOutcomes` for per-agent stats. Append-only + dedup on `(agent, repo, pr)` keep re-runs idempotent.
- `vp-dev run` polls outcomes before the setup preview. Failures are swallowed onto stderr — outcome metrics are advisory and must never block a run.
- `--stalled-threshold-days <n>` flag (default 14) on `run` and `agents stats`.
- `vp-dev agents stats` subcommand: human-readable table + `--json` rollup, `--no-poll` for offline reporting.
- `costUsd` stays `null` until #34 (cost ceilings) lands.

Unblocks #31 (merge/retire decisions), #34 (cost-ceiling defaults), #35 (triage rubric tuning).

## Salvage context

This PR was opened by hand because the agent never got to `gh pr create` — see #49 for the parse-error class that lost 4/11 agents in the same run. Diff and commit unchanged from agent-75a0's push.

## Test plan

- [ ] CI green (`npm ci && npm run typecheck && npm run build`).
- [ ] `vp-dev agents stats` works on a repo with no `state/outcomes/` (cold start).
- [ ] `vp-dev agents stats --no-poll` works offline.
- [ ] Re-running `pollOutcomes` is idempotent (no duplicate entries).
