### PR TITLE
feat(reconcile): rebuild envelope from git/gh state on parser failure (#53)

### DIFF
--- a/src/agent/codingAgent.ts
+++ b/src/agent/codingAgent.ts
@@ -7,6 +7,7 @@ import {
 } from "@anthropic-ai/claude-agent-sdk";
 import { buildAgentSystemPrompt } from "./prompt.js";
 import { extractEnvelope } from "./parseResult.js";
+import { reconcileFromState, type ReconcileState } from "./reconcile.js";
 import type { AgentRecord, ResultEnvelope } from "../types.js";
 import type { Logger } from "../log/logger.js";
 
@@ -32,6 +33,19 @@ export interface CodingAgentResult {
   isError: boolean;
   errorReason?: string;
   toolUseTrace: { tool: string; input: string }[];
+  /**
+   * Set when extractEnvelope failed and the orchestrator queried git/gh state
+   * to rebuild an envelope. Values:
+   *  - "pr-found" — envelope was synthesized from an open PR; `parseError`
+   *    stays populated as a soft warning.
+   *  - "branch-only" — branch on remote without an open PR; `branchUrl` is
+   *    available in run logs (`agent.reconcile_orphan_branch`); envelope
+   *    stays undefined.
+   *  - "no-state" / "error" — original parseError behavior preserved.
+   */
+  reconciled?: ReconcileState;
+  /** Populated when reconciliation found a branch on remote. */
+  branchUrl?: string;
 }
 
 const ALLOWED_NATIVE_TOOLS = ["Bash", "Read", "Edit", "Write", "Grep", "Glob"];
@@ -146,26 +160,59 @@ export async function runCodingAgent(input: CodingAgentInput): Promise<CodingAge
 
   const durationMs = Date.now() - start;
   const parsed = extractEnvelope(finalText);
+
+  let envelope = parsed.envelope;
+  const parseError = parsed.ok ? undefined : parsed.error;
+  let reconciled: ReconcileState | undefined;
+  let branchUrl: string | undefined;
+
+  // Reconciliation pass — when extractEnvelope fails, rebuild from git/gh
+  // state so a successful PR / orphan branch isn't lost behind a parse error.
+  // Skipped in dry-run: branch and PR creation are intercepted (rewritten to
+  // `printf`), so no real state exists to reconcile against.
+  if (!parsed.ok && !input.dryRun) {
+    const r = await reconcileFromState({
+      agentId: input.agent.agentId,
+      issueId: input.issueId,
+      targetRepo: input.targetRepo,
+      targetRepoPath: input.targetRepoPath,
+      branchName: input.branchName,
+      parseError: parseError ?? "unknown",
+      logger: input.logger,
+    });
+    reconciled = r.state;
+    branchUrl = r.branchUrl;
+    if (r.reconciledEnvelope) {
+      envelope = r.reconciledEnvelope;
+      // parseError intentionally retained: the bug stays visible in logs and
+      // CodingAgentResult; reconciliation just stops it from corrupting status.
+    }
+  }
+
   const result: CodingAgentResult = {
-    envelope: parsed.envelope,
+    envelope,
     finalText,
-    parseError: parsed.ok ? undefined : parsed.error,
+    parseError,
     durationMs,
     costUsd,
     isError,
     errorReason,
     toolUseTrace,
+    reconciled,
+    branchUrl,
   };
 
   input.logger.info("agent.completed", {
     agentId: input.agent.agentId,
     issueId: input.issueId,
-    decision: parsed.envelope?.decision ?? null,
-    prUrl: parsed.envelope?.prUrl ?? null,
+    decision: envelope?.decision ?? null,
+    prUrl: envelope?.prUrl ?? null,
     durationMs,
     costUsd: costUsd ?? null,
     isError,
-    parseError: result.parseError ?? null,
+    parseError: parseError ?? null,
+    reconciled: reconciled ?? null,
+    branchUrl: branchUrl ?? null,
   });
   return result;
 }

