### PR TITLE
feat(specialization): expire failure-lesson sentinels after K overlapping successes

### DIFF
--- a/src/agent/runIssueCore.ts
+++ b/src/agent/runIssueCore.ts
@@ -1,8 +1,14 @@
 import { promises as fs } from "node:fs";
 import { ensureAgent, mutateRegistry } from "../state/registry.js";
 import { runCodingAgent } from "./codingAgent.js";
-import { appendBlock, forkClaudeMd, type AppendOutcome } from "./specialization.js";
+import {
+  appendBlock,
+  expireFailureLessons,
+  forkClaudeMd,
+  type AppendOutcome,
+} from "./specialization.js";
 import { isInfraFlake, summarizeFailureRun, summarizeRun, type SummarizerOutput } from "./summarizer.js";
+import { resolveExpireK } from "../util/sentinels.js";
 import {
   createWorktree,
   removeWorktree,
@@ -115,11 +121,44 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
           issue: input.issue,
           runId: input.runId,
           outcome: outcomeTag,
+          tags: envelope.memoryUpdate.addTags,
           targetRepoPath: input.targetRepoPath,
           logger: input.logger,
         });
         appendOutcome = appendResult.appendOutcome;
         summarySkipReason = appendResult.summarySkipReason;
+
+        // Failure-lesson expiry: after a successful implement run has
+        // been recorded, walk the agent's CLAUDE.md and drop any
+        // failure-lesson sentinel that ≥ K subsequent implements with
+        // overlapping tags have superseded. Only fires for implement —
+        // pushback / failure-lesson runs don't trigger expiry. K is
+        // env-configurable (`VP_DEV_FAILURE_LESSON_EXPIRE_K`, default 3).
+        if (
+          envelope.decision === "implement" &&
+          appendOutcome?.kind === "appended"
+        ) {
+          try {
+            const k = resolveExpireK();
+            const expired = await expireFailureLessons(input.agent.agentId, k);
+            if (expired.kind === "expired") {
+              input.logger.info("specialization.expired", {
+                agentId: input.agent.agentId,
+                issueId: input.issue.id,
+                k,
+                droppedCount: expired.dropped.length,
+                droppedIssues: expired.dropped.map((h) => h.issueId),
+                totalBytes: expired.totalBytes,
+              });
+            }
+          } catch (err) {
+            input.logger.warn("specialization.expire_failed", {
+              agentId: input.agent.agentId,
+              issueId: input.issue.id,
+              err: (err as Error).message,
+            });
+          }
+        }
       }
     } else {
       input.agent.errorCount += 1;
@@ -150,6 +189,10 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
             issue: input.issue,
             runId: input.runId,
             outcome: "failure-lesson",
+            // No envelope this branch — fall back to the agent's current
+            // tag fingerprint as the failure-lesson's topical signal.
+            // Best-effort; expiry's tag-overlap check stays conservative.
+            tags: input.agent.tags,
             targetRepoPath: input.targetRepoPath,
             logger: input.logger,
           });
@@ -217,6 +260,8 @@ interface AppendArgs {
   issue: IssueSummary;
   runId: string;
   outcome: string;
+  /** Tags this issue contributed (envelope.memoryUpdate.addTags). */
+  tags?: string[];
   targetRepoPath: string;
   logger: Logger;
 }
@@ -242,6 +287,7 @@ async function maybeAppendSummary(args: AppendArgs): Promise<{
     outcome: args.outcome,
     heading: args.summary.heading,
     body: args.summary.body,
+    tags: args.tags,
     targetRepoPath: args.targetRepoPath,
   });
   if (appendOutcome.kind === "appended") {

--- a/src/agent/specialization.ts
+++ b/src/agent/specialization.ts
@@ -1,6 +1,11 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { ensureDir, withFileLock } from "../state/locks.js";
+import {
+  expireFailureLessonsInContent,
+  formatSentinelHeader,
+  type SentinelHeader,
+} from "../util/sentinels.js";
 
 export const AGENTS_ROOT = path.resolve(process.cwd(), "agents");
 export const SOFT_CAP_BYTES = 64 * 1024;
@@ -84,6 +89,15 @@ export interface AppendBlockInput {
   heading: string;
   body: string;
   targetRepoPath: string;
+  /**
+   * Tags this issue contributed to the agent's evolving topical
+   * fingerprint (= envelope.memoryUpdate.addTags). Embedded into the
+   * sentinel header as `tags:t1,t2` so future expiry passes can detect
+   * whether subsequent successes are topically related to a stored
+   * failure-lesson. Optional for back-compat; sentinels written without
+   * tags are treated conservatively (never expired) by `expireFailureLessons`.
+   */
+  tags?: string[];
 }
 
 export type AppendOutcome =
@@ -105,9 +119,16 @@ export async function appendBlock(input: AppendBlockInput): Promise<AppendOutcom
     }
 
     const ts = new Date().toISOString();
