### PR TITLE
narrow triage body/comments-conflict skip to irreconcilable cases

### DIFF
--- a/src/orchestrator/triage.ts
+++ b/src/orchestrator/triage.ts
@@ -198,9 +198,13 @@ Rubric:
 - Ready: a concrete bug with a repro, or a feature with explicit acceptance criteria, or a clearly-scoped refactor.
 - NOT ready — ambiguous: "we should think about", "explore", "investigate", "discuss", or no acceptance criteria.
 - NOT ready — duplicate: the issue body or comments explicitly say it is a duplicate of another open issue.
-- NOT ready — body/comments conflict: the comments redirect to a different scope than the body, and a coding agent reading body-only would do the wrong thing.
+- NOT ready — body/comments conflict (irreconcilable only): comments mark the issue obsolete / superseded / won't-fix, redirect to a different open issue as a true duplicate, or invalidate the body's premise ("actually we don't want this anymore"). Only skip when the conflict cannot be resolved at dispatch time.
 
 The "Issue Analysis" rule from the agent's CLAUDE.md REQUIRES reading comments — body and comments together form the spec. Prefer comments when they correct or override the body.
+
+Pass through (ready: true) for transient conflicts the dispatched agent can resolve by re-reading comments:
+- "blocked on PR #N" / "depends on #M" / "waiting for upstream merge" — the agent re-reads comments at dispatch time and pushes back if still blocked, or proceeds if the dependency landed.
+- Comments adding follow-up scope or clarifying acceptance criteria without invalidating the body.
 
 Output: a single JSON object, no fences, no prose.
   {"ready": boolean, "reason": "<one short sentence, ≤240 chars>", "suggestedSpecialty"?: "<short hint, optional>"}


### PR DESCRIPTION
Closes #67.

## Summary

Narrow the triage rubric's body/comments-conflict skip to **irreconcilable** cases only. Transient "blocked on PR #N" / "depends on #M" conflicts now pass through (`ready: true`) so the dispatched coding agent — which already re-reads comments per the global Issue Analysis rule — can either push back if still blocked, or proceed once the dependency lands.

## What changed

`src/orchestrator/triage.ts` — prompt-only edit to the rubric. The "NOT ready — body/comments conflict" branch now requires obsolete / superseded / won't-fix / true-duplicate / invalidated-premise signals, and an explicit pass-through clause covers transient blockers and additive scope-clarifying comments.

## Why this is the smallest fix

The issue itself proposed a prompt tweak as the implementation hint; no orchestrator code changes are needed. The agent's existing pushback path handles still-blocked dispatches correctly, so the conservative skip's only saved cost is a single sonnet call — outweighed by the user-side cost of re-running `vp-dev run --plan` after upstream PRs merge or globally `--include-non-ready`-ing.

## Test plan

- [x] `npm run build` — clean compile
- [x] `npm test` — 12/12 pass
- [ ] Behavioral validation lands when the next planning run encounters a "blocked on PR #N" issue (e.g. a future analog of #56) and dispatches it instead of skipping.

— Rogue Oracle (agent-72c6)