--- a/src/agent/reconcile.ts
+++ b/src/agent/reconcile.ts
@@ -1,0 +1,173 @@
+import { promisify } from "node:util";
+import { execFile as execFileCb } from "node:child_process";
+import type { Logger } from "../log/logger.js";
+import type { ResultEnvelope } from "../types.js";
+
+const execFile = promisify(execFileCb);
+
+export interface ReconcileInput {
+  agentId: string;
+  issueId: number;
+  /** GitHub `owner/repo`. */
+  targetRepo: string;
+  /** Local clone of the target repo (worktree's host path). */
+  targetRepoPath: string;
+  /** `vp-dev/<agentId>/issue-<n>` per createWorktree convention. */
+  branchName: string;
+  /** The original `extractEnvelope` failure — preserved as a soft warning. */
+  parseError: string;
+  logger: Logger;
+}
+
+export type ReconcileState = "pr-found" | "branch-only" | "no-state" | "error";
+
+export interface ReconcileResult {
+  state: ReconcileState;
+  /** Populated when state === "pr-found": a synthesized envelope to keep status integrity. */
+  reconciledEnvelope?: ResultEnvelope;
+  /** Populated when state ∈ {"pr-found", "branch-only"}. */
+  branchUrl?: string;
+  /** Populated when state === "pr-found". */
+  prUrl?: string;
+  /** Human-readable note for logs / orchestrator. */
+  note: string;
+}
+
+/**
+ * Rebuild a result envelope from git/gh state when extractEnvelope fails.
+ *
+ * Bounded by spec (#53 acceptance): exactly one `git ls-remote` and at most
+ * one `gh pr list` per call, no polling. Cases:
+ *
+ *  - **pr-found** — branch on remote + open PR exists. Returns a synthesized
+ *    envelope `{decision: "implement", prUrl, reason: "Reconciled from PR
+ *    state ..."}`. The original parseError stays in CodingAgentResult so the
+ *    bug remains visible.
+ *  - **branch-only** — branch on remote, no open PR. Returns branchUrl so the
+ *    orphan branch is grep-able from the run log; envelope stays undefined
+ *    (caller treats as failure but with cleanup info attached). We do NOT
+ *    auto-create the PR: a stub-bodied PR with no agent context is worse than
+ *    a flagged orphan branch the user can salvage by hand in one command.
+ *  - **no-state** — no branch on remote. Original parseError behavior preserved.
+ *  - **error** — git or gh tooling itself failed. Original parseError behavior
+ *    preserved; failure logged as a warning.
+ */
+export async function reconcileFromState(input: ReconcileInput): Promise<ReconcileResult> {
+  // 1. Branch check — does the agent's expected branch exist on remote?
+  let branchExists: boolean;
+  try {
+    const { stdout } = await execFile(
+      "git",
+      ["ls-remote", "--heads", "origin", input.branchName],
+      { cwd: input.targetRepoPath },
+    );
+    branchExists = stdout.trim().length > 0;
+  } catch (err) {
+    input.logger.warn("agent.reconcile_git_failed", {
+      agentId: input.agentId,
+      issueId: input.issueId,
+      branch: input.branchName,
+      err: errMessage(err),
+    });
+    return { state: "error", note: "git ls-remote failed; preserving parseError." };
+  }
+
+  if (!branchExists) {
+    return { state: "no-state", note: "No branch on remote; preserving parseError." };
+  }
+
+  const branchUrl = `https://github.com/${input.targetRepo}/tree/${encodeURIComponent(
+    input.branchName,
+  )}`;
+
+  // 2. PR check — open PR for this branch?
+  let prUrl: string | undefined;
+  try {
+    const { stdout } = await execFile(
+      "gh",
+      [
+        "pr",
+        "list",
+        "--repo",
+        input.targetRepo,
+        "--head",
+        input.branchName,
+        "--state",
+        "open",
+        "--json",
+        "url",
+      ],
+      { cwd: input.targetRepoPath },
+    );
+    const arr = JSON.parse(stdout) as unknown;
+    if (Array.isArray(arr) && arr.length > 0) {
+      const first = arr[0] as { url?: unknown };
+      if (typeof first.url === "string") prUrl = first.url;
+    }
+  } catch (err) {
+    // Branch exists but PR check failed (network/auth/etc). Surface as
+    // branch-only so the user gets the branchUrl and can verify by hand.
+    input.logger.warn("agent.reconcile_gh_failed", {
+      agentId: input.agentId,
+      issueId: input.issueId,
+      branch: input.branchName,
+      err: errMessage(err),
+    });
+    return {
+      state: "branch-only",
+      branchUrl,
+      note: `gh pr list failed; branch exists at ${branchUrl}. Verify with: gh pr list --repo ${input.targetRepo} --head ${input.branchName}`,
+    };
+  }
+
+  if (prUrl) {
+    const reconciledEnvelope: ResultEnvelope = {
+      decision: "implement",
+      reason: `Reconciled from PR state (parser failed: ${truncate(input.parseError, 200)})`,
+      prUrl,
+      memoryUpdate: { addTags: [] },
+    };
+    input.logger.info("agent.reconciled", {
+      agentId: input.agentId,
+      issueId: input.issueId,
+      branch: input.branchName,
+      prUrl,
+      parseError: truncate(input.parseError, 200),
+    });
+    return {
+      state: "pr-found",
+      reconciledEnvelope,
+      prUrl,
+      branchUrl,
+      note: "Reconciled to implement decision from open PR.",
+    };
+  }
+
+  // Branch exists, no open PR — orphan. Don't auto-create: a stub PR with no
+  // agent context is worse than a flagged orphan the user can salvage with
+  // one `gh pr create` command. Surface branchUrl in a structured warn log so
+  // it's grep-able from the run JSONL.
+  const salvageHint = `gh pr create --repo ${input.targetRepo} --base main --head ${input.branchName} --title "<title>" --body "Closes #${input.issueId}"`;
+  input.logger.warn("agent.reconcile_orphan_branch", {
+    agentId: input.agentId,
+    issueId: input.issueId,
+    branch: input.branchName,
+    branchUrl,
+    salvageHint,
+    parseError: truncate(input.parseError, 200),
+  });
+  return {
+    state: "branch-only",
+    branchUrl,
+    note: `Branch pushed without PR. Salvage: ${salvageHint}`,
+  };
+}
+
+function errMessage(err: unknown): string {
+  const e = err as { stderr?: string; message?: string };
+  return e.stderr ?? e.message ?? String(err);
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n - 3) + "..." : s;
+}