+    const sentinel = formatSentinelHeader({
+      runId: input.runId,
+      issueId: input.issueId,
+      outcome: input.outcome,
+      ts,
+      tags: input.tags,
+    });
     const block = [
       "",
-      `<!-- run:${input.runId} issue:#${input.issueId} outcome:${input.outcome} ts:${ts} -->`,
+      sentinel,
       `## ${input.heading.trim()}`,
       "",
       input.body.trim(),
@@ -124,6 +145,50 @@ export async function appendBlock(input: AppendBlockInput): Promise<AppendOutcom
       kind: "appended",
       bytesAppended: Buffer.byteLength(block, "utf-8"),
       totalBytes,
+    };
+  });
+}
+
+export type ExpireOutcome =
+  | { kind: "no-op" }
+  | { kind: "expired"; dropped: SentinelHeader[]; totalBytes: number };
+
+/**
+ * Walk the agent's CLAUDE.md and drop `outcome:failure-lesson` blocks
+ * that have ≥ k subsequent `outcome:implement` blocks sharing at least
+ * one tag with the lesson. Idempotent — re-running on the same content
+ * with the same `k` is a no-op. Conservative on legacy sentinels with
+ * no `tags:` field: those are never expired.
+ *
+ * Wired from `runIssueCore` after a successful implement run, matching
+ * the issue's "summarizer rewrites the file after a successful run"
+ * trigger. Shares the same per-file lock as `appendBlock` so the
+ * read-rewrite-write sequence is atomic against concurrent appends.
+ */
+export async function expireFailureLessons(
+  agentId: string,
+  k: number,
+): Promise<ExpireOutcome> {
+  const filePath = agentClaudeMdPath(agentId);
+  return withFileLock(filePath, async () => {
+    let current: string;
+    try {
+      current = await fs.readFile(filePath, "utf-8");
+    } catch {
+      // No CLAUDE.md yet → nothing to expire. Don't seed here; that's
+      // forkClaudeMd / appendBlock's job.
+      return { kind: "no-op" };
+    }
+    const result = expireFailureLessonsInContent(current, k);
+    if (result.droppedHeaders.length === 0) return { kind: "no-op" };
+
+    const tmp = `${filePath}.tmp.${process.pid}`;
+    await fs.writeFile(tmp, result.content);
+    await fs.rename(tmp, filePath);
+    return {
+      kind: "expired",
+      dropped: result.droppedHeaders,
+      totalBytes: Buffer.byteLength(result.content, "utf-8"),
     };
   });
 }

