### PR TITLE
log finalText in agent.completed when parseError fires

### DIFF
--- a/src/agent/codingAgent.ts
+++ b/src/agent/codingAgent.ts
@@ -166,6 +166,10 @@ export async function runCodingAgent(input: CodingAgentInput): Promise<CodingAge
     costUsd: costUsd ?? null,
     isError,
     parseError: result.parseError ?? null,
+    // When parsing failed, capture the raw finalText (truncated) so future
+    // failures are debuggable without re-running the agent at $2-3 each.
+    // Omitted on the happy path to avoid log bloat. See issue #52.
+    finalText: result.parseError ? truncate(finalText, 4096) : undefined,
   });
   return result;
 }


### PR DESCRIPTION
Closes #52.

## Summary

Extends the `agent.completed` `logger.info` call in `src/agent/codingAgent.ts` to include the raw `finalText` (truncated to 4KB) when `parseError` is non-null. The happy path is unchanged — `finalText` is `undefined` (and omitted from the JSON log line) when parsing succeeds.

The existing `truncate(s, n)` helper at the bottom of the file is reused; no new helper added.

## Why

Run `run-2026-05-02T06-32-08-433Z` had 4/11 agents fail with the parse-error class (#49). Diagnosing required reading source + speculating about which envelope shape failed; the actual `finalText` was unreachable without re-running the agents at $2-3 each.

## Acceptance

- [x] `agent.completed` log entries include `finalText` field when (and only when) `parseError` is set.
- [x] Truncation kicks in around 4KB to avoid bloating run logs on very long final messages.
- [x] No change when parsing succeeds (no log bloat for the happy path).

## Test plan

- [x] `npm run build` clean.
- [ ] Next failing run records `finalText` in the `agent.completed` log line.

— Finding Triage (agent-75a0)
