### PR TITLE
fix(dispatch): skip issues already covered by an open vp-dev PR

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import {
   approveSetup,
   buildSetupPreview,
   formatSetupPreview,
+  type OpenPrSkipped,
   type TriageSkipped,
 } from "./orchestrator/setup.js";
 import {
@@ -37,6 +38,7 @@ import {
   pruneWorktrees,
   resolveTargetRepoPath,
 } from "./git/worktree.js";
+import { findOpenVpDevPrs } from "./git/openPrs.js";
 import { agentClaudeMdPath, forkClaudeMd } from "./agent/specialization.js";
 import { promises as fs } from "node:fs";
 import { runIssueCore } from "./agent/runIssueCore.js";
@@ -346,6 +348,27 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     process.exit(2);
   }
 
+  // Issues with an open vp-dev PR can't be re-dispatched: `git worktree add
+  // -b <branch>` collides on the branch the prior run pushed. Filter them
+  // before the gate so the user sees the skip in the preview. Per #62 — the
+  // smallest, least surprising default.
+  const openPrMap = await findOpenVpDevPrs({
+    targetRepo: opts.targetRepo,
+    repoPath,
+  });
+  const { dispatchIssues: dispatchAfterPr, openPrSkipped } = partitionOpenPrIssues(
+    dispatchIssues,
+    openPrMap,
+  );
+  const triagePassedCount = dispatchIssues.length;
+  dispatchIssues = dispatchAfterPr;
+  if (dispatchIssues.length === 0) {
+    console.error(
+      `ERROR: all ${triagePassedCount} triage-ready issue(s) are already covered by an open vp-dev PR. Let those PRs land (or close them) before re-dispatching.`,
+    );
+    process.exit(2);
+  }
+
   const registry = await loadRegistry();
   const preview = await buildSetupPreview({
     targetRepo: opts.targetRepo,
@@ -358,6 +381,7 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     resume: false,
     registry,
     triageSkipped,
+    openPrSkipped,
   });
 
   if (opts.plan) {
@@ -510,7 +534,20 @@ async function runResume(opts: RunOpts): Promise<void> {
 
   const { open, skippedClosed } = await resolveRangeToIssues(state.targetRepo, state.issueRange);
   const tracked = new Set(Object.keys(state.issues).map(Number));
-  const issues = open.filter((i) => tracked.has(i.id));
+  const trackedOpen = open.filter((i) => tracked.has(i.id));
+
+  // Same filter as `cmdRun` — issues whose vp-dev branch already has an
+  // open PR can't be re-dispatched without colliding on `git worktree add
+  // -b`. On resume this is even more likely: a previous run that crashed
+  // mid-tick will have left in-flight PRs behind.
+  const openPrMap = await findOpenVpDevPrs({
+    targetRepo: state.targetRepo,
+    repoPath,
+  });
+  const { dispatchIssues: issues, openPrSkipped } = partitionOpenPrIssues(
+    trackedOpen,
+    openPrMap,
+  );
 
   const registry = await loadRegistry();
   const preview = await buildSetupPreview({
@@ -523,6 +560,7 @@ async function runResume(opts: RunOpts): Promise<void> {
     dryRun: state.dryRun,
     resume: true,
     registry,
+    openPrSkipped,
   });
   const approved = await approveSetup({ preview, yes: !!opts.yes });
   if (!approved) {
@@ -1188,4 +1226,36 @@ function parsePositive(value: string): number {
     throw new Error(`Expected positive integer, got "${value}"`);
   }
   return n;
+}
+
+/**
+ * Split a candidate dispatch list into (issues to dispatch, issues to skip
+ * because an open vp-dev PR already covers them). Pure — no I/O.
+ *
+ * Per issue #62: when `pruneStaleAgentBranches` keeps a branch because
+ * `gh pr list --head <branch> --state open` returned a row, the dispatcher's
+ * `git worktree add -b <branch>` will collide. Pre-filtering here makes the
+ * skip explicit in the y/N gate instead of surfacing as an
+ * `error.agent.uncaught` mid-run.
+ */
+function partitionOpenPrIssues(
+  issues: IssueSummary[],
+  openPrMap: Map<number, { branch: string; prUrl: string; agentId: string }>,
+): { dispatchIssues: IssueSummary[]; openPrSkipped: OpenPrSkipped[] } {
+  const dispatchIssues: IssueSummary[] = [];
+  const openPrSkipped: OpenPrSkipped[] = [];
+  for (const issue of issues) {
+    const pr = openPrMap.get(issue.id);
+    if (pr) {
+      openPrSkipped.push({
+        issue,
+        agentId: pr.agentId,
+        branch: pr.branch,
+        prUrl: pr.prUrl,
+      });
+    } else {
+      dispatchIssues.push(issue);
+    }
+  }
+  return { dispatchIssues, openPrSkipped };
 }

--- a/src/git/openPrs.ts
+++ b/src/git/openPrs.ts
@@ -1,0 +1,117 @@
+import { promisify } from "node:util";
+import { execFile as execFileCb } from "node:child_process";
+import type { Logger } from "../log/logger.js";
+
+const execFile = promisify(execFileCb);
+
+// Same shape as createWorktree branch convention: vp-dev/<agentId>/issue-<N>.
+// Captures (agentId, issueId) so callers can render which agent's PR is
+// blocking dispatch — useful diagnostic when the same issue has more than
+// one historical vp-dev attempt.
+const VP_DEV_BRANCH_RE = /^vp-dev\/(agent-[a-z0-9]+)\/issue-(\d+)$/;
+
+export interface OpenVpDevPr {
+  issueId: number;
+  agentId: string;
+  branch: string;
+  prUrl: string;
+  prNumber: number;
+}
+
+interface GhPrListRecord {
+  number: number;
+  url: string;
+  headRefName: string;
+}
+
+/**
+ * Pure helper — extracted so the regex / shape mapping is unit-testable
+ * without spawning `gh`. Records that don't match the vp-dev shape are
+ * silently dropped (human-authored branches are out of scope).
+ */
+export function parseOpenVpDevPrs(records: GhPrListRecord[]): OpenVpDevPr[] {
+  const out: OpenVpDevPr[] = [];
+  for (const r of records) {
+    const m = VP_DEV_BRANCH_RE.exec(r.headRefName);
+    if (!m) continue;
+    const [, agentId, issueIdStr] = m;
+    out.push({
+      issueId: parseInt(issueIdStr, 10),
+      agentId,
+      branch: r.headRefName,
+      prUrl: r.url,
+      prNumber: r.number,
+    });
+  }
+  return out;
+}
+
+/**
+ * Query GitHub for every open PR in `targetRepo` whose head matches the
+ * vp-dev branch convention. Returned as a `Map<issueId, OpenVpDevPr>` so
+ * the dispatcher can decide "skip this issue, an open PR already covers it"
+ * without a per-issue `gh` call.
+ *
+ * If the same issueId has multiple open vp-dev PRs (rare), the first one
+ * wins.
+ *
+ * Failure mode: any `gh` / parse error returns an empty map. The caller
+ * proceeds as if no open PRs existed — the worktree-add collision will
+ * then surface the underlying problem instead of swallowing it under a
+ * generic "skipped due to open PR" reason. We log a warning so the
+ * operator can see the gh check broke.
+ */
+export async function findOpenVpDevPrs(opts: {
+  targetRepo: string;
+  repoPath: string;
+  logger?: Logger;
+}): Promise<Map<number, OpenVpDevPr>> {
+  let raw = "";
+  try {
+    const { stdout } = await execFile(
+      "gh",
+      [
+        "pr",
+        "list",
+        "--repo",
+        opts.targetRepo,
+        "--state",
+        "open",
+        "--limit",
+        "1000",
+        "--json",
+        "number,url,headRefName",
+      ],
+      { cwd: opts.repoPath, maxBuffer: 50 * 1024 * 1024 },
+    );
+    raw = stdout;
+  } catch (err) {
+    opts.logger?.warn("dispatch.open_pr_list_failed", {
+      err: (err as { stderr?: string; message?: string }).stderr ?? (err as Error).message,
+    });
+    return new Map();
+  }
+
+  let records: GhPrListRecord[];
+  try {
+    const arr = JSON.parse(raw) as unknown;
+    if (!Array.isArray(arr)) {
+      opts.logger?.warn("dispatch.open_pr_list_unexpected_shape", { sample: raw.slice(0, 200) });
+      return new Map();
+    }
+    records = arr as GhPrListRecord[];
+  } catch (err) {
+    opts.logger?.warn("dispatch.open_pr_list_parse_failed", {
+      err: (err as Error).message,
+      sample: raw.slice(0, 200),
+    });
+    return new Map();
+  }
+
+  const prs = parseOpenVpDevPrs(records);
+  const map = new Map<number, OpenVpDevPr>();
+  for (const p of prs) {
+    if (!map.has(p.issueId)) map.set(p.issueId, p);
+  }
+  return map;
+}

--- a/src/orchestrator/setup.ts
+++ b/src/orchestrator/setup.ts
@@ -12,6 +12,17 @@ export interface TriageSkipped {
   reason: string;
 }
 
+// Issues filtered out because an open vp-dev PR already covers them. See
+// issue #62: re-dispatching the same (agent, issue) pair throws on
+// `git worktree add -b` because the branch from the prior run still
+// exists. Skipping is the safe default — let the open PR land first.
+export interface OpenPrSkipped {
+  issue: IssueSummary;
+  agentId: string;
+  branch: string;
+  prUrl: string;
+}
+
 export interface SetupPreview {
   targetRepo: string;
   targetRepoPath: string;
@@ -32,6 +43,11 @@ export interface SetupPreview {
   // the gate so the user can see what is being dropped before y/N. When
   // --include-non-ready is passed, triage is skipped and this is empty.
   triageSkipped: TriageSkipped[];
+  // Issues filtered out because an open vp-dev PR already covers them.
+  // Always enforced — there is no override flag (close the PR first, or
+  // use `vp-dev spawn` against a one-off agent if you really need parallel
+  // attempts).
+  openPrSkipped: OpenPrSkipped[];
 }
 
 export interface BuildPreviewInput {
@@ -45,6 +61,7 @@ export interface BuildPreviewInput {
   resume: boolean;
   registry: AgentRegistryFile;
   triageSkipped?: TriageSkipped[];
+  openPrSkipped?: OpenPrSkipped[];
 }
 
 export async function buildSetupPreview(input: BuildPreviewInput): Promise<SetupPreview> {
@@ -79,6 +96,7 @@ export async function buildSetupPreview(input: BuildPreviewInput): Promise<Setup
     generalCount: pick.generalCount,
     overloadWarnings,
     triageSkipped: input.triageSkipped ?? [],
+    openPrSkipped: input.openPrSkipped ?? [],
   };
 }
 
@@ -137,6 +155,17 @@ export function formatSetupPreview(p: SetupPreview): string {
       lines.push(`  #${s.issue.id} — ${s.reason}`);
     }
     lines.push("  Override with --include-non-ready.");
+    lines.push("");
+  }
+
+  if (p.openPrSkipped.length > 0) {
+    lines.push(`${p.openPrSkipped.length} issue(s) skipped — open vp-dev PR already covers them:`);
+    for (const s of p.openPrSkipped) {
+      lines.push(`  #${s.issue.id} — ${s.prUrl} (branch ${s.branch})`);
+    }
+    lines.push(
+      "  The PR from the prior run is the in-flight work. Let it land (or close it) before re-dispatching.",
+    );
     lines.push("");
   }
 

--- a/src/util/openPrs.test.ts
+++ b/src/util/openPrs.test.ts
@@ -1,0 +1,63 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseOpenVpDevPrs } from "../git/openPrs.js";
+
+test("extracts vp-dev PRs from a mixed PR list", () => {
+  const records = [
+    { number: 100, url: "https://github.com/o/r/pull/100", headRefName: "feature/foo" },
+    { number: 101, url: "https://github.com/o/r/pull/101", headRefName: "vp-dev/agent-e22f/issue-29" },
+    { number: 102, url: "https://github.com/o/r/pull/102", headRefName: "vp-dev/agent-5ade/issue-32" },
+    { number: 103, url: "https://github.com/o/r/pull/103", headRefName: "main" },
+  ];
+  const out = parseOpenVpDevPrs(records);
+  assert.equal(out.length, 2);
+  assert.deepEqual(out[0], {
+    issueId: 29,
+    agentId: "agent-e22f",
+    branch: "vp-dev/agent-e22f/issue-29",
+    prUrl: "https://github.com/o/r/pull/101",
+    prNumber: 101,
+  });
+  assert.equal(out[1].issueId, 32);
+  assert.equal(out[1].agentId, "agent-5ade");
+});
+
+test("ignores branches that don't match the vp-dev shape", () => {
+  const records = [
+    { number: 1, url: "u", headRefName: "vp-dev/issue-29" }, // missing agent segment
+    { number: 2, url: "u", headRefName: "vp-dev/agent-x/29" }, // missing issue- prefix
+    { number: 3, url: "u", headRefName: "vp-dev/agent-AB/issue-29" }, // uppercase agent id
+    { number: 4, url: "u", headRefName: "renovate/vp-dev/agent-x/issue-1" }, // not at root
+  ];
+  assert.equal(parseOpenVpDevPrs(records).length, 0);
+});
+
+test("accepts the canonical agentId charset (lowercase alnum)", () => {
+  const records = [
+    { number: 1, url: "u", headRefName: "vp-dev/agent-75a0/issue-62" },
+    { number: 2, url: "u", headRefName: "vp-dev/agent-916a/issue-41" },
+    { number: 3, url: "u", headRefName: "vp-dev/agent-ef41/issue-35" },
+  ];
+  const out = parseOpenVpDevPrs(records);
+  assert.equal(out.length, 3);
+  assert.deepEqual(
+    out.map((p) => [p.agentId, p.issueId]),
+    [
+      ["agent-75a0", 62],
+      ["agent-916a", 41],
+      ["agent-ef41", 35],
+    ],
+  );
+});
+
+test("empty input → empty output", () => {
+  assert.deepEqual(parseOpenVpDevPrs([]), []);
+});
+
+test("multi-digit issue numbers are parsed correctly", () => {
+  const records = [
+    { number: 1, url: "u", headRefName: "vp-dev/agent-x/issue-1234" },
+  ];
+  const out = parseOpenVpDevPrs(records);
+  assert.equal(out[0].issueId, 1234);
+});


### PR DESCRIPTION
Closes #62.

## Summary

Pre-launch sweep correctly keeps `vp-dev/<agentId>/issue-<N>` branches when an open PR depends on them. But the dispatcher's `git worktree add -b <branch>` fails on the next run for the same `(agentId, issueId)` pair because the branch is still around — silently dropping the issue under `error.agent.uncaught`. 4 of 14 issues lost in `run-2026-05-02T10-31-33-192Z`, and the failure rate would compound on every subsequent run.

This change implements resolution path 1 from the issue (the recommended default): a single `gh pr list --state open` call at run start partitions the dispatch list. Issues already covered by an open vp-dev PR are surfaced in the y/N gate alongside `triageSkipped` and dropped from dispatch — the open PR is the in-flight work, let it land or close it.

## Files

- `src/git/openPrs.ts` — new. `findOpenVpDevPrs()` does the gh call; `parseOpenVpDevPrs()` is the pure record→`OpenVpDevPr` mapper, unit-tested.
- `src/orchestrator/setup.ts` — adds `OpenPrSkipped` to the preview struct, renders it under "N issue(s) skipped — open vp-dev PR already covers them".
- `src/cli.ts` — calls `findOpenVpDevPrs` after triage in both `cmdRun` and `runResume`; pure `partitionOpenPrIssues` helper splits the dispatch list.
- `src/util/openPrs.test.ts` — 5 cases for the regex / mapper.

## Design notes

- **No override flag.** The issue framing is "the PR *is* the in-flight work — let it land first." If the user genuinely needs parallel attempts, they can close the PR or use `vp-dev spawn`.
- **Fail-safe ≠ fail-silent on gh failure.** If the gh call breaks (network, auth), we log a warning and proceed with an empty map. The pre-existing stale-branch sweep then keeps the branch and the worktree-add collision surfaces the actual problem instead of being masked by a bogus skip.
- **Smallest fix.** Resolution paths 2 (reuse existing branch) and 3 (salt branch name) were both rejected in the issue write-up — path 1 is the minimum change that solves the failure mode.
- **`--include-non-ready` does NOT bypass this filter.** That flag controls triage; open-PR collision is a hard tooling failure, not a triage rubric.
- **`--plan` / `--confirm` flow.** If the open-PR set changes between plan and confirm (a PR merged or closed), the previewHash diverges and the user is forced to re-plan — correct, since a fresh run might pick up newly-uncovered issues.

## Test plan

- [x] `npm run build` — green.
- [x] `npm test` — 17/17 pass (12 pre-existing + 5 new).
- [ ] Manual: re-run `run-2026-05-02T10-31-33-192Z`'s scenario after merge — issues 29/32/35/41 should appear in the preview's "open vp-dev PR" skip block, not in dispatch.

— Finding Triage (agent-75a0)