--- a/src/util/sentinels.test.ts
+++ b/src/util/sentinels.test.ts
@@ -1,0 +1,322 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_FAILURE_LESSON_EXPIRE_K,
+  decideExpiry,
+  expireFailureLessonsInContent,
+  formatSentinelHeader,
+  parseSentinelHeader,
+  resolveExpireK,
+} from "./sentinels.js";
+
+test("parseSentinelHeader: legacy sentinel without tags", () => {
+  const h = parseSentinelHeader(
+    "<!-- run:run-1 issue:#42 outcome:failure-lesson ts:2026-05-01T00:00:00.000Z -->",
+  );
+  assert.notEqual(h, null);
+  assert.deepEqual(h, {
+    runId: "run-1",
+    issueId: 42,
+    outcome: "failure-lesson",
+    ts: "2026-05-01T00:00:00.000Z",
+    tags: [],
+  });
+});
+
+test("parseSentinelHeader: sentinel with tags", () => {
+  const h = parseSentinelHeader(
+    "<!-- run:run-1 issue:#42 outcome:implement ts:2026-05-02T00:00:00.000Z tags:auth,refactor -->",
+  );
+  assert.notEqual(h, null);
+  assert.deepEqual(h?.tags, ["auth", "refactor"]);
+  assert.equal(h?.outcome, "implement");
+});
+
+test("parseSentinelHeader: non-sentinel line returns null", () => {
+  assert.equal(parseSentinelHeader("## Some heading"), null);
+  assert.equal(parseSentinelHeader("body text"), null);
+  assert.equal(parseSentinelHeader(""), null);
+});
+
+test("formatSentinelHeader: round-trip", () => {
+  const line = formatSentinelHeader({
+    runId: "run-X",
+    issueId: 7,
+    outcome: "failure-lesson",
+    ts: "2026-05-01T00:00:00.000Z",
+    tags: ["b", "a"],
+  });
+  // Tags are sorted at format time for stable output.
+  assert.equal(
+    line,
+    "<!-- run:run-X issue:#7 outcome:failure-lesson ts:2026-05-01T00:00:00.000Z tags:a,b -->",
+  );
+  const parsed = parseSentinelHeader(line);
+  assert.deepEqual(parsed?.tags, ["a", "b"]);
+});
+
+test("decideExpiry: drops failure-lesson with K=3 overlapping implements", () => {
+  const headers = [
+    {
+      runId: "r1",
+      issueId: 1,
+      outcome: "failure-lesson",
+      ts: "t1",
+      tags: ["auth"],
+    },
+    { runId: "r2", issueId: 2, outcome: "implement", ts: "t2", tags: ["auth"] },
+    {
+      runId: "r3",
+      issueId: 3,
+      outcome: "implement",
+      ts: "t3",
+      tags: ["auth", "x"],
+    },
+    { runId: "r4", issueId: 4, outcome: "implement", ts: "t4", tags: ["auth"] },
+  ];
+  const d = decideExpiry(headers, 3);
+  assert.deepEqual(d.drop, [0]);
+});
+
+test("decideExpiry: keeps failure-lesson with non-overlapping implements", () => {
+  const headers = [
+    {
+      runId: "r1",
+      issueId: 1,
+      outcome: "failure-lesson",
+      ts: "t1",
+      tags: ["auth"],
+    },
+    { runId: "r2", issueId: 2, outcome: "implement", ts: "t2", tags: ["docs"] },
+    { runId: "r3", issueId: 3, outcome: "implement", ts: "t3", tags: ["docs"] },
+    { runId: "r4", issueId: 4, outcome: "implement", ts: "t4", tags: ["docs"] },
+  ];
+  const d = decideExpiry(headers, 3);
+  assert.deepEqual(d.drop, []);
+});
+
+test("decideExpiry: keeps failure-lesson with K-1 overlapping implements", () => {
+  const headers = [
+    {
+      runId: "r1",
+      issueId: 1,
+      outcome: "failure-lesson",
+      ts: "t1",
+      tags: ["auth"],
+    },
+    { runId: "r2", issueId: 2, outcome: "implement", ts: "t2", tags: ["auth"] },
+    { runId: "r3", issueId: 3, outcome: "implement", ts: "t3", tags: ["auth"] },
+  ];
+  const d = decideExpiry(headers, 3);
+  assert.deepEqual(d.drop, []);
+});
+
+test("decideExpiry: pushback blocks don't count toward expiry", () => {
+  const headers = [
+    {
+      runId: "r1",
+      issueId: 1,
+      outcome: "failure-lesson",
+      ts: "t1",
+      tags: ["auth"],
+    },
+    { runId: "r2", issueId: 2, outcome: "implement", ts: "t2", tags: ["auth"] },
+    { runId: "r3", issueId: 3, outcome: "pushback", ts: "t3", tags: ["auth"] },
+    { runId: "r4", issueId: 4, outcome: "pushback", ts: "t4", tags: ["auth"] },
+  ];
+  const d = decideExpiry(headers, 3);
+  assert.deepEqual(d.drop, []);
+});
+
+test("decideExpiry: legacy failure-lesson without tags is never dropped", () => {
+  const headers = [
+    {
+      runId: "r1",
+      issueId: 1,
+      outcome: "failure-lesson",
+      ts: "t1",
+      tags: [],
+    },
+    { runId: "r2", issueId: 2, outcome: "implement", ts: "t2", tags: ["auth"] },
+    { runId: "r3", issueId: 3, outcome: "implement", ts: "t3", tags: ["auth"] },
+    { runId: "r4", issueId: 4, outcome: "implement", ts: "t4", tags: ["auth"] },
+  ];
+  const d = decideExpiry(headers, 3);
+  assert.deepEqual(d.drop, []);
+});
+
+test("decideExpiry: only successes AFTER the lesson count", () => {
+  const headers = [
+    { runId: "r0", issueId: 0, outcome: "implement", ts: "t0", tags: ["auth"] },
+    { runId: "r1", issueId: 1, outcome: "implement", ts: "t1", tags: ["auth"] },
+    {
+      runId: "r2",
+      issueId: 2,
+      outcome: "failure-lesson",
+      ts: "t2",
+      tags: ["auth"],
+    },
+    { runId: "r3", issueId: 3, outcome: "implement", ts: "t3", tags: ["auth"] },
+  ];
+  const d = decideExpiry(headers, 3);
+  // Only one subsequent implement → keep.
+  assert.deepEqual(d.drop, []);
+});
+
+test("decideExpiry: K=0 disables expiry", () => {
+  const headers = [
+    {
+      runId: "r1",
+      issueId: 1,
+      outcome: "failure-lesson",
+      ts: "t1",
+      tags: ["auth"],
+    },
+    { runId: "r2", issueId: 2, outcome: "implement", ts: "t2", tags: ["auth"] },
+  ];
+  const d = decideExpiry(headers, 0);
+  assert.deepEqual(d.drop, []);
+});
+
+test("expireFailureLessonsInContent: drops block and is idempotent", () => {
+  const content = [
+    "# Agent CLAUDE.md",
+    "",
+    "Some prelude text.",
+    "",
+    "<!-- run:r1 issue:#1 outcome:failure-lesson ts:2026-05-01T00:00:00.000Z tags:auth -->",
+    "## Auth lesson",
+    "",
+    "Don't reuse session tokens.",
+    "",
+    "<!-- run:r2 issue:#2 outcome:implement ts:2026-05-02T00:00:00.000Z tags:auth -->",
+    "## Auth refactor 1",
+    "",
+    "Refactor body.",
+    "",
+    "<!-- run:r3 issue:#3 outcome:implement ts:2026-05-03T00:00:00.000Z tags:auth -->",
+    "## Auth refactor 2",
+    "",
+    "Refactor body.",
+    "",
+    "<!-- run:r4 issue:#4 outcome:implement ts:2026-05-04T00:00:00.000Z tags:auth -->",
+    "## Auth refactor 3",
+    "",
+    "Refactor body.",
+    "",
+  ].join("\n");
+
+  const r1 = expireFailureLessonsInContent(content, 3);
+  assert.equal(r1.droppedHeaders.length, 1);
+  assert.equal(r1.droppedHeaders[0].outcome, "failure-lesson");
+  assert.ok(!r1.content.includes("Auth lesson"));
+  assert.ok(r1.content.includes("Auth refactor 1"));
+  assert.ok(r1.content.includes("Auth refactor 2"));
+  assert.ok(r1.content.includes("Auth refactor 3"));
+  // Prelude must be preserved.
+  assert.ok(r1.content.startsWith("# Agent CLAUDE.md\n"));
+  assert.ok(r1.content.includes("Some prelude text."));
+
+  // Idempotent: re-applying changes nothing.
+  const r2 = expireFailureLessonsInContent(r1.content, 3);
+  assert.equal(r2.droppedHeaders.length, 0);
+  assert.equal(r2.content, r1.content);
+});
+
+test("expireFailureLessonsInContent: preserves non-overlapping lesson", () => {
+  const content = [
+    "# Agent CLAUDE.md",
+    "",
+    "<!-- run:r1 issue:#1 outcome:failure-lesson ts:2026-05-01T00:00:00.000Z tags:auth -->",
+    "## Auth lesson",
+    "",
+    "Don't reuse session tokens.",
+    "",
+    "<!-- run:r2 issue:#2 outcome:implement ts:2026-05-02T00:00:00.000Z tags:docs -->",
+    "## Docs typo 1",
+    "",
+    "Body.",
+    "",
+    "<!-- run:r3 issue:#3 outcome:implement ts:2026-05-03T00:00:00.000Z tags:docs -->",
+    "## Docs typo 2",
+    "",
+    "Body.",
+    "",
+    "<!-- run:r4 issue:#4 outcome:implement ts:2026-05-04T00:00:00.000Z tags:docs -->",
+    "## Docs typo 3",
+    "",
+    "Body.",
+    "",
+  ].join("\n");
+
+  const r = expireFailureLessonsInContent(content, 3);
+  assert.equal(r.droppedHeaders.length, 0);
+  assert.equal(r.content, content);
+});
+
+test("expireFailureLessonsInContent: empty / sentinel-free content is a no-op", () => {
+  const empty = "";
+  const r1 = expireFailureLessonsInContent(empty, 3);
+  assert.equal(r1.content, empty);
+  assert.equal(r1.droppedHeaders.length, 0);
+
+  const noSentinels = "# Heading\n\nSome body.\n";
+  const r2 = expireFailureLessonsInContent(noSentinels, 3);
+  assert.equal(r2.content, noSentinels);
+  assert.equal(r2.droppedHeaders.length, 0);
+});
+
+test("expireFailureLessonsInContent: drops only the lesson, not the success blocks", () => {
+  const content = [
+    "<!-- run:r1 issue:#1 outcome:failure-lesson ts:t1 tags:auth -->",
+    "## Lesson",
+    "",
+    "L body.",
+    "",
+    "<!-- run:r2 issue:#2 outcome:implement ts:t2 tags:auth -->",
+    "## Success 1",
+    "",
+    "S body.",
+    "",
+    "<!-- run:r3 issue:#3 outcome:implement ts:t3 tags:auth -->",
+    "## Success 2",
+    "",
+    "S body.",
+    "",
+    "<!-- run:r4 issue:#4 outcome:implement ts:t4 tags:auth -->",
+    "## Success 3",
+    "",
+    "S body.",
+    "",
+  ].join("\n");
+
+  const r = expireFailureLessonsInContent(content, 3);
+  assert.equal(r.droppedHeaders.length, 1);
+  assert.ok(!r.content.includes("## Lesson"));
+  assert.ok(r.content.includes("## Success 1"));
+  assert.ok(r.content.includes("## Success 2"));
+  assert.ok(r.content.includes("## Success 3"));
+});
+
+test("resolveExpireK: default when env unset", () => {
+  assert.equal(resolveExpireK({}), DEFAULT_FAILURE_LESSON_EXPIRE_K);
+});
+
+test("resolveExpireK: parses env override", () => {
+  assert.equal(resolveExpireK({ VP_DEV_FAILURE_LESSON_EXPIRE_K: "5" }), 5);
+});
+
+test("resolveExpireK: falls back on garbage", () => {
+  assert.equal(
+    resolveExpireK({ VP_DEV_FAILURE_LESSON_EXPIRE_K: "abc" }),
+    DEFAULT_FAILURE_LESSON_EXPIRE_K,
+  );
+  assert.equal(
+    resolveExpireK({ VP_DEV_FAILURE_LESSON_EXPIRE_K: "0" }),
+    DEFAULT_FAILURE_LESSON_EXPIRE_K,
+  );
+  assert.equal(
+    resolveExpireK({ VP_DEV_FAILURE_LESSON_EXPIRE_K: "-2" }),
+    DEFAULT_FAILURE_LESSON_EXPIRE_K,
+  );
+});

