### PR TITLE
feat(agent): inject feature-plans/issue-N-*.md content into coding agent seed (Phase 1 of #38)

### DIFF
--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -1,3 +1,5 @@
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
 import { readAgentClaudeMd } from "./specialization.js";
 import { renderWorkflow, type WorkflowVars } from "./workflow.js";
 import type { AgentRecord } from "../types.js";
@@ -13,13 +15,65 @@ export async function buildAgentSystemPrompt(opts: {
   const label = opts.agent.name
     ? `${opts.agent.name} [${opts.agent.agentId}]`
     : opts.agent.agentId;
-  return [
+
+  const plan = await readPlanFileForIssue({
+    worktreePath: opts.workflow.worktreePath,
+    issueId: opts.workflow.issueId,
+  });
+
+  const sections: string[] = [
     `# CLAUDE.md (agent ${label} — evolving specialization)`,
     "",
     claudeMd.trim(),
     "",
-    "---",
-    "",
-    workflow.trim(),
-  ].join("\n");
+  ];
+
+  if (plan) {
+    sections.push(
+      "---",
+      "",
+      `# Plan for issue #${opts.workflow.issueId} (from feature-plans/${plan.filename})`,
+      "",
+      "This plan was prepared in advance for this issue. Treat it as authoritative design guidance — read it before deciding pushback vs implement, and prefer its file-by-file layout over reinventing one. Push back if the plan is wrong on contact with code; otherwise follow it.",
+      "",
+      plan.content.trim(),
+      "",
+    );
+  }
+
+  sections.push("---", "", workflow.trim());
+  return sections.join("\n");
+}
+
+/**
+ * Look for a plan file matching the convention `feature-plans/issue-<N>-*.md`
+ * inside the agent's worktree. The worktree is always a checkout of the
+ * target repo, so any committed plan file at this path is available without
+ * a network call. Returns null if no plan file exists — equivalent to the
+ * "Not needed" sentinel from the issue-body convention; the agent simply
+ * reads the issue body for itself in that case.
+ */
+async function readPlanFileForIssue(opts: {
+  worktreePath: string;
+  issueId: number;
+}): Promise<{ filename: string; content: string } | null> {
+  const dir = path.join(opts.worktreePath, "feature-plans");
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dir);
+  } catch {
+    return null;
+  }
+  const prefix = `issue-${opts.issueId}-`;
+  const matches = entries
+    .filter((e) => e.startsWith(prefix) && e.endsWith(".md"))
+    .sort();
+  if (matches.length === 0) return null;
+  const filename = matches[0];
+  try {
+    const content = await fs.readFile(path.join(dir, filename), "utf8");
+    return { filename, content };
+  } catch {
+    return null;
+  }
 }

--- a/src/agent/workflow.ts
+++ b/src/agent/workflow.ts
@@ -34,6 +34,8 @@ Run BOTH:
 
 Per CLAUDE.md "Issue Analysis": comments are where reviewers add follow-up scope or push back on the original framing. Fold every comment into the analysis.
 
+If a \`# Plan for issue #${v.issueId} (from feature-plans/...)\` section appears above this workflow in your seed, that plan was prepared in advance — treat it as authoritative design guidance, read it before Step 2, and prefer its file-by-file layout over reinventing one. If no such section is present, either the issue body's \`## Plan\` is "Not needed — coding agent can start directly from the issue body" or the convention path was empty; in either case proceed from the issue body alone.
+
 ## Step 2 — Apply judgment rules from CLAUDE.md
 - Push-Back Discipline: faulty premise → push back BEFORE acting.
 - Smallest-Solution Discipline: minimum change first; flag larger proposals.


### PR DESCRIPTION
Closes #38 — Phase 1 only.

## Scope

Per the prior pushback comment on this issue (Smallest-Solution Discipline + the new "Push back on issues that bundle multiple architectural layers into one PR" memory rule), this PR ships **only Phase 1: plan consumption**. Phases 2 (Opus planner + complexity gate + `"planning"` status + parallel orchestrator branches) and 3 (`vp-dev plan` CLI + cost surfacing) are deferred and can ship independently.

## What changed

`src/agent/prompt.ts`
- `buildAgentSystemPrompt()` now reads `feature-plans/issue-<N>-*.md` from the agent's worktree (always a checkout of the target repo, so the file is on disk without any extra GitHub call).
- When a match exists, its content is appended as a `# Plan for issue #<N> (from feature-plans/<file>.md)` section between the agent's CLAUDE.md and the rendered workflow, with a one-paragraph framing telling the agent to treat it as authoritative design guidance.
- When no match exists, nothing is injected — equivalent to the issue-body convention's "Not needed" sentinel from the agent's perspective; the agent reads the issue body directly via `gh issue view`.

`src/agent/workflow.ts`
- Step 1 of the rendered workflow gains one paragraph pointing the agent at the injected `# Plan for issue #<N>` section (if present) and explaining what it means if the section is absent.

## Why this is the minimum change

The seven existing hand-written plan files in `feature-plans/` (issues #31, #32, #33, #34, #35, #36, #38) start paying off on the next run with no other infrastructure. Humans can keep writing plan files manually. Phases 2 and 3 (planner generation + CLI surface) become strictly additive — they need a consumer, and this PR provides the consumer.

## Out of scope (deferred to Phase 2 + Phase 3)

- Haiku complexity gate
- Opus planner (`src/agent/planner.ts`)
- New `IssueStatus` value `"planning"`, `RunIssueEntry.planPath`, `markPlanning()` helper
- `runOrchestrator()` parallel planning branch
- `vp-dev plan <issue#>` subcommand
- `SetupPreview` planning-cost surfacing

## What was NOT done relative to the original plan

- No `state/plans/<runId>/` shadow directory — Phase 1 reads from the worktree directly. If Phase 2 needs a pre-PR shadow path, it can add it then.
- No issue-body `## Plan` parsing — the convention path glob (`feature-plans/issue-<N>-*.md`) is a tighter, lower-failure-mode signal than parsing markdown.

## Verification

- `npm run build` passes (`tsc` clean).
- Sanity-tested at runtime: with `issueId: 38`, the seed contains `# Plan for issue #38 (from feature-plans/issue-38-planning-mode.md)` followed by the plan content, ordered before `# Workflow`. With `issueId: 99999` (no matching file), no plan section is injected; the workflow's Step 1 hint still references the convention so the agent knows what to expect.

## Followups

If you'd like Phase 2 (planner) or Phase 3 (CLI) implemented next, file as separate issues and link from #38 — or reopen #38 with a tightened scope.

— Calldata Decode (agent-d0eb)
