### PR TITLE
refactor(parser): share JSON-envelope extractor across 4 call sites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,5 @@ jobs:
       - run: npm run typecheck
 
       - run: npm run build
+
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "typecheck": "tsc --noEmit",
+    "test": "tsc && node --test dist/src/util/*.test.js",
     "vp-dev": "node dist/bin/vp-dev.js"
   },
   "dependencies": {

--- a/src/agent/parseResult.ts
+++ b/src/agent/parseResult.ts
@@ -1,3 +1,4 @@
+import { parseJsonEnvelope } from "../util/parseJsonEnvelope.js";
 import { ResultEnvelopeSchema, type ResultEnvelope } from "../types.js";
 
 export interface ParseOutcome {
@@ -7,99 +8,13 @@ export interface ParseOutcome {
   raw?: string;
 }
 
-const FENCED_RE = /```(?:json)?\s*\n?([\s\S]*?)\n?```/gi;
-
+/**
+ * Extract and validate the `ResultEnvelope` JSON payload from a coding
+ * agent's final assistant message. Thin wrapper over the shared
+ * {@link parseJsonEnvelope} extractor — kept so call sites that read
+ * `.envelope` (rather than `.value`) don't churn.
+ */
 export function extractEnvelope(finalMessage: string): ParseOutcome {
-  const candidates = collectCandidates(finalMessage);
-
-  if (candidates.length === 0) {
-    return { ok: false, error: "No JSON envelope found in final assistant message." };
-  }
-
-  let lastSchemaError: string | undefined;
-  let lastSchemaRaw: string | undefined;
-  let lastJsonError: string | undefined;
-  let lastJsonRaw: string | undefined;
-
-  for (let i = candidates.length - 1; i >= 0; i--) {
-    const raw = candidates[i];
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(raw);
-    } catch (err) {
-      lastJsonError = (err as Error).message;
-      lastJsonRaw = raw;
-      continue;
-    }
-    const result = ResultEnvelopeSchema.safeParse(parsed);
-    if (result.success) {
-      return { ok: true, envelope: result.data, raw };
-    }
-    lastSchemaError = result.error.message;
-    lastSchemaRaw = raw;
-  }
-
-  if (lastSchemaError !== undefined) {
-    return { ok: false, error: `Schema validation failed: ${lastSchemaError}`, raw: lastSchemaRaw };
-  }
-  return { ok: false, error: `JSON parse failed: ${lastJsonError}`, raw: lastJsonRaw };
-}
-
-function collectCandidates(message: string): string[] {
-  const out: string[] = [];
-
-  const trimmed = message.trim();
-  if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
-    out.push(trimmed);
-  }
-
-  let m: RegExpExecArray | null;
-  FENCED_RE.lastIndex = 0;
-  while ((m = FENCED_RE.exec(message)) !== null) {
-    const inner = m[1].trim();
-    if (inner) out.push(inner);
-  }
-
-  const balanced = lastBalancedObject(message);
-  if (balanced) out.push(balanced);
-
-  return out;
-}
-
-function lastBalancedObject(message: string): string | null {
-  let depth = 0;
-  let start = -1;
-  let inString = false;
-  let escape = false;
-  let lastObject: string | null = null;
-  for (let i = 0; i < message.length; i++) {
-    const ch = message[i];
-    if (escape) {
-      escape = false;
-      continue;
-    }
-    if (inString) {
-      if (ch === "\\") escape = true;
-      else if (ch === '"') inString = false;
-      continue;
-    }
-    if (ch === '"') {
-      inString = true;
-      continue;
-    }
-    if (ch === "{") {
-      if (depth === 0) start = i;
-      depth++;
-    } else if (ch === "}") {
-      depth--;
-      if (depth === 0 && start >= 0) {
-        lastObject = message.slice(start, i + 1);
-        start = -1;
-      } else if (depth < 0) {
-        depth = 0;
-        start = -1;
-      }
-    }
-  }
-  return lastObject;
+  const r = parseJsonEnvelope(finalMessage, ResultEnvelopeSchema);
+  return { ok: r.ok, envelope: r.value, error: r.error, raw: r.raw };
 }

--- a/src/agent/split.ts
+++ b/src/agent/split.ts
@@ -5,6 +5,7 @@ import { agentClaudeMdPath, agentDir } from "./specialization.js";
 import { claudeBinPath } from "./sdkBinary.js";
 import { mutateRegistry, newAgentId } from "../state/registry.js";
 import { ensureDir } from "../state/locks.js";