--- a/src/util/sentinels.ts
+++ b/src/util/sentinels.ts
@@ -1,0 +1,192 @@
+// Sentinel comment helpers for per-agent CLAUDE.md.
+//
+// Format written by `appendBlock` in src/agent/specialization.ts:
+//   <!-- run:<runId> issue:#<N> outcome:<X> ts:<ISO> [tags:t1,t2] -->
+//
+// Pure functions only — file I/O lives in `specialization.ts`. Tested in
+// `sentinels.test.ts` (node --test glob picks up `dist/src/util/*.test.js`).
+
+const SENTINEL_RE =
+  /^<!--\s+run:(\S+)\s+issue:#(\d+)\s+outcome:([\w-]+)\s+ts:(\S+?)(?:\s+tags:(\S+))?\s+-->$/;
+
+export interface SentinelHeader {
+  runId: string;
+  issueId: number;
+  outcome: string;
+  ts: string;
+  tags: string[];
+}
+
+export function parseSentinelHeader(line: string): SentinelHeader | null {
+  const m = line.match(SENTINEL_RE);
+  if (!m) return null;
+  const tagsRaw = m[5];
+  const tags =
+    tagsRaw && tagsRaw.length > 0 ? tagsRaw.split(",").filter(Boolean) : [];
+  return {
+    runId: m[1],
+    issueId: Number(m[2]),
+    outcome: m[3],
+    ts: m[4],
+    tags,
+  };
+}
+
+export function formatSentinelHeader(input: {
+  runId: string;
+  issueId: number;
+  outcome: string;
+  ts: string;
+  tags?: string[];
+}): string {
+  const base = `<!-- run:${input.runId} issue:#${input.issueId} outcome:${input.outcome} ts:${input.ts}`;
+  const tagsPart =
+    input.tags && input.tags.length > 0
+      ? ` tags:${[...input.tags].sort().join(",")}`
+      : "";
+  return `${base}${tagsPart} -->`;
+}
+
+interface SentinelLocation {
+  header: SentinelHeader;
+  /** 0-based line index of the sentinel comment line. */
+  startLine: number;
+  /**
+   * 0-based line index where this block ends (exclusive) — equal to the
+   * next sentinel's startLine, or `lines.length` for the last block.
+   */
+  endLine: number;
+}
+
+function locateSentinels(lines: string[]): SentinelLocation[] {
+  const headers: { header: SentinelHeader; startLine: number }[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const h = parseSentinelHeader(lines[i].trim());
+    if (h) headers.push({ header: h, startLine: i });
+  }
+  const out: SentinelLocation[] = [];
+  for (let i = 0; i < headers.length; i++) {
+    const next = headers[i + 1];
+    out.push({
+      header: headers[i].header,
+      startLine: headers[i].startLine,
+      endLine: next ? next.startLine : lines.length,
+    });
+  }
+  return out;
+}
+
+export interface ExpireDecision {
+  /** Header indices to drop, in order. */
+  drop: number[];
+  /** Original sentinel headers (parallel to drop indices). */
+  all: SentinelHeader[];
+}
+
+/**
+ * Decide which `outcome:failure-lesson` blocks to drop. A block is dropped
+ * when ≥ k subsequent `outcome:implement` blocks each share at least one
+ * tag with the failure-lesson's tag-fingerprint.
+ *
+ * Conservative on missing tags: a failure-lesson with `tags: []` (legacy
+ * sentinel from before tag embedding) never overlaps with any implement
+ * sentinel and is therefore never expired. An `implement` block with
+ * `tags: []` likewise contributes nothing to any expiry count. Better to
+ * keep stale lessons than evict still-relevant ones.
+ *
+ * Out-of-order writes are not a concern: blocks accumulate by file
+ * append, so file order matches chronological order — no need to re-sort
+ * by `ts`.
+ */
+export function decideExpiry(
+  headers: SentinelHeader[],
+  k: number,
+): ExpireDecision {
+  const drop: number[] = [];
+  if (k <= 0) return { drop, all: headers };
+  for (let i = 0; i < headers.length; i++) {
+    const h = headers[i];
+    if (h.outcome !== "failure-lesson") continue;
+    if (h.tags.length === 0) continue; // legacy / no fingerprint — keep
+    const lessonTags = new Set(h.tags);
+    let overlaps = 0;
+    for (let j = i + 1; j < headers.length; j++) {
+      const succ = headers[j];
+      if (succ.outcome !== "implement") continue;
+      if (succ.tags.length === 0) continue;
+      const intersects = succ.tags.some((t) => lessonTags.has(t));
+      if (intersects) overlaps += 1;
+      if (overlaps >= k) break;
+    }
+    if (overlaps >= k) drop.push(i);
+  }
+  return { drop, all: headers };
+}
+
+export interface ExpireResult {
+  content: string;
+  droppedHeaders: SentinelHeader[];
+}
+
+/**
+ * Walk the agent's CLAUDE.md content, drop expired failure-lesson blocks,
+ * and return the rewritten content. Idempotent — re-applying on the
+ * returned content with the same `k` drops nothing.
+ */
+export function expireFailureLessonsInContent(
+  content: string,
+  k: number,
+): ExpireResult {
+  const lines = content.split("\n");
+  const located = locateSentinels(lines);
+  if (located.length === 0) return { content, droppedHeaders: [] };
+
+  const decision = decideExpiry(
+    located.map((l) => l.header),
+    k,
+  );
+  if (decision.drop.length === 0) return { content, droppedHeaders: [] };
+
+  const dropSet = new Set(decision.drop);
+  const dropped: SentinelHeader[] = [];
+  for (const idx of decision.drop) dropped.push(located[idx].header);
+
+  // Rebuild line-by-line. Prelude = everything before first sentinel.
+  // For each kept sentinel, append its full block (header + body up to the
+  // next sentinel boundary). For each dropped sentinel, also drop the
+  // single blank line that precedes its header (appendBlock writes a
+  // leading blank before every block); without this we'd accumulate a
+  // stray blank line on each rewrite.
+  const out: string[] = [];
+  for (let i = 0; i < located[0].startLine; i++) out.push(lines[i]);
+
+  for (let idx = 0; idx < located.length; idx++) {
+    const loc = located[idx];
+    if (dropSet.has(idx)) {
+      // Trim a single trailing blank line off `out` so the dropped block's
+      // leading blank doesn't survive the drop. Only collapse one — runs
+      // of intentional blanks elsewhere in the file are preserved.
+      if (out.length > 0 && out[out.length - 1] === "") out.pop();
+      continue;
+    }
+    for (let i = loc.startLine; i < loc.endLine; i++) out.push(lines[i]);
+  }
+
+  return { content: out.join("\n"), droppedHeaders: dropped };
+}
+
+/**
+ * Resolve `K` from env (`VP_DEV_FAILURE_LESSON_EXPIRE_K`) with a default
+ * of 3. Non-positive / non-numeric env values fall back to the default
+ * rather than disabling expiry silently — set the env to a large number
+ * to effectively disable.
+ */
+export const DEFAULT_FAILURE_LESSON_EXPIRE_K = 3;
+
+export function resolveExpireK(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.VP_DEV_FAILURE_LESSON_EXPIRE_K;
+  if (raw == null || raw === "") return DEFAULT_FAILURE_LESSON_EXPIRE_K;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_FAILURE_LESSON_EXPIRE_K;
+  return Math.floor(n);
+}


