### PR TITLE
fix(worktree): surface unprunable stale branches as actionable warning + state audit trail

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,13 @@ import {
 } from "./state/runConfirm.js";
 import { triageBatch } from "./orchestrator/triage.js";
 import { Logger } from "./log/logger.js";
-import { fetchOriginMain, pruneStaleAgentBranches, pruneWorktrees, resolveTargetRepoPath } from "./git/worktree.js";
+import {
+  fetchOriginMain,
+  formatUnprunableWarning,
+  pruneStaleAgentBranches,
+  pruneWorktrees,
+  resolveTargetRepoPath,
+} from "./git/worktree.js";
 import { agentClaudeMdPath, forkClaudeMd } from "./agent/specialization.js";
 import { promises as fs } from "node:fs";
 import { runIssueCore } from "./agent/runIssueCore.js";
@@ -438,7 +444,12 @@ async function cmdRun(opts: RunOpts): Promise<void> {
 
   try {
     await pruneWorktrees(repoPath);
-    await pruneStaleAgentBranches(repoPath, opts.targetRepo, logger);
+    const sweep = await pruneStaleAgentBranches(repoPath, opts.targetRepo, logger);
+    if (sweep.unprunable.length > 0) {
+      state.unprunableStaleBranches = sweep.unprunable;
+      await saveRunState(state);
+      process.stderr.write(formatUnprunableWarning(sweep.unprunable, { color: !!process.stderr.isTTY }));
+    }
     await pollOutcomesLazy({ logger, staleThresholdDays: opts.stalledThresholdDays });
     await runOrchestrator({
       state,
@@ -527,7 +538,12 @@ async function runResume(opts: RunOpts): Promise<void> {
     issueCount: issues.length,
   });
   try {
-    await pruneStaleAgentBranches(repoPath, state.targetRepo, logger);
+    const sweep = await pruneStaleAgentBranches(repoPath, state.targetRepo, logger);
+    if (sweep.unprunable.length > 0) {
+      state.unprunableStaleBranches = sweep.unprunable;
+      await saveRunState(state);
+      process.stderr.write(formatUnprunableWarning(sweep.unprunable, { color: !!process.stderr.isTTY }));
+    }
     await pollOutcomesLazy({ logger, staleThresholdDays: opts.stalledThresholdDays });
     await runOrchestrator({
       state,
@@ -959,7 +975,13 @@ async function cmdSpawn(opts: SpawnOpts): Promise<void> {
   try {
     await fetchOriginMain(repoPath);
     await pruneWorktrees(repoPath);
-    await pruneStaleAgentBranches(repoPath, opts.targetRepo, logger);
+    const sweep = await pruneStaleAgentBranches(repoPath, opts.targetRepo, logger);
+    if (sweep.unprunable.length > 0) {
+      // `vp-dev spawn` doesn't carry a RunState, so the audit trail lives
+      // only in the run log JSONL. Still surface the actionable summary
+      // on stderr — same yellow header as `vp-dev run` (#63).
+      process.stderr.write(formatUnprunableWarning(sweep.unprunable, { color: !!process.stderr.isTTY }));
+    }
 
     const inspectPaths = opts.inspectPaths
       ? opts.inspectPaths.split(",").map((s) => s.trim()).filter((s) => s.length > 0)

--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -3,6 +3,7 @@ import { execFile as execFileCb } from "node:child_process";
 import path from "node:path";
 import { promises as fs } from "node:fs";
 import type { Logger } from "../log/logger.js";
+import type { UnprunableStaleBranch } from "../types.js";
 
 const execFile = promisify(execFileCb);
 
@@ -141,6 +142,23 @@ export async function listWorktrees(repoPath: string): Promise<string[]> {
   }
 }
 
+// Parses the worktree path out of `git branch -D`'s rejection message:
+//   error: cannot delete branch '<branch>' used by worktree at '<path>'
+// Falls back to undefined if the error format ever changes — callers
+// should treat this as best-effort metadata, not a contract.
+const WORKTREE_AT_RE = /used by worktree at '([^']+)'/;
+
+function parseWorktreePathFromBranchDError(stderr: string): string | undefined {
+  const m = WORKTREE_AT_RE.exec(stderr);
+  return m ? m[1] : undefined;
+}
+
+export interface PruneStaleResult {
+  pruned: number;
+  kept: number;
+  unprunable: UnprunableStaleBranch[];
+}
+
 // Sweep stale `vp-dev/agent-*/issue-*` branches whose PR is no longer open.
 //
 // After a successful "implement" run, runIssueCore intentionally retains the
@@ -157,11 +175,18 @@ export async function listWorktrees(repoPath: string): Promise<string[]> {
 //
 // Push-protection invariant: all writes are local (`git branch -D`,
 // `git worktree remove`). No `git push --delete`, no remote mutation.
+//
+// Some stale branches can't be deleted because the branch is still
+// checked out in a worktree at a non-default path (e.g. a manually-created
+// `.claude/worktrees/pr-43-conflict` for in-flight conflict resolution).
+// `git branch -D` rejects these with an error, which we surface as
+// structured `unprunable` entries — callers persist them into RunState so
+// the user has an audit trail beyond the single dim warning. See #63.
 export async function pruneStaleAgentBranches(
   repoPath: string,
   targetRepo: string,
   logger?: Logger,
-): Promise<{ pruned: number; kept: number }> {
+): Promise<PruneStaleResult> {
   let branches: string[] = [];
   try {
     const { stdout } = await execFile(
@@ -174,15 +199,16 @@ export async function pruneStaleAgentBranches(
     logger?.warn("worktree.stale_branches_list_failed", {
       err: (err as Error).message,
     });
-    return { pruned: 0, kept: 0 };
+    return { pruned: 0, kept: 0, unprunable: [] };
   }
   if (branches.length === 0) {
-    logger?.info("worktree.stale_branches_swept", { pruned: 0, kept: 0 });
-    return { pruned: 0, kept: 0 };
+    logger?.info("worktree.stale_branches_swept", { pruned: 0, kept: 0, unprunable: 0 });
+    return { pruned: 0, kept: 0, unprunable: [] };
   }
 
   let pruned = 0;
   let kept = 0;
+  const unprunable: UnprunableStaleBranch[] = [];
   for (const branch of branches) {
     const m = VP_DEV_BRANCH_RE.exec(branch);
     if (!m) {
@@ -238,13 +264,60 @@ export async function pruneStaleAgentBranches(
       logger?.info("worktree.stale_branch_pruned", { branch, agentId, issueId });
     } catch (err) {
       kept++;
+      const stderr = (err as { stderr?: string }).stderr ?? (err as Error).message;
+      const worktreePath = parseWorktreePathFromBranchDError(stderr);
+      unprunable.push({
+        branch,
+        agentId,
+        issueId,
+        worktreePath,
+        reason: stderr,
+      });
       logger?.warn("worktree.stale_branch_delete_failed", {
         branch,
-        err: (err as { stderr?: string }).stderr ?? (err as Error).message,
+        agentId,
+        issueId,
+        worktreePath,
+        err: stderr,
       });
     }
   }
 
-  logger?.info("worktree.stale_branches_swept", { pruned, kept });
-  return { pruned, kept };
+  logger?.info("worktree.stale_branches_swept", {
+    pruned,
+    kept,
+    unprunable: unprunable.length,
+  });
+  return { pruned, kept, unprunable };
+}
+
+// Renders a clearly-actionable warning summary for the unprunable branches
+// returned by pruneStaleAgentBranches. Intended for direct stderr output —
+// dim, scrolling-by event lines aren't enough (see #63). Uses ANSI colors
+// only when stderr is a TTY so log capture stays clean.
+const ANSI_YELLOW = "\x1b[33m";
+const ANSI_BOLD = "\x1b[1m";
+const ANSI_RESET = "\x1b[0m";
+
+export function formatUnprunableWarning(
+  unprunable: UnprunableStaleBranch[],
+  opts: { color: boolean } = { color: false },
+): string {
+  if (unprunable.length === 0) return "";
+  const y = opts.color ? ANSI_YELLOW : "";
+  const b = opts.color ? ANSI_BOLD : "";
+  const r = opts.color ? ANSI_RESET : "";
+  const header = `${y}${b}WARNING:${r}${y} ${unprunable.length} stale branch(es) attached to a worktree could not be pruned.${r}`;
+  const lines = [header];
+  for (const u of unprunable) {
+    const where = u.worktreePath ? ` — worktree at ${u.worktreePath}` : "";
+    lines.push(`  ${u.branch}${where}`);
+  }
+  lines.push(
+    "  To clean up: review the worktree, then `git worktree remove --force <path>` and `git branch -D <branch>`.",
+  );
+  lines.push(
+    "  Recorded under `unprunableStaleBranches` in the run-state JSON for later audit.",
+  );
+  return lines.join("\n") + "\n";
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,22 @@ export interface RunIssueEntry {
   error?: string;
 }
 
+// A `vp-dev/agent-*/issue-*` branch the stale-branch sweep determined was
+// dead (no open PR) but could not delete because the branch is still
+// attached to a worktree. Surfaced into RunState so the user can grep
+// `state/<runId>.json` for accumulated cleanup-needed entries — see issue
+// #63 for the rationale (single dim warning per run was too easy to miss).
+export interface UnprunableStaleBranch {
+  branch: string;
+  agentId: string;
+  issueId: number;
+  // Worktree path parsed out of the `git branch -D` error message
+  // (`used by worktree at '<path>'`). Optional in case the error format
+  // changes in a future git release — fall back to `reason` then.
+  worktreePath?: string;
+  reason: string;
+}
+
 export interface RunState {
   runId: string;
   targetRepo: string;
@@ -76,6 +92,9 @@ export interface RunState {
   lastTickAt: string;
   startedAt: string;
   dryRun: boolean;
+  // Populated by the stale-branch sweep at run start. Optional for
+  // back-compat with run states written before #63.
+  unprunableStaleBranches?: UnprunableStaleBranch[];
 }
 
 export const ResultEnvelopeSchema = z.object({


### PR DESCRIPTION
Closes #63.

## Summary

The stale-branch sweep can't `git branch -D` a `vp-dev/agent-*/issue-*` branch that's still checked out in a worktree (e.g. a manually-held `.claude/worktrees/pr-43-conflict` for in-flight conflict resolution). Today that surfaces as a single dim `warn.worktree.stale_branch_delete_failed` event that scrolls past with the routine info logs — silent enough to accumulate over months of heavy `vp-dev` use until disk pressure or branch-namespace collisions force attention, with no audit trail to reconstruct what was supposed to be cleaned up.

This implements the smaller of the two options the issue proposed (option 2 — promote the warning to a discoverable surface). The auto-`git worktree remove --force` path was rejected because a deliberately-held conflict-resolution worktree would be silently nuked.

## Changes

- `pruneStaleAgentBranches` now returns `{ pruned, kept, unprunable: UnprunableStaleBranch[] }`. Each unprunable entry carries `branch`, `agentId`, `issueId`, the worktree path parsed out of `git`'s `used by worktree at '<path>'` error, and the raw stderr.
- `RunState` gains an optional `unprunableStaleBranches?: UnprunableStaleBranch[]`. `runOnce` and `runResume` persist the sweep's findings via `saveRunState`, so they survive in `state/<runId>.json` for later `jq`/`grep`-based audit.
- All three sweep call sites (`vp-dev run`, `vp-dev run --resume`, `vp-dev spawn`) print a yellow-headed remediation summary to stderr when `unprunable.length > 0`, including the exact `git worktree remove --force <path>` + `git branch -D <branch>` commands. ANSI colors are gated on `process.stderr.isTTY` so log capture stays clean.
- The per-branch `warn.worktree.stale_branch_delete_failed` event now carries `agentId`, `issueId`, and `worktreePath` alongside the raw stderr — `jq`-based log analysis is no longer limited to opaque error strings.
- The summary `worktree.stale_branches_swept` event picks up an `unprunable` count.

## Non-goals

- No automatic worktree removal — the issue flagged that as risky and out of scope. The remediation hint points the user at the manual command.
- No changes to the run-setup preview. The sweep runs after `approveSetup`, so a preview-time surface would require restructuring run startup; the state-file + stderr surface is sufficient and far smaller.

## Test plan

- [x] `npm run build` succeeds.
- [ ] On a repo with a `vp-dev/agent-*/issue-*` branch attached to a non-default worktree, `vp-dev run` prints the yellow warning to stderr and `state/<runId>.json` contains an `unprunableStaleBranches` array with the parsed `worktreePath`.
- [ ] On a repo with no unprunable branches, `state/<runId>.json` does NOT contain the field (back-compat with the existing schema).
- [ ] `vp-dev spawn` prints the same warning when applicable, with no state-file write (no RunState in the spawn flow).

— Finding Triage (agent-75a0)
