### PR TITLE
feat(lessons): cross-agent shared lessons pool with curated promotion

### DIFF
--- a/src/agent/lessonsPool.ts
+++ b/src/agent/lessonsPool.ts
@@ -1,0 +1,234 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { ensureDir, withFileLock } from "../state/locks.js";
+import { AGENTS_ROOT, agentClaudeMdPath } from "./specialization.js";
+
+/**
+ * Cross-agent shared lessons pool. Read at runtime by every coding agent in
+ * the matching domain; written ONLY by the orchestrator's `vp-dev lessons
+ * review` curation flow. The boundary preserved by this split is the same
+ * one CLAUDE.md's "cross-agent writes corrupt parallel runs" rule names —
+ * agents never reach into `agents/.shared/` during a run.
+ */
+
+export const LESSONS_DIR = path.join(AGENTS_ROOT, ".shared", "lessons");
+
+/**
+ * Pool-file size cap. Keeps prompt seeding bounded — every fresh agent in
+ * the matching domain reads the entire pool file, so unbounded growth would
+ * inflate every dispatch.
+ */
+export const POOL_LINE_CAP = 200;
+
+/**
+ * Per-entry length cap. Defense in depth around the prompt-injection-via-
+ * promotion residual risk: a borderline candidate that slips past human
+ * review can't smuggle a multi-page rule into every sibling's seed.
+ */
+export const ENTRY_LINE_CAP = 30;
+
+const POOL_HEADER = `# Shared lessons pool
+
+Read-only at agent runtime. Curated by \`vp-dev lessons review\` — never
+edited by a coding agent during a run. The orchestrator process is the only
+writer for this directory.
+
+## Format constraints
+- Each entry: at most ${ENTRY_LINE_CAP} lines (including provenance comment + heading).
+- Descriptive observations only — no imperative instructions to siblings.
+- Quote or fence technical content (commands, addresses, code).
+- File capped at ${POOL_LINE_CAP} lines. When full, trim manually before
+  promoting more.
+
+`;
+
+export interface PoolEntry {
+  domain: string;
+  heading: string;
+  body: string;
+  sourceAgentId: string;
+  ts: string;
+}
+
+export function poolPath(domain: string): string {
+  return path.join(LESSONS_DIR, `${normalizeDomain(domain)}.md`);
+}
+
+export function normalizeDomain(domain: string): string {
+  return domain.trim().toLowerCase().replace(/[^a-z0-9-]/g, "-");
+}
+
+export async function readDomainPool(domain: string): Promise<string | null> {
+  const norm = normalizeDomain(domain);
+  if (!norm) return null;
+  try {
+    return await fs.readFile(poolPath(norm), "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+export function formatEntry(entry: PoolEntry): string {
+  return [
+    "",
+    `<!-- promoted from:${entry.sourceAgentId} ts:${entry.ts} -->`,
+    `## ${entry.heading.trim()}`,
+    "",
+    entry.body.trim(),
+    "",
+  ].join("\n");
+}
+
+export function countLines(s: string): number {
+  if (s.length === 0) return 0;
+  // Trailing newline contributes a final empty "line" via split — match the
+  // user's mental model (`wc -l`) by trimming one trailing newline before
+  // counting.
+  const stripped = s.endsWith("\n") ? s.slice(0, -1) : s;
+  if (stripped.length === 0) return 0;
+  return stripped.split(/\r?\n/).length;
+}
+
+export type AppendResult =
+  | { kind: "appended"; totalLines: number; entryLines: number }
+  | { kind: "rejected-pool-cap"; currentLines: number; entryLines: number; cap: number }
+  | { kind: "rejected-entry-cap"; entryLines: number; cap: number };
+
+export async function appendDomainPool(entry: PoolEntry): Promise<AppendResult> {
+  const filePath = poolPath(entry.domain);
+  const formatted = formatEntry(entry);
+  const entryLines = countLines(formatted);
+  if (entryLines > ENTRY_LINE_CAP) {
+    return { kind: "rejected-entry-cap", entryLines, cap: ENTRY_LINE_CAP };
+  }
+  await ensureDir(path.dirname(filePath));
+  return withFileLock(filePath, async () => {
+    let current: string;
+    try {
+      current = await fs.readFile(filePath, "utf-8");
+    } catch {
+      current = POOL_HEADER;
+    }
+    const currentLines = countLines(current);
+    if (currentLines + entryLines > POOL_LINE_CAP) {
+      return {
+        kind: "rejected-pool-cap",
+        currentLines,
+        entryLines,
+        cap: POOL_LINE_CAP,
+      };
+    }
+    const next = current.endsWith("\n") ? current + formatted : current + "\n" + formatted;
+    const tmp = `${filePath}.tmp.${process.pid}`;
+    await fs.writeFile(tmp, next);
+    await fs.rename(tmp, filePath);
+    return { kind: "appended", totalLines: countLines(next), entryLines };
+  });
+}
+
+/**
+ * Promotion-candidate marker scanner. The summarizer prompt instructs the
+ * LLM to wrap cross-agent-useful body content in
+ * `<!-- promote-candidate:<domain> -->...<!-- /promote-candidate -->`. This
+ * regex extracts each candidate block from a CLAUDE.md, leaving every other
+ * <!-- ... --> comment (provenance, promoted, not-promoted) untouched.
+ */
+const CANDIDATE_RE =
+  /<!--\s*promote-candidate:([a-z0-9-]+)\s*-->([\s\S]*?)<!--\s*\/promote-candidate\s*-->/gi;
+
+/** Match a markdown ATX h2 heading line. */
+const H2_RE = /^##\s+(.+?)\s*$/m;
+
+export interface PendingCandidate {
+  agentId: string;
+  domain: string;
+  /** The text between the open + close markers, trimmed. */
+  inner: string;
+  /** The nearest preceding `## ...` heading, used as the pool entry heading. */
+  heading: string;
+  /** Index in the source CLAUDE.md where the open marker begins. */
+  startIdx: number;
+  /** Index where the close marker ends (exclusive). */
+  endIdx: number;
+  /** The full match including markers — used to splice replacements. */
+  rawBlock: string;
+}
+
+export function scanCandidates(agentId: string, claudeMd: string): PendingCandidate[] {
+  const out: PendingCandidate[] = [];
+  for (const m of claudeMd.matchAll(CANDIDATE_RE)) {
+    const startIdx = m.index ?? 0;
+    const endIdx = startIdx + m[0].length;
+    const heading = nearestHeadingBefore(claudeMd, startIdx);
+    out.push({
+      agentId,
+      domain: m[1].toLowerCase(),
+      inner: m[2].trim(),
+      heading,
+      startIdx,
+      endIdx,
+      rawBlock: m[0],
+    });
+  }
+  return out;
+}
+
+function nearestHeadingBefore(md: string, idx: number): string {
+  const before = md.slice(0, idx);
+  // Walk backward through h2 headings; the last (latest) match wins.
+  let last: string | null = null;
+  for (const m of before.matchAll(new RegExp(H2_RE.source, "gm"))) {
+    last = m[1].trim();
+  }
+  return last ?? `Promoted lesson`;
+}
+
+/**
+ * Replace a candidate's markers in place with a status comment. Used by the
+ * review CLI after the human picks accept/reject — the source CLAUDE.md
+ * keeps the body content but loses the candidate wrapping so the same block
+ * never re-surfaces in the next review pass. Acquires the agent's CLAUDE.md
+ * lock so a concurrent summarizer-append doesn't trample the splice.
+ */
+export async function replaceCandidateMarkers(input: {
+  agentId: string;
+  startIdx: number;
+  endIdx: number;
+  inner: string;
+  status: "promoted" | "not-promoted";
+  meta: string;
+}): Promise<void> {
+  const filePath = agentClaudeMdPath(input.agentId);
+  await withFileLock(filePath, async () => {
+    const current = await fs.readFile(filePath, "utf-8");
+    // Re-locate the block by content, not by stale index — another summarizer
+    // append between scan and apply would have shifted offsets but not the
+    // contents of this exact wrapped block.
+    const open = `<!-- promote-candidate:`;
+    const close = `<!-- /promote-candidate -->`;
+    const innerSlice = current.slice(input.startIdx, input.endIdx);
+    let startIdx = input.startIdx;
+    let endIdx = input.endIdx;
+    if (!innerSlice.startsWith(open) || !current.slice(0, endIdx).endsWith(close)) {
+      // Fall back to a content search using the original raw block.
+      const probe = current.indexOf(input.inner);
+      if (probe < 0) throw new Error(`candidate inner not found in ${filePath}`);
+      // Find the open marker preceding it, and the close after it.
+      const openIdx = current.lastIndexOf(open, probe);
+      if (openIdx < 0) throw new Error(`open marker not found before inner`);
+      const closeIdx = current.indexOf(close, probe + input.inner.length);
+      if (closeIdx < 0) throw new Error(`close marker not found after inner`);
+      startIdx = openIdx;
+      endIdx = closeIdx + close.length;
+    }
+    const ts = new Date().toISOString();
+    const replacement =
+      input.status === "promoted"
+        ? `<!-- promoted:${input.meta}:${ts} -->\n${input.inner}`
+        : `<!-- not-promoted:${input.meta}:${ts} -->\n${input.inner}`;
+    const next = current.slice(0, startIdx) + replacement + current.slice(endIdx);
+    const tmp = `${filePath}.tmp.${process.pid}`;
+    await fs.writeFile(tmp, next);
+    await fs.rename(tmp, filePath);
+  });
+}

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-import { readAgentClaudeMd } from "./specialization.js";
+import { primaryDomain, readAgentClaudeMd } from "./specialization.js";
+import { readDomainPool } from "./lessonsPool.js";
 import { renderWorkflow, type WorkflowVars } from "./workflow.js";
 import type { AgentRecord } from "../types.js";
 
@@ -27,6 +28,25 @@ export async function buildAgentSystemPrompt(opts: {
     claudeMd.trim(),
     "",
   ];
+
+  // Shared lessons pool seeded between the agent's own CLAUDE.md and any
+  // per-issue plan. Domain = the agent's first non-general tag. No file ⇒
+  // skip silently (the absence is normal — most agent/domain pairs won't have
+  // a curated pool yet).
+  const domain = primaryDomain(opts.agent.tags);
+  const sharedLessons = domain ? await readDomainPool(domain) : null;
+  if (sharedLessons && sharedLessons.trim().length > 0) {
+    sections.push(
+      "---",
+      "",
+      `# Shared lessons (${domain})`,
+      "",
+      "Domain knowledge curated from sibling agents. Read-only seed — never write to `agents/.shared/`.",
+      "",
+      sharedLessons.trim(),
+      "",
+    );
+  }
 
   if (plan) {
     sections.push(

--- a/src/agent/specialization.ts
+++ b/src/agent/specialization.ts
@@ -76,6 +76,22 @@ export async function readAgentClaudeMd(
   }
 }
 
+/**
+ * Pick the agent's primary domain — the first non-"general" tag, lowercased.
+ * Returns null if the agent only carries "general" or has no tags. The shared
+ * lessons pool keys files on this value, so any domain a sibling pool exists
+ * for must round-trip through this resolver to stay reachable. Deliberately
+ * does NOT introduce a second taxonomy on top of the existing free-form tag
+ * set — domains ARE tags.
+ */
+export function primaryDomain(tags: readonly string[]): string | null {
+  for (const t of tags) {
+    const lower = t.toLowerCase().trim();
+    if (lower && lower !== "general") return lower;
+  }
+  return null;
+}
+
 export interface AppendBlockInput {
   agentId: string;
   runId: string;

--- a/src/agent/summarizer.ts
+++ b/src/agent/summarizer.ts
@@ -225,6 +225,13 @@ Hard rules:
 - Do NOT mention the specific issue number, PR number, or run id — that's in the provenance comment. Talk about the class of situation, not this instance.
 - Inside heading / body / skipReason string values: escape every double-quote as \\" and every literal newline as \\n. Do NOT escape apostrophes — \\' is INVALID JSON (the parser only knows \\", \\\\, \\/, \\b, \\f, \\n, \\r, \\t, \\uXXXX). Write apostrophes as a plain ': don't, isn't, can't. Prefer single-quote ' or backticks for emphasis when the alternative is acceptable.
 
+Cross-agent promotion (OPTIONAL):
+- If the lesson would also help a sibling agent in the same primary domain — typically a domain quirk, an SDK gotcha, an on-chain protocol invariant, or a tooling pitfall — wrap the body content in \`<!-- promote-candidate:<DOMAIN> --> ... <!-- /promote-candidate -->\` where DOMAIN is the agent's first non-"general" tag, lowercased.
+- The wrapped section MUST be a descriptive observation, not an imperative directive ("on chain X, RPC Y returns null when …" — yes; "always do Z before calling Y" — no, that's per-agent rule shape).
+- Fence or quote technical content (commands, addresses, code snippets).
+- Skip the wrapping for behaviour rules specific to THIS agent's role, push-back patterns, workflow discipline, or anything that wouldn't survive being read by a sibling with a different tag set.
+- A human reviewer gates promotion via \`vp-dev lessons review\` — false positives are recoverable, false negatives lose the cross-agent signal.
+
 Output: a single JSON object, no fences, no prose. The \`skip\` field is MANDATORY in every response. Use \`{"skip": false, "heading": "...", "body": "..."}\` when there is a lesson worth saving, and \`{"skip": true, "skipReason": "..."}\` otherwise. Schema:
   {"skip": boolean, "skipReason"?: string, "heading"?: string, "body"?: string}`;
 
@@ -245,6 +252,12 @@ Hard rules:
 - Body: ≤ 2000 chars. 2–8 short lines. No prose paragraphs.
 - Do NOT mention the specific issue number, PR number, or run id — that's in the provenance comment. Talk about the class of failure, not this instance.
 - Inside heading / body / skipReason string values: escape every double-quote as \\" and every literal newline as \\n. Do NOT escape apostrophes — \\' is INVALID JSON. Write apostrophes as a plain ': don't, isn't, can't.
+
+Cross-agent promotion (OPTIONAL):
+- If the failure mode would also bite a sibling agent in the same primary domain (SDK quirk, RPC behaviour, protocol invariant, build / test pitfall), wrap the relevant body content in \`<!-- promote-candidate:<DOMAIN> --> ... <!-- /promote-candidate -->\` where DOMAIN is the agent's first non-"general" tag, lowercased.
+- Wrapped content MUST be a descriptive observation, not an imperative directive. Fence technical content (commands, addresses, code).
+- Skip the wrapping for failures specific to this agent's workflow, push-back style, or one-off plan-vs-code mismatch — those don't generalize across siblings.
+- Human reviewer gates promotion via \`vp-dev lessons review\`.
 
 Output: a single JSON object, no fences, no prose. The \`skip\` field is MANDATORY in every response. Schema:
   {"skip": boolean, "skipReason"?: string, "heading"?: string, "body"?: string}`;

--- a/src/agent/workflow.ts
+++ b/src/agent/workflow.ts
@@ -90,6 +90,7 @@ Tags: lowercase, dash-separated, domain-specific (e.g. solana, spl-token, aave, 
 Hard rules:
 - Never push to main. Never run \`git push origin main\`.
 - Never use --no-verify, --force without --force-with-lease, or amend a pushed commit.
+- Never write to \`agents/.shared/\` — that directory is curated by the orchestrator's \`vp-dev lessons review\` flow. Read-only seed from your perspective; cross-agent writes corrupt parallel runs.
 - The JSON envelope MUST be your last message. Missing or malformed → the run records the issue as failed.
 `;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,7 +38,19 @@ import {
   resolveTargetRepoPath,
 } from "./git/worktree.js";
 import { agentClaudeMdPath, forkClaudeMd } from "./agent/specialization.js";
+import {
+  appendDomainPool,
+  ENTRY_LINE_CAP,
+  POOL_LINE_CAP,
+  poolPath,
+  replaceCandidateMarkers,
+  scanCandidates,
+  type PendingCandidate,
+} from "./agent/lessonsPool.js";
 import { promises as fs } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawn } from "node:child_process";
 import { runIssueCore } from "./agent/runIssueCore.js";
 import {
   applySplit,
@@ -200,6 +212,26 @@ export function buildCli(): Command {
         }),
     );
   program.addCommand(agentsCmd);
+
+  const lessonsCmd = new Command("lessons")
+    .description("Curate the cross-agent shared lessons pool (agents/.shared/lessons/<domain>.md)")
+    .addCommand(
+      new Command("list")
+        .description("List pending promotion candidates across all agents")
+        .option("--json", "Print machine-readable JSON")
+        .action(async (opts) => {
+          await cmdLessonsList(opts);
+        }),
+    )
+    .addCommand(
+      new Command("review")
+        .description("Walk pending promotion candidates and accept / reject / skip each (interactive)")
+        .option("--yes", "Accept every candidate without prompting (only valid in non-interactive scripts; bypasses the human gate)")
+        .action(async (opts) => {
+          await cmdLessonsReview(opts);
+        }),
+    );
+  program.addCommand(lessonsCmd);
 
   return program;
 }
@@ -1171,6 +1203,215 @@ async function cmdAgentsStats(opts: AgentsStatsOpts): Promise<void> {
     String(r.medianCiCycles),
   ]);
   printTable(headers, rows);
+}
+
+interface LessonsListOpts {
+  json?: boolean;
+}
+
+async function cmdLessonsList(opts: LessonsListOpts): Promise<void> {
+  const candidates = await collectAllCandidates();
+  if (opts.json) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          candidates: candidates.map((c) => ({
+            agentId: c.agentId,
+            domain: c.domain,
+            heading: c.heading,
+            innerPreview: c.inner.length > 200 ? c.inner.slice(0, 197) + "..." : c.inner,
+          })),
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    return;
+  }
+  if (candidates.length === 0) {
+    process.stdout.write("No pending promotion candidates.\n");
+    return;
+  }
+  const byDomain = new Map<string, PendingCandidate[]>();
+  for (const c of candidates) {
+    const arr = byDomain.get(c.domain) ?? [];
+    arr.push(c);
+    byDomain.set(c.domain, arr);
+  }
+  for (const [domain, list] of [...byDomain.entries()].sort()) {
+    process.stdout.write(`\n=== domain: ${domain} (${list.length} candidate${list.length === 1 ? "" : "s"})\n`);
+    for (const c of list) {
+      process.stdout.write(`  - ${c.agentId}  heading="${c.heading}"\n`);
+    }
+  }
+  process.stdout.write(`\nTotal: ${candidates.length} pending. Run \`vp-dev lessons review\` to triage.\n`);
+}
+
+interface LessonsReviewOpts {
+  yes?: boolean;
+}
+
+async function cmdLessonsReview(opts: LessonsReviewOpts): Promise<void> {
+  const candidates = await collectAllCandidates();
+  if (candidates.length === 0) {
+    process.stdout.write("No pending promotion candidates.\n");
+    return;
+  }
+  if (opts.yes) {
+    process.stdout.write(
+      "WARNING: --yes accepts every candidate without prompting. The pool's defense in depth (per-entry line cap, pool cap) still applies, but content review is bypassed.\n\n",
+    );
+  } else if (!process.stdin.isTTY) {
+    process.stderr.write(
+      "ERROR: stdin is not a TTY. Use --yes to bypass the prompt (accepts every candidate; pool/entry caps still enforced).\n",
+    );
+    process.exit(2);
+  }
+
+  let acceptedCount = 0;
+  let rejectedCount = 0;
+  let skippedCount = 0;
+  let capRejectCount = 0;
+
+  const { createInterface } = await import("node:readline/promises");
+  const rl = opts.yes
+    ? null
+    : createInterface({ input: process.stdin, output: process.stdout });
+
+  try {
+    for (let i = 0; i < candidates.length; i++) {
+      const c = candidates[i];
+      process.stdout.write(
+        `\n[${i + 1}/${candidates.length}] agent=${c.agentId} domain=${c.domain} heading="${c.heading}"\n`,
+      );
+      process.stdout.write(`---\n${c.inner}\n---\n`);
+
+      let action: "accept" | "edit" | "reject" | "skip" = "accept";
+      let editedInner: string | null = null;
+      if (rl) {
+        const answer = (await rl.question("[a]ccept / [e]dit / [r]eject / [s]kip / [q]uit: "))
+          .trim()
+          .toLowerCase();
+        if (answer === "q" || answer === "quit") break;
+        if (answer === "r" || answer === "reject") action = "reject";
+        else if (answer === "s" || answer === "skip" || answer === "") action = "skip";
+        else if (answer === "e" || answer === "edit") {
+          const edited = await editInExternalEditor(c.inner);
+          if (edited === null) {
+            process.stdout.write("(editor unchanged — accepting as-is)\n");
+            action = "accept";
+          } else if (edited.trim().length === 0) {
+            process.stdout.write("(editor produced empty content — treating as reject)\n");
+            action = "reject";
+          } else {
+            editedInner = edited;
+            action = "accept";
+          }
+        } else {
+          action = "accept";
+        }
+      }
+
+      if (action === "skip") {
+        skippedCount += 1;
+        process.stdout.write("  → skipped (will resurface in next review).\n");
+        continue;
+      }
+      if (action === "reject") {
+        let reason = "manual";
+        if (rl) {
+          const r = (await rl.question("  reject reason (one short word, default 'manual'): ")).trim();
+          if (r) reason = r.replace(/[^a-zA-Z0-9-]/g, "-").slice(0, 32) || "manual";
+        }
+        await replaceCandidateMarkers({
+          agentId: c.agentId,
+          startIdx: c.startIdx,
+          endIdx: c.endIdx,
+          inner: c.inner,
+          status: "not-promoted",
+          meta: reason,
+        });
+        rejectedCount += 1;
+        process.stdout.write(`  → rejected (reason=${reason}).\n`);
+        continue;
+      }
+
+      const finalInner = editedInner ?? c.inner;
+      const result = await appendDomainPool({
+        domain: c.domain,
+        heading: c.heading,
+        body: finalInner,
+        sourceAgentId: c.agentId,
+        ts: new Date().toISOString(),
+      });
+      if (result.kind === "rejected-entry-cap") {
+        capRejectCount += 1;
+        process.stdout.write(
+          `  → ENTRY-CAP REJECT: this entry is ${result.entryLines} lines, cap=${result.cap}. Trim the body or split into multiple smaller entries, then re-run review.\n`,
+        );
+        continue;
+      }
+      if (result.kind === "rejected-pool-cap") {
+        capRejectCount += 1;
+        process.stdout.write(
+          `  → POOL-CAP REJECT: pool ${poolPath(c.domain)} is ${result.currentLines} lines, adding this would exceed ${result.cap}. Trim the pool file by hand, then re-run review.\n`,
+        );
+        continue;
+      }
+      await replaceCandidateMarkers({
+        agentId: c.agentId,
+        startIdx: c.startIdx,
+        endIdx: c.endIdx,
+        inner: c.inner,
+        status: "promoted",
+        meta: c.domain,
+      });
+      acceptedCount += 1;
+      process.stdout.write(
+        `  → accepted → ${poolPath(c.domain)} (pool now ${result.totalLines}/${POOL_LINE_CAP} lines, entry ${result.entryLines}/${ENTRY_LINE_CAP}).\n`,
+      );
+    }
+  } finally {
+    rl?.close();
+  }
+
+  process.stdout.write(
+    `\nReview complete: accepted=${acceptedCount} rejected=${rejectedCount} skipped=${skippedCount} cap-reject=${capRejectCount}\n`,
+  );
+}
+
+async function collectAllCandidates(): Promise<PendingCandidate[]> {
+  const reg = await loadRegistry();
+  const out: PendingCandidate[] = [];
+  for (const a of reg.agents) {
+    let md: string;
+    try {
+      md = await fs.readFile(agentClaudeMdPath(a.agentId), "utf-8");
+    } catch {
+      continue;
+    }
+    out.push(...scanCandidates(a.agentId, md));
+  }
+  return out;
+}
+
+async function editInExternalEditor(initial: string): Promise<string | null> {
+  const editor = process.env.EDITOR || process.env.VISUAL || "vi";
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "vp-dev-lesson-"));
+  const file = path.join(dir, "candidate.md");
+  await fs.writeFile(file, initial);
+  const before = await fs.readFile(file, "utf-8");
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(editor, [file], { stdio: "inherit" });
+    child.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`editor exited with code ${code}`));
+    });
+    child.on("error", reject);
+  });
+  const after = await fs.readFile(file, "utf-8");
+  await fs.rm(dir, { recursive: true, force: true });
+  return after === before ? null : after;
 }
 
 function printTable(headers: string[], rows: string[][]): void {


### PR DESCRIPTION
Closes #33.

## Summary

Adds `agents/.shared/lessons/<domain>.md` — read-only at agent runtime, write-only via human-gated `vp-dev lessons review` curation. Lets domain knowledge (Solana RPC quirks, ERC-4626 semantics, ethers v5/v6 drift) flow between sibling agents without violating the "no cross-agent writes" boundary.

- **Read path**: `buildAgentSystemPrompt()` resolves the agent's primary domain (first non-"general" tag) and seeds the matching pool file alongside the agent's own CLAUDE.md. Skipped silently when the pool doesn't exist.
- **Tagging path**: success and failure summarizer prompts ask the LLM to wrap cross-agent-useful body content in `<!-- promote-candidate:<domain> -->...<!-- /promote-candidate -->`. Marker is descriptive-observation only — siblings can't be told what to do, only what was observed.
- **Curation path**: `vp-dev lessons list` (with `--json`) and `vp-dev lessons review` (interactive `accept/edit/reject/skip/quit`). Source CLAUDE.md keeps the body content but loses the candidate wrapping — replaced with `<!-- promoted:... -->` or `<!-- not-promoted:... -->` so the same block never re-surfaces.
- **Caps**: 30 lines per entry, 200 lines per pool file. Cap-rejects surface trim instructions and leave the pool file unchanged.
- **Boundary preservation**: coding agents never touch `agents/.shared/` — only the orchestrator's review CLI writes there. Explicit "never write to `agents/.shared/`" guard rail added to `renderWorkflow()`.

## Files

- `src/agent/lessonsPool.ts` (new) — pool file management, candidate scanner, file-locked marker replacement.
- `src/agent/specialization.ts` — `primaryDomain()` resolver.
- `src/agent/prompt.ts` — pool-seeding section in the agent system prompt.
- `src/agent/summarizer.ts` — promotion-marker instructions in success + failure prompts.
- `src/agent/workflow.ts` — `agents/.shared/` write-guard rule.
- `src/cli.ts` — `vp-dev lessons list / review` subcommands.

## Test plan

- [ ] `npm run typecheck` clean
- [ ] `npm run build` clean
- [ ] Hand-create a `<!-- promote-candidate:solana --> ... <!-- /promote-candidate -->` block in an agent's CLAUDE.md → `vp-dev lessons list` surfaces it
- [ ] `vp-dev lessons review` → `accept` appends to `agents/.shared/lessons/solana.md`, replaces source wrapping with `<!-- promoted:solana:<ts> -->`
- [ ] `vp-dev lessons review` → `reject` replaces source wrapping with `<!-- not-promoted:<reason>:<ts> -->`, pool file unchanged
- [ ] Per-entry > 30 lines → `ENTRY-CAP REJECT` with trim instruction, pool unchanged
- [ ] Pool already > 200 lines → `POOL-CAP REJECT` with trim instruction, pool unchanged
- [ ] Fresh dispatch on a `solana`-tagged agent shows `# Shared lessons (solana)` block in the prompt log

🤖 Generated with [Claude Code](https://claude.com/claude-code)