### PR DESCRIPTION
Closes #56.

## Summary

Failure-lesson sentinels added by PR #46 (`<!-- run:R issue:#N outcome:failure-lesson ts:T -->`) accumulated forever in `agents/<id>/CLAUDE.md`. This change retires a lesson when ≥ K subsequent successful runs on topically-overlapping issues have superseded it.

- **New `src/util/sentinels.ts`** — pure parsing + expiry decision. `expireFailureLessonsInContent(content, k)` returns the rewritten file plus the dropped headers; `decideExpiry` is the underlying rule.
- **Sentinel format extended** — `appendBlock` now embeds `tags:t1,t2` (= `envelope.memoryUpdate.addTags`) in every sentinel header, providing the topical fingerprint expiry reasons over. Legacy sentinels (no tags) parse fine and are preserved by expiry — fail-safe.
- **`runIssueCore` triggers expiry** after a successful implement run is appended. K resolves from `VP_DEV_FAILURE_LESSON_EXPIRE_K` (default 3). Errors inside expiry are caught and warned — never blocks the run.
- **17 new tests** (`src/util/sentinels.test.ts`) cover tag-overlap drop, non-overlap preservation (the "auth lesson vs 3 docs-typo successes" case), K-1 boundary, pushback ignored, legacy-sentinel preservation, prelude/order safety, env parsing.

