### PR TITLE
feat(setup-preview): surface triage cost in vp-dev run gate

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -316,6 +316,11 @@ async function cmdRun(opts: RunOpts): Promise<void> {
   await triageLogger.open();
   let dispatchIssues = open;
   let triageSkipped: TriageSkipped[] = [];
+  // `undefined` distinguishes "triage was bypassed" (omit gate line) from
+  // "triage ran but everything was a cache hit" (show $0.0000). Per #55
+  // acceptance: "no change when triage is disabled — the line is
+  // omitted, not zero-valued."
+  let triageCostUsd: number | undefined;
   try {
     if (opts.includeNonReady) {
       triageLogger.info("triage.bypassed", { reason: "--include-non-ready", issueCount: open.length });
@@ -329,12 +334,13 @@ async function cmdRun(opts: RunOpts): Promise<void> {
       triageSkipped = triaged
         .filter((t) => !t.result.ready)
         .map((t) => ({ issue: t.issue, reason: t.result.reason }));
+      triageCostUsd = triaged.reduce((sum, t) => sum + t.costUsd, 0);
       triageLogger.info("triage.batch_completed", {
         total: triaged.length,
         ready: dispatchIssues.length,
         skipped: triageSkipped.length,
         cacheHits: triaged.filter((t) => t.fromCache).length,
-        totalCostUsd: triaged.reduce((sum, t) => sum + t.costUsd, 0),
+        totalCostUsd: triageCostUsd,
       });
     }
   } finally {
@@ -382,6 +388,7 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     registry,
     triageSkipped,
     openPrSkipped,
+    triageCostUsd,
   });
 
   if (opts.plan) {

--- a/src/orchestrator/setup.ts
+++ b/src/orchestrator/setup.ts
@@ -48,6 +48,12 @@ export interface SetupPreview {
   // use `vp-dev spawn` against a one-off agent if you really need parallel
   // attempts).
   openPrSkipped: OpenPrSkipped[];
+  // Total $ already spent by pre-dispatch triage (haiku rubric) for this
+  // run. `undefined` when triage was bypassed (--include-non-ready) — the
+  // gate omits the line entirely in that case rather than showing $0,
+  // since "no triage" and "triage was free" are different signals (per
+  // issue #55 acceptance: "the line is omitted, not zero-valued").
+  triageCostUsd?: number;
 }
 
 export interface BuildPreviewInput {
@@ -62,6 +68,7 @@ export interface BuildPreviewInput {
   registry: AgentRegistryFile;
   triageSkipped?: TriageSkipped[];
   openPrSkipped?: OpenPrSkipped[];
+  triageCostUsd?: number;
 }
 
 export async function buildSetupPreview(input: BuildPreviewInput): Promise<SetupPreview> {
@@ -97,6 +104,7 @@ export async function buildSetupPreview(input: BuildPreviewInput): Promise<Setup
     overloadWarnings,
     triageSkipped: input.triageSkipped ?? [],
     openPrSkipped: input.openPrSkipped ?? [],
+    triageCostUsd: input.triageCostUsd,
   };
 }
 
@@ -119,6 +127,15 @@ export function formatSetupPreview(p: SetupPreview): string {
   lines.push(
     `  Planned:        ${p.planned} (${p.specialistCount} specialist, ${p.generalCount} general${freshNote})`,
   );
+  // Triage cost is "already incurred" — it ran before the gate and is
+  // shown so the user sees the small haiku-call cost the run already paid
+  // (and will pay again if they re-run). Omitted entirely when triage was
+  // bypassed via --include-non-ready (per issue #55: not zero-valued).
+  // The projected dispatch-cost anchor lands separately with #34's hard
+  // cost ceiling — until then this row stands alone.
+  if (p.triageCostUsd !== undefined) {
+    lines.push(`  Triage cost:    ~$${p.triageCostUsd.toFixed(4)} (already incurred)`);
+  }
   lines.push(`  Dry run:        ${p.dryRun ? "yes" : "no"}`);
   lines.push(`  Resume:         ${p.resume ? "yes" : "no"}`);
   lines.push("");


### PR DESCRIPTION
Closes #55.

## Summary

- `vp-dev run` setup-preview now shows `Triage cost: ~$Z (already incurred)` in the meta block, just below `Planned:`. The value comes from the same per-issue `costUsd` sum that `triage.batch_completed.totalCostUsd` already logs.
- Threaded through a new optional `triageCostUsd` field on `SetupPreview` and `BuildPreviewInput`, populated in `cmdRun()` from the `triageBatch()` result.
- Omitted entirely (not zero-valued) when triage is bypassed via `--include-non-ready` — distinguishes "no triage ran" from "triage ran but every issue was a cache hit" (which still shows `$0.0000`). On `--resume` no triage runs, so the field stays `undefined` and the line is correctly absent.

## Why this lands without #34

The issue and the prior holds note this should land alongside #34's projected dispatch-cost anchor to avoid a partial cost surface. Per the user's 2026-05-04 instruction, the cross-dependency cycle is being broken explicitly: #34 is open with no PR (one prior attempt was truncated by the SDK turn ceiling — see #76), and waiting indefinitely on #34 is the wrong default. The standalone triage-cost row provides immediate user value at the gate; when #34 ships its projected-cost line, it slots in above this row.

## Test plan

- [x] `npm run build` — clean.
- [x] `npm test` — 35/35 pass.
- [ ] Manual: `vp-dev run` against an issue range with no cache hits → preview shows `Triage cost: ~$0.00XX (already incurred)`.
- [ ] Manual: `vp-dev run --include-non-ready ...` → preview omits the row entirely.
- [ ] Manual: `vp-dev resume ...` → preview omits the row entirely (no triage on resume).
- [ ] Manual: cache-hit-only run → preview shows `Triage cost: ~$0.0000 (already incurred)` — matches the rule "omit when bypassed, not when zero."

— Keccak Guard (agent-aa26)
