### PR TITLE
fix(split): pick child display names from human-name pool

### DIFF
--- a/src/agent/split.ts
+++ b/src/agent/split.ts
@@ -4,6 +4,7 @@ import { query } from "@anthropic-ai/claude-agent-sdk";
 import { agentClaudeMdPath, agentDir } from "./specialization.js";
 import { claudeBinPath } from "./sdkBinary.js";
 import { mutateRegistry, newAgentId } from "../state/registry.js";
+import { pickName } from "../state/names.js";
 import { ensureDir } from "../state/locks.js";
 import type { AgentRecord } from "../types.js";
 
@@ -386,12 +387,13 @@ export async function applySplit(input: ApplySplitInput): Promise<ApplySplitResu
       while (takenAgentIds.has(childId)) childId = newAgentId();
       takenAgentIds.add(childId);
 
-      let name = cluster.proposedName;
-      if (takenNames.has(name)) {
-        // Append the new agentId hex tail to disambiguate. Same pattern
-        // pickName uses for pool exhaustion in the names module.
-        name = `${cluster.proposedName}-${childId.replace(/^agent-/, "")}`;
-      }
+      // Display name: pull from the curated human-name pool, the same source
+      // every freshly-minted agent uses. cluster.proposedName is a topical
+      // section-heading phrase (e.g. "Rogue-MCP Trust Boundary") that reads
+      // as a label rather than an identity — kept on the proposal for the
+      // formatProposal log line, but not stored on the child record. Tags
+      // already carry the routing/topic information.
+      const name = pickName(childId, takenNames);
       takenNames.add(name);
 
       const now = new Date().toISOString();


### PR DESCRIPTION
Closes #64

## Summary
Split-child agents were stored with `cluster.proposedName` as their display name — topical section-heading phrases like `Rogue-MCP Trust Boundary`, `Issue Lifecycle Hygiene`, `Safe Forensics`. These read as topic labels, not identities, and clashed visually with the curated single-name convention every freshly-minted agent already follows (Ada, Erlang, Khwarizmi, Tesla, Shannon, Floyd, …).

`applySplit` now calls `pickName(childId, takenNames)` for each child, the same source `forkAgent` uses. `cluster.proposedName` stays on the proposal so `formatProposal` can still surface what each cluster covers in the per-cluster log line (`-> Rogue-MCP Trust Boundary  (4 sections, 7 tags)`); only the stored `AgentRecord.name` changes.

The pre-existing collision-fallback (`<name>-<hexSuffix>`) is removed — `pickName` already linear-probes the pool and falls back to a hex-suffixed base if the entire pool is exhausted, so the bespoke disambiguation became dead code.

## Scope
- Future splits only. Existing children created under the old convention are untouched (per the issue's "Out of scope" note); a registry hand-edit can rename them if needed.

## Test plan
- [x] `npm run build` — clean.
- [ ] Next `vp-dev agents split <agent> --apply` produces children with names from `NAME_POOL`, deterministically derived from each child's `agentId`.
- [ ] `formatProposal` output unchanged — still prints `cluster.proposedName` per cluster.

— Safe Forensics (agent-e22f)
