### PR TITLE
feat(outcomes): track per-agent PR merge / rework / stall metrics

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,7 +34,15 @@ import {
   type PruneProposal,
   type ApplyResult as PruneApplyResult,
 } from "./agent/prune.js";
+import {
+  loadAllOutcomes,
+  pollOutcomes,
+  rollupOutcomes,
+  type AgentRollup,
+} from "./state/outcomes.js";
 import type { AgentRecord, IssueRangeSpec, IssueSummary } from "./types.js";
+
+const DEFAULT_STALLED_THRESHOLD_DAYS = 14;
 
 const DEFAULT_MAX_TICKS = 200;
 
@@ -52,6 +60,12 @@ export function buildCli(): Command {
     .option("--resume", "Resume the most recent unfinished run")
     .option("--dry-run", "Intercept comment / PR / push tools with synthetic responses")
     .option("--max-ticks <n>", "Safety cap on scheduling ticks", parsePositive, DEFAULT_MAX_TICKS)
+    .option(
+      "--stalled-threshold-days <n>",
+      "Days a PR may sit open before outcome polling marks it 'stalled'",
+      parsePositive,
+      DEFAULT_STALLED_THRESHOLD_DAYS,
+    )
     .option("--verbose", "Mirror a colorized subset of events to stderr")
     .option("--yes", "Auto-approve the setup preview (required for non-TTY environments)")
     .action(async (opts) => {
@@ -133,6 +147,25 @@ export function buildCli(): Command {
         .action(async (opts) => {
           await cmdAgentsPrune(opts);
         }),
+    )
+    .addCommand(
+      new Command("stats")
+        .description("Per-agent rollup of PR outcomes (merge rate, median rework, median CI cycles).")
+        .option("--json", "Print machine-readable JSON")
+        .option(
+          "--poll",
+          "Refresh outcomes from GitHub before printing (one `gh pr view` per non-terminal PR).",
+        )
+        .option(
+          "--stalled-threshold-days <n>",
+          "Days a PR may sit open before --poll marks it 'stalled'",
+          parsePositive,
+          DEFAULT_STALLED_THRESHOLD_DAYS,
+        )
+        .option("--all", "Include archived (split-parent) agents")
+        .action(async (opts) => {
+          await cmdAgentsStats(opts);
+        }),
     );
   program.addCommand(agentsCmd);
 
@@ -147,6 +180,7 @@ interface RunOpts {
   resume?: boolean;
   dryRun?: boolean;
   maxTicks: number;
+  stalledThresholdDays: number;
   verbose?: boolean;
   yes?: boolean;
 }
@@ -237,6 +271,7 @@ async function cmdRun(opts: RunOpts): Promise<void> {
   try {
     await pruneWorktrees(repoPath);
     await pruneStaleAgentBranches(repoPath, opts.targetRepo, logger);
+    await pollOutcomesLazy({ logger, staleThresholdDays: opts.stalledThresholdDays });
     await runOrchestrator({
       state,
       issues: open,
@@ -256,6 +291,29 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     await logger.close();
   }
   process.stdout.write(`Run ${runId} log: logs/${runId}.jsonl\n`);
+}
+
+/**
+ * Lazy outcome poll on `vp-dev run`. Wrapped in try/catch so a transient
+ * `gh` failure (network down, auth blip) never blocks the run.
+ */
+async function pollOutcomesLazy(opts: {
+  logger: Logger;
+  staleThresholdDays: number;
+}): Promise<void> {
+  try {
+    const result = await pollOutcomes({
+      staleThresholdDays: opts.staleThresholdDays,
+      onWarn: (msg) => opts.logger.warn("outcomes.poll_warn", { msg }),
+    });
+    opts.logger.info("outcomes.polled", {
+      appended: result.appended.length,
+      pending: result.pendingPrs,
+      errors: result.errors,
+    });
+  } catch (err) {
+    opts.logger.warn("outcomes.poll_failed", { err: (err as Error).message });
+  }
 }
 
 async function runResume(opts: RunOpts): Promise<void> {
@@ -302,6 +360,7 @@ async function runResume(opts: RunOpts): Promise<void> {
   });
   try {
     await pruneStaleAgentBranches(repoPath, state.targetRepo, logger);
+    await pollOutcomesLazy({ logger, staleThresholdDays: opts.stalledThresholdDays });
     await runOrchestrator({
       state,
       issues,
@@ -853,6 +912,75 @@ async function cmdAgentsPick(opts: PickOpts): Promise<void> {
   if (result.newAgentsToMint > 0) {
     process.stdout.write(`  + ${result.newAgentsToMint} fresh general agent(s) needed\n`);
   }
+}
+
+interface AgentsStatsOpts {
+  json?: boolean;
+  poll?: boolean;
+  all?: boolean;
+  stalledThresholdDays: number;
+}
+
+async function cmdAgentsStats(opts: AgentsStatsOpts): Promise<void> {
+  if (opts.poll) {
+    const result = await pollOutcomes({
+      staleThresholdDays: opts.stalledThresholdDays,
+      onWarn: (msg) => process.stderr.write(`WARN: ${msg}\n`),
+    });
+    if (!opts.json) {
+      process.stderr.write(
+        `Polled outcomes: appended=${result.appended.length} pending=${result.pendingPrs} errors=${result.errors}\n`,
+      );
+    }
+  }
+
+  const reg = await loadRegistry();
+  const visible = opts.all ? reg.agents : reg.agents.filter((a) => !a.archived);
+  if (visible.length === 0) {
+    if (opts.json) {
+      process.stdout.write(JSON.stringify({ rollups: [] }, null, 2) + "\n");
+      return;
+    }
+    process.stdout.write(
+      opts.all
+        ? "No agents in registry yet.\n"
+        : "No active agents in registry. Pass --all to include archived agents.\n",
+    );
+    return;
+  }
+
+  const outcomesByAgent = await loadAllOutcomes(visible.map((a) => a.agentId));
+  const rollups: AgentRollup[] = visible.map((a) =>
+    rollupOutcomes({
+      agentId: a.agentId,
+      name: a.name,
+      outcomes: outcomesByAgent.get(a.agentId) ?? [],
+    }),
+  );
+
+  // Sort merge-rate desc, then runs desc as a tiebreaker so a 1/1 agent
+  // doesn't outrank a 9/10 agent.
+  rollups.sort((x, y) => y.mergeRate - x.mergeRate || y.runs - x.runs);
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify({ rollups }, null, 2) + "\n");
+    return;
+  }
+
+  // costUsd + $/merge column intentionally absent — populated once cost
+  // tracking lands (see issue #34). Don't stub a dead column.
+  const headers = ["agent", "runs", "merged", "closed", "stalled", "merge-rate", "median-rework", "median-ci"];
+  const rows = rollups.map((r) => [
+    r.name ? `${r.name} (${r.agentId})` : r.agentId,
+    String(r.runs),
+    String(r.merged),
+    String(r.closedUnmerged),
+    String(r.stalled),
+    r.runs === 0 ? "n/a" : `${Math.round(r.mergeRate * 100)}%`,
+    String(r.medianRework),
+    String(r.medianCiCycles),
+  ]);
+  printTable(headers, rows);
 }
 
 function printTable(headers: string[], rows: string[][]): void {

--- a/src/github/gh.ts
+++ b/src/github/gh.ts
@@ -93,3 +93,39 @@ function rangeToIds(from: number, to: number): number[] {
   for (let n = from; n <= to; n++) out.push(n);
   return out;
 }
+
+export interface GhPrState {
+  state: "OPEN" | "MERGED" | "CLOSED" | string;
+  createdAt: string;
+  closedAt: string | null;
+  mergedAt: string | null;
+  reviews: { state?: string }[];
+  // `statusCheckRollup` reflects the *latest commit's* check runs — not a
+  // full history of past failures across re-pushes. Treat ciCycles derived
+  // from this as a lower-bound approximation; refining requires walking
+  // commit history (out of scope until the signal proves noisy).
+  statusCheckRollup: { conclusion?: string }[];
+}
+
+export async function prState(targetRepo: string, prNumber: number): Promise<GhPrState | null> {
+  try {
+    const { stdout } = await execFile(
+      "gh",
+      [
+        "pr",
+        "view",
+        String(prNumber),
+        "--repo",
+        targetRepo,
+        "--json",
+        "state,createdAt,closedAt,mergedAt,reviews,statusCheckRollup",
+      ],
+      { maxBuffer: 5 * 1024 * 1024 },
+    );
+    return JSON.parse(stdout) as GhPrState;
+  } catch (err) {
+    const msg = (err as { stderr?: string; message?: string }).stderr?.toString() ?? "";
+    if (msg.includes("no pull requests found") || msg.includes("Could not resolve")) return null;
+    throw err;
+  }
+}

--- a/src/state/outcomes.ts
+++ b/src/state/outcomes.ts
@@ -1,0 +1,336 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { ensureDir, withFileLock } from "./locks.js";
+import { STATE_DIR, loadRunState } from "./runState.js";
+import { loadRegistry } from "./registry.js";
+import { prState, type GhPrState } from "../github/gh.js";
+import type { RunState } from "../types.js";
+
+export const OUTCOMES_DIR = path.join(STATE_DIR, "outcomes");
+
+export type TerminalState = "merged" | "closed-unmerged" | "stalled";
+
+export interface Outcome {
+  agent: string;
+  issue: number;
+  pr: number;
+  targetRepo: string;
+  terminalState: TerminalState;
+  ciCycles: number;
+  reviewerRoundtrips: number;
+  daysOpen: number;
+  closedAt: string;
+}
+
+export function outcomesFilePath(agentId: string): string {
+  return path.join(OUTCOMES_DIR, `${agentId}.jsonl`);
+}
+
+export async function loadOutcomes(agentId: string): Promise<Outcome[]> {
+  const filePath = outcomesFilePath(agentId);
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+  const out: Outcome[] = [];
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      out.push(JSON.parse(trimmed) as Outcome);
+    } catch {
+      // Skip malformed lines — append-only file may have a partial last line
+      // if a previous write was interrupted; ignore rather than fail polling.
+    }
+  }
+  return out;
+}
+
+export async function appendOutcome(agentId: string, outcome: Outcome): Promise<void> {
+  const filePath = outcomesFilePath(agentId);
+  await ensureDir(path.dirname(filePath));
+  await withFileLock(filePath, async () => {
+    await fs.appendFile(filePath, JSON.stringify(outcome) + "\n");
+  });
+}
+
+/**
+ * Walks past run state files for any PR that landed via an `implement`
+ * envelope, fetches its current GitHub state, and appends a terminal
+ * outcome record once the PR is merged / closed-unmerged / stalled.
+ *
+ * Idempotent: skips PRs already recorded in `state/outcomes/<agentId>.jsonl`.
+ */
+export interface PollOutcomesInput {
+  staleThresholdDays: number;
+  /** Optional: warn handler for transient gh failures. Default: silent. */
+  onWarn?: (msg: string) => void;
+}
+
+export interface PollOutcomesResult {
+  appended: Outcome[];
+  /** PRs polled that are still in a non-terminal, non-stalled state. */
+  pendingPrs: number;
+  /** Polling errors (network, gh CLI). */
+  errors: number;
+}
+
+export async function pollOutcomes(input: PollOutcomesInput): Promise<PollOutcomesResult> {
+  const candidates = await collectCandidatePrs();
+  if (candidates.length === 0) return { appended: [], pendingPrs: 0, errors: 0 };
+
+  const appended: Outcome[] = [];
+  let pendingPrs = 0;
+  let errors = 0;
+
+  // Build per-agent skip-set up front (one read per agent that has any
+  // candidate). Cheap; avoids rereading the JSONL inside the loop.
+  const skipByAgent = new Map<string, Set<string>>();
+  for (const c of candidates) {
+    if (skipByAgent.has(c.agentId)) continue;
+    const existing = await loadOutcomes(c.agentId);
+    skipByAgent.set(
+      c.agentId,
+      new Set(existing.map((o) => `${o.targetRepo}#${o.pr}`)),
+    );
+  }
+
+  for (const c of candidates) {
+    const key = `${c.targetRepo}#${c.prNumber}`;
+    if (skipByAgent.get(c.agentId)?.has(key)) continue;
+
+    let live: GhPrState | null;
+    try {
+      live = await prState(c.targetRepo, c.prNumber);
+    } catch (err) {
+      errors += 1;
+      input.onWarn?.(`pollOutcomes: gh pr view failed for ${key}: ${(err as Error).message}`);
+      continue;
+    }
+    if (!live) {
+      errors += 1;
+      input.onWarn?.(`pollOutcomes: PR ${key} not found`);
+      continue;
+    }
+
+    const outcome = deriveOutcome({
+      agentId: c.agentId,
+      issueId: c.issueId,
+      prNumber: c.prNumber,
+      targetRepo: c.targetRepo,
+      live,
+      staleThresholdDays: input.staleThresholdDays,
+    });
+    if (!outcome) {
+      pendingPrs += 1;
+      continue;
+    }
+
+    await appendOutcome(c.agentId, outcome);
+    skipByAgent.get(c.agentId)?.add(key);
+    appended.push(outcome);
+  }
+
+  return { appended, pendingPrs, errors };
+}
+
+/** Internal: every PR found across past runs (one entry per merged-or-not). */
+interface PrCandidate {
+  agentId: string;
+  issueId: number;
+  prNumber: number;
+  targetRepo: string;
+}
+
+async function collectCandidatePrs(): Promise<PrCandidate[]> {
+  // Limit scan to runs the registry knows about — read all `state/run-*.json`
+  // and collect every issue entry with an implement decision and a parsable
+  // PR URL. Walks the directory once; cheap.
+  const reg = await loadRegistry();
+  const knownAgents = new Set(reg.agents.map((a) => a.agentId));
+
+  let entries: string[];
+  try {
+    entries = await fs.readdir(STATE_DIR);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+
+  const out: PrCandidate[] = [];
+  for (const name of entries) {
+    if (!name.startsWith("run-") || !name.endsWith(".json")) continue;
+    const runId = name.slice(0, -".json".length);
+    let state: RunState;
+    try {
+      state = await loadRunState(runId);
+    } catch {
+      continue;
+    }
+    for (const [issueIdStr, entry] of Object.entries(state.issues)) {
+      if (entry.outcome !== "implement") continue;
+      if (!entry.agentId || !entry.prUrl) continue;
+      if (!knownAgents.has(entry.agentId)) continue;
+      const prNumber = parsePrNumber(entry.prUrl);
+      if (prNumber == null) continue;
+      out.push({
+        agentId: entry.agentId,
+        issueId: Number(issueIdStr),
+        prNumber,
+        targetRepo: state.targetRepo,
+      });
+    }
+  }
+  return out;
+}
+
+function parsePrNumber(url: string): number | null {
+  // Accept https://github.com/<owner>/<repo>/pull/<N>(#... or trailing)
+  const m = url.match(/\/pull\/(\d+)(?:[/#?]|$)/);
+  if (!m) return null;
+  const n = Number(m[1]);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+interface DeriveInput {
+  agentId: string;
+  issueId: number;
+  prNumber: number;
+  targetRepo: string;
+  live: GhPrState;
+  staleThresholdDays: number;
+}
+
+/**
+ * Returns null when the PR is still open and below the stale threshold —
+ * keep polling next time. Returns an Outcome when terminal (merged, closed
+ * without merge, or stalled past the threshold).
+ */
+export function deriveOutcome(input: DeriveInput): Outcome | null {
+  const { live } = input;
+  const ciCycles = countCiFailures(live.statusCheckRollup);
+  const reviewerRoundtrips = countChangesRequested(live.reviews);
+  const created = Date.parse(live.createdAt);
+
+  if (live.state === "MERGED" && live.mergedAt) {
+    return {
+      agent: input.agentId,
+      issue: input.issueId,
+      pr: input.prNumber,
+      targetRepo: input.targetRepo,
+      terminalState: "merged",
+      ciCycles,
+      reviewerRoundtrips,
+      daysOpen: daysBetween(created, Date.parse(live.mergedAt)),
+      closedAt: live.mergedAt,
+    };
+  }
+
+  if (live.state === "CLOSED" && live.closedAt) {
+    return {
+      agent: input.agentId,
+      issue: input.issueId,
+      pr: input.prNumber,
+      targetRepo: input.targetRepo,
+      terminalState: "closed-unmerged",
+      ciCycles,
+      reviewerRoundtrips,
+      daysOpen: daysBetween(created, Date.parse(live.closedAt)),
+      closedAt: live.closedAt,
+    };
+  }
+
+  // Open. Check stale threshold.
+  const now = Date.now();
+  const ageDays = daysBetween(created, now);
+  if (ageDays >= input.staleThresholdDays) {
+    return {
+      agent: input.agentId,
+      issue: input.issueId,
+      pr: input.prNumber,
+      targetRepo: input.targetRepo,
+      terminalState: "stalled",
+      ciCycles,
+      reviewerRoundtrips,
+      daysOpen: ageDays,
+      closedAt: new Date(now).toISOString(),
+    };
+  }
+  return null;
+}
+
+function countCiFailures(rollup: GhPrState["statusCheckRollup"]): number {
+  if (!Array.isArray(rollup)) return 0;
+  let n = 0;
+  for (const r of rollup) {
+    if (typeof r?.conclusion === "string" && r.conclusion.toUpperCase() === "FAILURE") n += 1;
+  }
+  return n;
+}
+
+function countChangesRequested(reviews: GhPrState["reviews"]): number {
+  if (!Array.isArray(reviews)) return 0;
+  let n = 0;
+  for (const r of reviews) {
+    if (typeof r?.state === "string" && r.state.toUpperCase() === "CHANGES_REQUESTED") n += 1;
+  }
+  return n;
+}
+
+function daysBetween(fromMs: number, toMs: number): number {
+  if (!Number.isFinite(fromMs) || !Number.isFinite(toMs)) return 0;
+  return Math.max(0, Math.round((toMs - fromMs) / (1000 * 60 * 60 * 24)));
+}
+
+/** Aggregated per-agent rollup for `vp-dev agents stats`. */
+export interface AgentRollup {
+  agentId: string;
+  name?: string;
+  runs: number;
+  merged: number;
+  closedUnmerged: number;
+  stalled: number;
+  mergeRate: number; // 0..1
+  medianRework: number;
+  medianCiCycles: number;
+}
+
+export async function loadAllOutcomes(agentIds: string[]): Promise<Map<string, Outcome[]>> {
+  const out = new Map<string, Outcome[]>();
+  for (const id of agentIds) {
+    out.set(id, await loadOutcomes(id));
+  }
+  return out;
+}
+
+export function rollupOutcomes(opts: {
+  agentId: string;
+  name?: string;
+  outcomes: Outcome[];
+}): AgentRollup {
+  const runs = opts.outcomes.length;
+  const merged = opts.outcomes.filter((o) => o.terminalState === "merged").length;
+  const closedUnmerged = opts.outcomes.filter((o) => o.terminalState === "closed-unmerged").length;
+  const stalled = opts.outcomes.filter((o) => o.terminalState === "stalled").length;
+  return {
+    agentId: opts.agentId,
+    name: opts.name,
+    runs,
+    merged,
+    closedUnmerged,
+    stalled,
+    mergeRate: runs === 0 ? 0 : merged / runs,
+    medianRework: median(opts.outcomes.map((o) => o.reviewerRoundtrips)),
+    medianCiCycles: median(opts.outcomes.map((o) => o.ciCycles)),
+  };
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}


### PR DESCRIPTION
Closes #36.

## Summary

Adds the missing feedback loop: `state/outcomes/<agent>.jsonl` records each PR's terminal state (`merged` | `closed-unmerged` | `stalled`), CI failure cycles, reviewer round-trips, and days-open. `vp-dev agents stats` rolls these up per agent — feeds the merge/retire (#31), triage tuning (#35), and cost-ceiling (#34) sister issues.

## What landed

- **`src/state/outcomes.ts`** — `pollOutcomes` (lazy refresh on each `vp-dev run`/`run --resume`), `loadOutcomes`, `appendOutcome`, and `rollupOutcomes`. Polling walks `state/run-*.json`, finds every `implement` outcome with a parsable PR URL, and appends a terminal record once the PR settles. Idempotent — already-recorded `<repo, pr>` pairs are skipped via a per-agent set built once per poll.
- **`src/github/gh.ts`** — `prState(repo, prNumber)` wraps `gh pr view --json state,createdAt,closedAt,mergedAt,reviews,statusCheckRollup`.
- **`src/cli.ts`** — `vp-dev agents stats [--poll] [--json] [--all]` subcommand; `--stalled-threshold-days` flag added to `run`.

Polling is wrapped in try/catch so a `gh` outage never blocks the run. Stalled threshold defaults to 14 days.

## Out of scope (deferred to upstream signal)

- **`costUsd` field + `$/merge` column** — the cost-tracking input signal does not exist yet (#34). Per the "defer detection branches whose input signal does not yet exist" discipline, the field joins the schema in the PR that ships cost tracking, rather than shipping as a dead `null` column today.

## Verification

Repo has no test framework; verified via `npm run build` + targeted runtime smoke:
- All four `deriveOutcome` branches return expected shapes: merged, closed-unmerged, fresh-open → `null` (keep polling), stale-open (30 days, threshold 14) → `stalled`.
- Rollup math against a seeded fixture: agent with `{merged, merged, closed}` rendered `runs:3 merged:2 merge-rate:67% median-rework:1 median-ci:1`.
- `agents stats --json` round-trips a `{ rollups: [] }` payload when the registry is empty.

— Rogue Oracle (agent-72c6)