## Acceptance criteria

- [x] Failure-lesson sentinels older than K successful runs are dropped on the next summarizer pass.
- [x] Drop only happens on meaningful tag overlap — non-overlapping success streak preserves the lesson.
- [x] Re-running the summarizer doesn't re-add the dropped sentinel (`expireFailureLessonsInContent` is idempotent).
- [x] Configurable threshold via `VP_DEV_FAILURE_LESSON_EXPIRE_K` (default 3).

## Upstream prerequisite

Issue body cited PR #46 (failure-lesson sentinels) and PR #50 (per-agent outcomes) as upstreams. PR #46 merged 2026-05-02. PR #50 was closed-unmerged but its work landed via PR #61 instead — so both prerequisites are on `main`. This implementation uses the in-file sentinel chain (already a chronological event log) for success-streak detection rather than `state/outcomes/<agent>.jsonl`, which sidesteps the need to map outcomes back to runIds for tag lookup.

## Verification

- `npm run build` — clean.
- `npm test` — 30/30 pass (13 pre-existing + 17 new).

## Out of scope

- General prune cadence for non-failure-lesson sentinels.
- Re-summarization of dropped lesson content.
- Backfilling tags onto historical sentinels (legacy entries are preserved by design).

— Rogue Component Trust Isolation (agent-6100)
