### PR TITLE
fix(parser): resilient extractEnvelope — handles prose, nested objects, untagged fences (#49)

### DIFF
--- a/src/agent/parseResult.ts
+++ b/src/agent/parseResult.ts
@@ -7,53 +7,99 @@ export interface ParseOutcome {
   raw?: string;
 }
 
-const FENCED_JSON_RE = /```json\s*\n([\s\S]*?)\n```/gi;
+const FENCED_RE = /```(?:json)?\s*\n?([\s\S]*?)\n?```/gi;
 
 export function extractEnvelope(finalMessage: string): ParseOutcome {
-  const candidates = collectFencedBlocks(finalMessage);
+  const candidates = collectCandidates(finalMessage);
 
   if (candidates.length === 0) {
-    const inlineCandidate = trySpliceObject(finalMessage);
-    if (inlineCandidate) candidates.push(inlineCandidate);
+    return { ok: false, error: "No JSON envelope found in final assistant message." };
   }
 
-  if (candidates.length === 0) {
-    return { ok: false, error: "No fenced ```json``` block found in final assistant message." };
+  let lastSchemaError: string | undefined;
+  let lastSchemaRaw: string | undefined;
+  let lastJsonError: string | undefined;
+  let lastJsonRaw: string | undefined;
+
+  for (let i = candidates.length - 1; i >= 0; i--) {
+    const raw = candidates[i];
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      lastJsonError = (err as Error).message;
+      lastJsonRaw = raw;
+      continue;
+    }
+    const result = ResultEnvelopeSchema.safeParse(parsed);
+    if (result.success) {
+      return { ok: true, envelope: result.data, raw };
+    }
+    lastSchemaError = result.error.message;
+    lastSchemaRaw = raw;
   }
 
-  const raw = candidates[candidates.length - 1];
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (err) {
-    return { ok: false, error: `JSON parse failed: ${(err as Error).message}`, raw };
+  if (lastSchemaError !== undefined) {
+    return { ok: false, error: `Schema validation failed: ${lastSchemaError}`, raw: lastSchemaRaw };
   }
-  const result = ResultEnvelopeSchema.safeParse(parsed);
-  if (!result.success) {
-    return { ok: false, error: `Schema validation failed: ${result.error.message}`, raw };
-  }
-  return { ok: true, envelope: result.data, raw };
+  return { ok: false, error: `JSON parse failed: ${lastJsonError}`, raw: lastJsonRaw };
 }
 
-function collectFencedBlocks(message: string): string[] {
+function collectCandidates(message: string): string[] {
   const out: string[] = [];
-  let m: RegExpExecArray | null;
-  FENCED_JSON_RE.lastIndex = 0;
-  while ((m = FENCED_JSON_RE.exec(message)) !== null) {
-    out.push(m[1].trim());
+
+  const trimmed = message.trim();
+  if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+    out.push(trimmed);
   }
+
+  let m: RegExpExecArray | null;
+  FENCED_RE.lastIndex = 0;
+  while ((m = FENCED_RE.exec(message)) !== null) {
+    const inner = m[1].trim();
+    if (inner) out.push(inner);
+  }
+
+  const balanced = lastBalancedObject(message);
+  if (balanced) out.push(balanced);
+
   return out;
 }
 
-function trySpliceObject(message: string): string | null {
-  const start = message.lastIndexOf("{");
-  const end = message.lastIndexOf("}");
-  if (start < 0 || end < 0 || end <= start) return null;
-  const candidate = message.slice(start, end + 1);
-  try {
-    JSON.parse(candidate);
-    return candidate;
-  } catch {
-    return null;
+function lastBalancedObject(message: string): string | null {
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escape = false;
+  let lastObject: string | null = null;
+  for (let i = 0; i < message.length; i++) {
+    const ch = message[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (inString) {
+      if (ch === "\\") escape = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === "{") {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (ch === "}") {
+      depth--;
+      if (depth === 0 && start >= 0) {
+        lastObject = message.slice(start, i + 1);
+        start = -1;
+      } else if (depth < 0) {
+        depth = 0;
+        start = -1;
+      }
+    }
   }
+  return lastObject;
 }


### PR DESCRIPTION
Closes #49.

## Summary

Replaces the strict `extractEnvelope` parser with a resilient one. The old parser produced `"No fenced \`\`\`json\`\`\` block found in final assistant message."` for **4/11 agents** in `run-2026-05-02T06-32-08-433Z` (~$11 burned with no work salvaged from 3 of them).

This fix is the **smallest** of the three layers in #49 — the parser change alone. Diagnostic capture and the reconciliation pass are deferred.

## Three concrete failure shapes the old parser couldn't handle

1. **Naive splice** — `lastIndexOf("{") / lastIndexOf("}")` breaks on any prose containing `{` before the envelope ("edited the `{foo}` placeholder…") and on nested objects (slice spans the wrong opening brace).
2. **Tag-required fence regex** — `/```json\s*\n…/` silently rejected agents that emitted untagged ` ``` ` blocks.
3. **First-match-wins** — when an early fenced block parsed but failed schema validation, the function returned that error without trying any later candidate. A real envelope further down was ignored.

## What changed

- `collectCandidates` gathers: bare-object (when the whole trimmed message is `{…}`), every fenced block with optional `json` tag, and a forward-scan brace-balanced last object (string-aware: tracks `"` quotes, handles `\\"` escapes, only zeroes depth at top-level closures).
- Iterates candidates **last-to-first**, returns the first one that both parses AND validates against `ResultEnvelopeSchema`.
- Error surface picks the most specific diagnostic: `Schema validation failed: …` if any candidate parsed; `JSON parse failed: …` if none did; `No JSON envelope found in final assistant message.` only when `collectCandidates` returns empty.

## Smoke tests (10 cases, all pass)

```
✓ bare json object only
✓ fenced json with tag
✓ fenced no tag                              ← regression shape #2
✓ prose with { in it before envelope         ← regression shape #1
✓ nested object with memoryUpdate            ← regression shape #1
✓ no envelope at all                         (correctly errors)
✓ malformed envelope                         (correctly errors with diagnostic)
✓ multiple fenced — pick last valid          ← regression shape #3
✓ pushback shape
✓ envelope after long prose with stray }
```

## Out of scope (still in #49)

- **Diagnostic capture** — log `finalText` (truncated) into `agent.completed` when `parseError` fires, so future failures are debuggable without rerunning. Trivial follow-up; #49 stays open.
- **Reconciliation pass** — when `parseError` does fire, query branch / PR state and reconstruct envelope (avoid orphan branches like `vp-dev/agent-75a0/issue-36`). Larger change; defer until we see whether the parser fix alone closes the gap.
- **Summarizer / split / dispatcher** all have their own loose parsers (`parseJsonLoose` etc.). Those were already more robust than `extractEnvelope` — sharing one parser is a follow-up cleanup, not a fix.

## Test plan

- [ ] CI green (`npm ci && npm run typecheck && npm run build`).
- [ ] Next `vp-dev` run shows < 36% parse-error rate on agent decisions.
- [ ] No regression on agents that already parsed successfully under the old extractor.