--- a/src/agent/runIssueCore.ts
+++ b/src/agent/runIssueCore.ts
@@ -35,6 +35,10 @@ export interface RunIssueCoreResult {
   summarySkipReason?: string;
   worktreePath?: string;
   branchName?: string;
+  /** See CodingAgentResult.reconciled. */
+  reconciled?: string;
+  /** See CodingAgentResult.branchUrl. */
+  branchUrl?: string;
 }
 
 export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCoreResult> {
@@ -152,6 +156,8 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
       summarySkipReason,
       worktreePath: worktree?.path,
       branchName: worktree?.branch,
+      reconciled: result.reconciled,
+      branchUrl: result.branchUrl,
     };
   } finally {
     if (worktree) {

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -308,11 +308,18 @@ async function runOneIssue(opts: {
       commentUrl: env.commentUrl,
     };
   } else {
+    // Reconciliation found a branch on remote without a PR — surface it in
+    // the failure record so the user can salvage with one `gh pr create`
+    // instead of grepping run logs for the orphan branch name.
+    const baseError = result.parseError ?? result.errorReason ?? "Unknown agent failure";
+    const error = result.branchUrl
+      ? `${baseError} | orphan branch: ${result.branchUrl}`
+      : baseError;
     opts.state.issues[String(opts.issue.id)] = {
       status: "failed",
       agentId: opts.agent.agentId,
       outcome: "error",
-      error: result.parseError ?? result.errorReason ?? "Unknown agent failure",
+      error,
     };
   }
 


### PR DESCRIPTION
Closes #53.

## Summary

Layer 2 of #49: when `extractEnvelope` returns `parseError`, the agent's expected branch + PR are now queried before the orchestrator marks the agent `errored`. This closes the two status-integrity gaps from `run-2026-05-02T06-32-08-433Z` that the parser fix in #51 alone did not address.

- **PR landed, status errored** (agent-aa26 #39 → PR #48): synthesized envelope with `decision="implement"`, `prUrl=<resolved>` is now produced when an open PR is found for the agent's branch.
- **Branch pushed, no PR** (agent-75a0 #36): branch is logged via `agent.reconcile_orphan_branch` (with `branchUrl` and a copy-paste salvage command) AND surfaced into the failed issue's `error` string in run state, so the orphan is grep-able from both the JSONL log and the run-state JSON.

The parser fix in #51 reduces frequency; this is the safety net for whatever still slips through.

## What changed

- **New module** `src/agent/reconcile.ts` — `reconcileFromState({agentId, issueId, targetRepo, targetRepoPath, branchName, parseError, logger})` returns `{state, reconciledEnvelope?, branchUrl?, prUrl?, note}`. Bounded per #53 acceptance: exactly one `git ls-remote --heads` + at most one `gh pr list --state open --json url`. No polling.
- **`src/agent/codingAgent.ts`** — calls `reconcileFromState` after `extractEnvelope` fails, only outside dry-run (in dry-run, push/PR are intercepted to `printf`, so no real state exists). `parseError` stays in `CodingAgentResult` even on successful reconciliation — the bug remains visible in logs. New `reconciled` + `branchUrl` log fields on `agent.completed`.
- **`src/agent/runIssueCore.ts`** — propagates `reconciled` + `branchUrl` so the orchestrator sees them.
- **`src/orchestrator/orchestrator.ts`** — when no envelope is produced (orphan-branch or true failure), the failed-issue `error` field now includes `| orphan branch: <url>` if reconciliation found one. Cleanup is one `gh pr create` away.

## Five reconciliation branches

| state          | trigger                                | result                                                                |
| -------------- | -------------------------------------- | --------------------------------------------------------------------- |
| `pr-found`     | branch on remote + open PR             | synthesize `decision="implement"`, `prUrl`, `reason` notes the parser failure |
| `branch-only`  | branch on remote, no open PR           | warn-log `agent.reconcile_orphan_branch` with `branchUrl` + salvageHint; no envelope |
| `no-state`     | no branch on remote                    | original parseError behavior preserved                                |
| `error`        | `git ls-remote` itself failed          | warn `agent.reconcile_git_failed`; preserve parseError                |
| (gh-fail)      | branch found but `gh pr list` failed   | warn `agent.reconcile_gh_failed`; downgrade to `branch-only`          |

We deliberately do **not** auto-create the PR in `branch-only`: a stub-bodied PR with no agent context is worse than a flagged orphan the user clears with one shell command.

## Acceptance (per #53)

- [x] `agent.completed` for an agent that errored at parse time but pushed a PR records `decision="implement"`, `prUrl=<url>`, `parseError=<original error>` (as warning).
- [x] `agent.completed` for an agent that pushed a branch without a PR flags `branchUrl` so cleanup is one command. (Auto-create deferred — stub PR is worse than the flag.)
- [x] No false reconciliation when neither branch nor PR exists (`no-state` returns no envelope).
- [x] Reconciliation calls are bounded: one `git ls-remote` + at most one `gh pr list` per failure, no loops.

## Test plan

- [x] `npm run build` clean (no test runner in repo).
- [x] Smoke-tested 14 assertions across all 5 branches with stubbed `git`/`gh` binaries on `PATH` (PR-found, branch-only, no-state, git-fail, gh-fail). All pass.
- [ ] Next live `vp-dev` run that hits a parse error shows `reconciled` field populated in `agent.completed`; PR-found case has `decision="implement"` despite parseError.

## Out of scope

- Layer 1 of #49 (diagnostic `finalText` capture in `agent.completed`) — separate concern, untouched here.
- Sharing the parser between `codingAgent` / `summarizer` / `dispatcher` / `split` — already noted as cleanup in #51.

— Khwarizmi (agent-08c4)