+import { parseJsonEnvelope } from "../util/parseJsonEnvelope.js";
 import type { AgentRecord } from "../types.js";
 
 // Thresholds for "this agent is overloaded enough to warrant splitting".
@@ -193,9 +194,14 @@ export async function proposeSplit(
     }
   }
 
-  const json = parseJsonLoose(raw);
-  if (!json) throw new Error(`split clusterer output not valid JSON: ${raw.slice(0, 200)}`);
-  const clamped = clampClusterFields(json);
+  // Extract the JSON envelope without schema validation — clampClusterFields
+  // needs to trim oversize rationales/names before ProposalSchema runs, so
+  // pass `z.unknown()` and run safeParse ourselves below.
+  const extracted = parseJsonEnvelope(raw, z.unknown());
+  if (!extracted.ok) {
+    throw new Error(`split clusterer output not valid JSON: ${raw.slice(0, 200)}`);
+  }
+  const clamped = clampClusterFields(extracted.value);
   const parsed = ProposalSchema.safeParse(clamped);
   if (!parsed.success) {
     throw new Error(
@@ -261,32 +267,6 @@ Output JSON: {"clusters": [{"proposedName": "...", "proposedTags": ["..."], "sec
 function truncate(s: string, max: number): string {
   if (s.length <= max) return s;
   return s.slice(0, max - 3) + "...";
-}
-
-function parseJsonLoose(raw: string): unknown {
-  const trimmed = raw.trim();
-  try {
-    return JSON.parse(trimmed);
-  } catch {
-    const fence = /```(?:json)?\s*\n([\s\S]*?)\n```/i.exec(trimmed);
-    if (fence) {
-      try {
-        return JSON.parse(fence[1]);
-      } catch {
-        return null;
-      }
-    }
-    const start = trimmed.indexOf("{");
-    const end = trimmed.lastIndexOf("}");
-    if (start >= 0 && end > start) {
-      try {
-        return JSON.parse(trimmed.slice(start, end + 1));
-      } catch {
-        return null;
-      }
-    }
-    return null;
-  }
 }
 
 export async function readAgentClaudeMdBytes(agentId: string): Promise<{ md: string; bytes: number }> {

--- a/src/agent/summarizer.ts
+++ b/src/agent/summarizer.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import { claudeBinPath } from "./sdkBinary.js";
+import { parseJsonEnvelope } from "../util/parseJsonEnvelope.js";
 import type { AgentRecord, IssueSummary, ResultEnvelope } from "../types.js";
 import type { Logger } from "../log/logger.js";
 
@@ -143,8 +144,12 @@ async function runSummarizerQuery(args: SummarizerQueryArgs): Promise<Summarizer
     return { skip: true, skipReason: `summarizer exception: ${(err as Error).message}` };
   }
 
-  const json = parseJsonLoose(raw);
-  if (!json) {
+  // Extract the JSON envelope without schema validation — we still need a
+  // clamp pass on raw heading/body lengths before SummarizerOutputSchema
+  // can be applied. `z.unknown()` makes the helper return whatever parses,
+  // delegating validation to the safeParse below.
+  const extracted = parseJsonEnvelope(raw, z.unknown());
+  if (!extracted.ok) {
     args.logger.warn("summarizer.malformed_payload", {
       agentId: args.agent.agentId,
       issueId: args.issue.id,
@@ -152,6 +157,7 @@ async function runSummarizerQuery(args: SummarizerQueryArgs): Promise<Summarizer
     });
     return { skip: true, skipReason: "summarizer output not valid JSON" };
   }
+  const json = extracted.value;
 
   // Post-parse safety net: clamp oversize heading/body BEFORE schema
   // validation so the entire summary isn't discarded just because the LLM
@@ -320,28 +326,3 @@ function truncate(s: string, max: number): string {
   return s.slice(0, max - 3) + "...";
 }
 
-function parseJsonLoose(raw: string): unknown {
-  const trimmed = raw.trim();
-  try {
-    return JSON.parse(trimmed);
-  } catch {
-    const match = /```(?:json)?\s*\n([\s\S]*?)\n```/i.exec(trimmed);
-    if (match) {
-      try {
-        return JSON.parse(match[1]);
-      } catch {
-        return null;
-      }
-    }
-    const start = trimmed.indexOf("{");
-    const end = trimmed.lastIndexOf("}");
-    if (start >= 0 && end > start) {
-      try {
-        return JSON.parse(trimmed.slice(start, end + 1));
-      } catch {
-        return null;
-      }
-    }
-    return null;
-  }
-}

--- a/src/orchestrator/dispatcher.ts
+++ b/src/orchestrator/dispatcher.ts
@@ -1,6 +1,7 @@
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import { buildTickPrompt } from "./prompt.js";
 import { claudeBinPath } from "../agent/sdkBinary.js";
+import { parseJsonEnvelope } from "../util/parseJsonEnvelope.js";
 import { TickProposalSchema, type TickAssignment } from "../types.js";
 import {
   classifyMatch,
@@ -118,38 +119,19 @@ async function tryProposeWithLLM(opts: {
     response: raw.length > 4000 ? raw.slice(0, 4000) + "..." : raw,
   });
 
-  const parsedJson = parseJsonLoose(raw);
-  if (!parsedJson) return { errors: ["Orchestrator response is not valid JSON."] };
-
-  const proposal = TickProposalSchema.safeParse(parsedJson);
-  if (!proposal.success) return { errors: [`Schema invalid: ${proposal.error.message}`] };
+  const proposal = parseJsonEnvelope(raw, TickProposalSchema);
+  if (!proposal.ok || !proposal.value) {
+    return { errors: [proposal.error ?? "Orchestrator response is not valid JSON."] };
+  }
 
   const errors = validateProposal({
-    proposal: proposal.data.assignments,
+    proposal: proposal.value.assignments,
     cap: opts.cap,
     idleAgents: opts.idleAgents,
     pendingIssues: opts.pendingIssues,
   });
   if (errors.length > 0) return { errors };
-  return { assignments: proposal.data.assignments };
-}
-
-function parseJsonLoose(raw: string): unknown {
-  const trimmed = raw.trim();
-  try {
-    return JSON.parse(trimmed);
-  } catch {
-    // try fenced extraction
-    const match = /```(?:json)?\s*\n([\s\S]*?)\n```/i.exec(trimmed);
-    if (match) {
-      try {
-        return JSON.parse(match[1]);
-      } catch {
-        return null;
-      }
-    }
-    return null;
-  }
+  return { assignments: proposal.value.assignments };
 }
 
 interface ValidateInput {

--- a/src/util/parseJsonEnvelope.test.ts
+++ b/src/util/parseJsonEnvelope.test.ts
@@ -1,0 +1,111 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { z } from "zod";
+import { parseJsonEnvelope } from "./parseJsonEnvelope.js";
+
+const EnvelopeSchema = z.object({
+  decision: z.enum(["implement", "pushback", "error"]),
+  reason: z.string(),
+});
+
+test("bare json object only", () => {
+  const r = parseJsonEnvelope(
+    `{"decision":"implement","reason":"ok"}`,
+    EnvelopeSchema,
+  );
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.value, { decision: "implement", reason: "ok" });
+});
+
+test("fenced json with tag", () => {
+  const msg =
+    "Here you go:\n```json\n{\"decision\":\"implement\",\"reason\":\"ok\"}\n```\n";
+  const r = parseJsonEnvelope(msg, EnvelopeSchema);
+  assert.equal(r.ok, true);
+  assert.equal(r.value?.decision, "implement");
+});
+
+test("fenced no tag", () => {
+  const msg =
+    "Result:\n```\n{\"decision\":\"pushback\",\"reason\":\"x\"}\n```";
+  const r = parseJsonEnvelope(msg, EnvelopeSchema);
+  assert.equal(r.ok, true);
+  assert.equal(r.value?.decision, "pushback");
+});
+
+test("prose with stray { before envelope", () => {
+  const msg =
+    "I edited the {foo} placeholder. Final answer:\n```json\n{\"decision\":\"implement\",\"reason\":\"ok\"}\n```";
+  const r = parseJsonEnvelope(msg, EnvelopeSchema);
+  assert.equal(r.ok, true);
+  assert.equal(r.value?.decision, "implement");
+});
+
+test("nested object", () => {
+  const NestedSchema = z.object({
+    decision: z.string(),
+    memoryUpdate: z.object({ addTags: z.array(z.string()) }),
+  });
+  const msg = `{"decision":"implement","memoryUpdate":{"addTags":["a","b"]}}`;
+  const r = parseJsonEnvelope(msg, NestedSchema);
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.value?.memoryUpdate.addTags, ["a", "b"]);
+});
+
+test("multiple fenced blocks — pick last valid", () => {
+  const msg =
+    "First try:\n" +
+    "```json\n{\"decision\":\"unknown\",\"reason\":\"first\"}\n```\n" +
+    "Actually:\n" +
+    "```json\n{\"decision\":\"implement\",\"reason\":\"second\"}\n```";
+  const r = parseJsonEnvelope(msg, EnvelopeSchema);
+  assert.equal(r.ok, true);
+  assert.equal(r.value?.reason, "second");
+});
+
+test("no envelope at all", () => {
+  const r = parseJsonEnvelope(
+    "just some prose with no JSON whatsoever",
+    EnvelopeSchema,
+  );
+  assert.equal(r.ok, false);
+  assert.match(r.error ?? "", /No JSON envelope/);
+});
+
+test("malformed envelope reports schema validation failure", () => {
+  const msg = `{"decision":"unknown","reason":42}`;
+  const r = parseJsonEnvelope(msg, EnvelopeSchema);
+  assert.equal(r.ok, false);
+  assert.match(r.error ?? "", /Schema validation failed/);
+});
+
+test("malformed JSON inside fences reports JSON parse failure", () => {
+  const msg = "```json\n{not valid json}\n```";
+  const r = parseJsonEnvelope(msg, EnvelopeSchema);
+  assert.equal(r.ok, false);
+  assert.match(r.error ?? "", /JSON parse failed/);
+});
+
+test("envelope after long prose with stray }", () => {
+  const msg =
+    "I had to edit foo} which broke the build.\n" +
+    "Final:\n" +
+    "```json\n{\"decision\":\"implement\",\"reason\":\"ok\"}\n```";
+  const r = parseJsonEnvelope(msg, EnvelopeSchema);
+  assert.equal(r.ok, true);
+  assert.equal(r.value?.decision, "implement");
+});
+
+test("z.unknown() returns parsed value without schema check", () => {
+  const r = parseJsonEnvelope(`{"foo":1,"bar":["a"]}`, z.unknown());
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.value, { foo: 1, bar: ["a"] });
+});
+
+test("z.unknown() with prose-wrapped JSON still extracts", () => {
+  const msg =
+    'Output: ```json\n{"skip":false,"heading":"H","body":"B"}\n```';
+  const r = parseJsonEnvelope(msg, z.unknown());
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.value, { skip: false, heading: "H", body: "B" });
+});

--- a/src/util/parseJsonEnvelope.ts
+++ b/src/util/parseJsonEnvelope.ts
@@ -1,0 +1,136 @@
+import type { ZodType } from "zod";
+
+/**
+ * Outcome of {@link parseJsonEnvelope}. On success `value` holds the
+ * schema-validated payload and `raw` holds the JSON candidate string that
+ * matched. On failure `error` carries the most-specific diagnostic
+ * available (schema-validation > JSON-parse > no-envelope) and `raw` may
+ * carry the offending candidate when one parsed but failed validation.
+ */
+export interface ParseEnvelopeOutcome<T> {
+  ok: boolean;
+  value?: T;
+  raw?: string;
+  error?: string;
+}
+
+const FENCED_RE = /```(?:json)?\s*\n?([\s\S]*?)\n?```/gi;
+
+/**
+ * Extract a JSON envelope from an LLM-generated message and validate it
+ * against a Zod schema. Tries three candidate shapes:
+ *
+ *   1. Bare object — entire trimmed message is `{...}`.
+ *   2. Fenced code blocks — every ` ```json ... ``` ` or ` ``` ... ``` `
+ *      block in document order.
+ *   3. Forward-scan brace-balanced last object (string-aware: tracks `"`
+ *      quotes, handles `\"` escapes, only zeroes depth at top-level
+ *      closures).
+ *
+ * Iterates candidates last-to-first and returns the first that BOTH
+ * parses as JSON and validates against the schema. Schema-validation
+ * errors are surfaced in preference to JSON-parse errors when at least
+ * one candidate parsed but no candidate validated — so callers see the
+ * most specific diagnostic rather than a misleading "no envelope found".
+ *
+ * Pass `z.unknown()` (or any always-passing schema) for sites that want
+ * extraction without schema validation; they can run their own
+ * `safeParse` on `value`.
+ */
+export function parseJsonEnvelope<T>(
+  message: string,
+  schema: ZodType<T>,
+): ParseEnvelopeOutcome<T> {
+  const candidates = collectCandidates(message);
+
+  if (candidates.length === 0) {
+    return { ok: false, error: "No JSON envelope found in final assistant message." };
+  }
+
+  let lastSchemaError: string | undefined;
+  let lastSchemaRaw: string | undefined;
+  let lastJsonError: string | undefined;
+  let lastJsonRaw: string | undefined;
+
+  for (let i = candidates.length - 1; i >= 0; i--) {
+    const raw = candidates[i];
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      lastJsonError = (err as Error).message;
+      lastJsonRaw = raw;
+      continue;
+    }
+    const result = schema.safeParse(parsed);
+    if (result.success) {
+      return { ok: true, value: result.data, raw };
+    }
+    lastSchemaError = result.error.message;
+    lastSchemaRaw = raw;
+  }
+
+  if (lastSchemaError !== undefined) {
+    return { ok: false, error: `Schema validation failed: ${lastSchemaError}`, raw: lastSchemaRaw };
+  }
+  return { ok: false, error: `JSON parse failed: ${lastJsonError}`, raw: lastJsonRaw };
+}
+
+function collectCandidates(message: string): string[] {
+  const out: string[] = [];
+
+  const trimmed = message.trim();
+  if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+    out.push(trimmed);
+  }
+
+  let m: RegExpExecArray | null;
+  FENCED_RE.lastIndex = 0;
+  while ((m = FENCED_RE.exec(message)) !== null) {
+    const inner = m[1].trim();
+    if (inner) out.push(inner);
+  }
+
+  const balanced = lastBalancedObject(message);
+  if (balanced) out.push(balanced);
+
+  return out;
+}
+
+function lastBalancedObject(message: string): string | null {
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escape = false;
+  let lastObject: string | null = null;
+  for (let i = 0; i < message.length; i++) {
+    const ch = message[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (inString) {
+      if (ch === "\\") escape = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === "{") {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (ch === "}") {
+      depth--;
+      if (depth === 0 && start >= 0) {
+        lastObject = message.slice(start, i + 1);
+        start = -1;
+      } else if (depth < 0) {
+        depth = 0;
+        start = -1;
+      }
+    }
+  }
+  return lastObject;
+}


### PR DESCRIPTION
Closes #54.

## Summary

Layer 3 of the #49 / #51 trio. Extracts the resilient JSON-envelope parser landed in #51 into a shared helper at `src/util/parseJsonEnvelope.ts` and migrates the four call sites that had their own loose parsers (`parseResult.extractEnvelope`, `dispatcher.parseJsonLoose`, `summarizer.parseJsonLoose`, `split.parseJsonLoose`) onto it.

## What changed

- New `src/util/parseJsonEnvelope.ts` exports `parseJsonEnvelope<T>(message, schema): { ok, value?, raw?, error? }`. Same three-candidate logic as the post-#51 `extractEnvelope`: bare-object → fenced-with-optional-tag → forward-scan brace-balanced. Last-to-first iteration. Schema-validation errors win over JSON-parse errors when at least one candidate parsed.
- `parseResult.ts` becomes a thin wrapper — `extractEnvelope` now just calls the helper with `ResultEnvelopeSchema` and renames `value`→`envelope` so existing callers (`codingAgent.ts`, `reconcile.ts`) don't churn.
- `dispatcher.ts` passes `TickProposalSchema` straight into the helper; the local `parseJsonLoose` is gone.
- `summarizer.ts` and `split.ts` pass `z.unknown()` because they clamp oversize fields BEFORE running their real schemas; the duplicated `parseJsonLoose` blocks are deleted.

## Tests

Added `src/util/parseJsonEnvelope.test.ts` with 12 cases (Node 20 built-in `node --test`, no devDeps): bare object, fenced w/ tag, fenced no tag, prose-with-stray-`{`, nested object, multiple fenced (last valid wins), no envelope, malformed schema, malformed JSON inside fences, envelope after long prose with stray `}`, `z.unknown()` bare, `z.unknown()` prose-wrapped. All pass.

Wired via `npm test` (compiles then runs against `dist/src/util/*.test.js`) and added a `npm test` step to `.github/workflows/ci.yml`.

## Behavior

- Sites that previously parsed continue to parse. Acceptance criterion held.
- Summarizer/split/dispatcher gain the brace-balanced forward-scan fallback they didn't have — strict improvement over the old `lastIndexOf("}")` splice (which broke on prose containing `{`) and the dispatcher's no-fallback fenced-only attempt.

— Rogue Oracle (agent-72c6)
