### PR TITLE
fix(agent-seed): inherit Best-Architectural-Solution Discipline, not Smallest-Solution

### DIFF
--- a/src/agent/specialization.ts
+++ b/src/agent/specialization.ts
@@ -21,7 +21,7 @@ fresh agent better starting rules.
 - PR body must use \`Closes #N\` on its own line for GitHub auto-close.
 
 ## Code Discipline
-- Smallest change first. Don't add features beyond the issue's stated scope.
+- Architecturally best-fitting change. Match scope to the problem's structural shape — don't paper over a structural issue with an inline patch, and don't over-engineer a localized bug.
 - Trust framework guarantees — don't add error handling for impossible cases.
 - Default to no comments. Only add when WHY is non-obvious.
 

--- a/src/agent/workflow.ts
+++ b/src/agent/workflow.ts
@@ -38,7 +38,7 @@ If a \`# Plan for issue #${v.issueId} (from feature-plans/...)\` section appears
 
 ## Step 2 — Apply judgment rules from CLAUDE.md
 - Push-Back Discipline: faulty premise → push back BEFORE acting.
-- Smallest-Solution Discipline: minimum change first; flag larger proposals.
+- Best-Architectural-Solution Discipline: pick the architecturally best-fitting scope — not the smallest, not the biggest. Match the resolution to the problem's structural shape; flag wrong-sized proposals.
 - Rogue-Agent-Only Triage: pure-advisory threats with no signing flow → close as architectural; do not invent skill-side defenses against rogue agents.
 - Cross-Repo Scope Splits: if the fix splits between MCP code and skill rendering, file the skill half as a tracked issue in vaultpilot-security-skill and link both ways.
 - Typed-Data Signing Discipline applies if the issue touches typed-data signing tools.


### PR DESCRIPTION
Closes #70

## Summary

Global `~/.claude/CLAUDE.md` was updated to replace **Smallest-Solution Discipline** with **Best-Architectural-Solution Discipline** ("push back with the architecturally best-fitting solution — not the smallest, not the biggest"). Two seed surfaces in the dispatch pipeline still carried the old text, so freshly seeded agents continued to inherit the superseded rule:

- `src/agent/workflow.ts` — Step 2 judgment rules in the workflow prompt rendered into every agent's seed.
- `src/agent/specialization.ts` — `GENERIC_SEED` used when the target repo ships no `CLAUDE.md`.

Both now mirror the new global rule, condensed to one bullet to match the surrounding density.

## Scope

Per Smallest-Solution / Best-Architectural-Solution Discipline itself: this is a localized two-line text update — no module restructure, no helper extraction, no test surface touched (the existing test suite covers JSON-envelope parsing, not prompt content).

## Verification

- `npm run build` → clean
- `npm test` → 12/12 pass

— Safe Forensics (agent-e22f)
