### PR TITLE
fix(triage): recognize short directive replies as resolution signals

### DIFF
--- a/src/orchestrator/triage.ts
+++ b/src/orchestrator/triage.ts
@@ -200,24 +200,34 @@ Rubric:
 - NOT ready — duplicate: the issue body or comments explicitly say it is a duplicate of another open issue.
 - NOT ready — body/comments conflict (irreconcilable only): comments mark the issue obsolete / superseded / won't-fix, redirect to a different open issue as a true duplicate, or invalidate the body's premise ("actually we don't want this anymore"). Only skip when the conflict cannot be resolved at dispatch time.
 
-The "Issue Analysis" rule from the agent's CLAUDE.md REQUIRES reading comments — body and comments together form the spec. Prefer comments when they correct or override the body.
+The "Issue Analysis" rule from the agent's CLAUDE.md REQUIRES reading comments — body and comments together form the spec. Prefer comments when they correct or override the body. The MOST RECENT comment (labeled "most recent" in the input) carries the most weight; treat it as the current state of the thread.
 
 Pass through (ready: true) for transient conflicts the dispatched agent can resolve by re-reading comments:
 - "blocked on PR #N" / "depends on #M" / "waiting for upstream merge" — the agent re-reads comments at dispatch time and pushes back if still blocked, or proceeds if the dependency landed.
 - Comments adding follow-up scope or clarifying acceptance criteria without invalidating the body.
+- The most recent comment is a short directive that selects from a previous comment's proposal: "do B", "option a", "go with it", "yes, A", "+1 to that", "ship it", "ack". A short reply RESOLVES the thread. Do NOT weight comment length when assessing resolution — a 4-character directive is as binding as a multi-paragraph rationale, especially when it follows a multi-path proposal.
+  Example: comment 3/4 lists options (a/b/c); comment 4/4 is "do B". The thread is resolved → ready: true.
 
 Output: a single JSON object, no fences, no prose.
   {"ready": boolean, "reason": "<one short sentence, ≤240 chars>", "suggestedSpecialty"?: "<short hint, optional>"}
 
 Hard rules:
 - Default to ready: true when uncertain (the approval gate is the human backstop).
-- The "reason" must explain WHY in one short sentence. For ready: cite the concrete signal ("explicit acceptance criteria", "bug with repro"). For not-ready: cite the disqualifier ("ambiguous scope", "duplicate of #N", "body/comments conflict").
+- If the reason you would write contains "unresolved", "undecided", "left open", "left direction", "no commitment", or "didn't commit" — that IS the uncertainty case. Return ready: true. The dispatched coding agent re-reads comments at runtime and pushes back if it disagrees.
+- The "reason" must explain WHY in one short sentence. For ready: cite the concrete signal ("explicit acceptance criteria", "bug with repro", "most recent comment selects option B"). For not-ready: cite the disqualifier ("ambiguous scope", "duplicate of #N", "body/comments conflict").
 - No markdown in the reason. No newlines inside the reason — write a single sentence.
 - If the body is empty AND there are no comments, return ready: true with reason "empty body — fail open".`;
 
 function buildPrompt(detail: IssueDetail): string {
+  const total = detail.comments.length;
   const commentBlocks = detail.comments
-    .map((c) => `--- comment by ${c.author} at ${c.createdAt}\n${c.body}`)
+    .map((c, i) => {
+      const ordinal = `${i + 1}/${total}`;
+      let recencyTag = "";
+      if (total > 1 && i === total - 1) recencyTag = " (most recent)";
+      else if (total > 1 && i === 0) recencyTag = " (oldest)";
+      return `--- comment ${ordinal}${recencyTag} by ${c.author} at ${c.createdAt}\n${c.body}`;
+    })
     .join("\n\n");
   return `Issue ${detail.id} — ${detail.title}
 Labels: ${JSON.stringify(detail.labels)}
@@ -236,8 +246,20 @@ function truncate(s: string, max: number): string {
   return s.slice(0, max - 3) + "...";
 }
 
+// Hash of the rubric + prompt-builder shape, mixed into the per-issue
+// contentHash so that any rubric edit auto-invalidates previously-cached
+// triage decisions. Without this, a prompt fix landing today would still
+// serve yesterday's stale verdict for every cached issue until its body
+// or comments mutate.
+const RUBRIC_FINGERPRINT = createHash("sha256")
+  .update(TRIAGE_SYSTEM_PROMPT)
+  .update("\n--prompt-shape-v2--\n") // bump when buildPrompt() output shape changes
+  .digest("hex")
+  .slice(0, 16);
+
 function computeContentHash(detail: IssueDetail): string {
   const h = createHash("sha256");
+  h.update("rubric:" + RUBRIC_FINGERPRINT + "\n");
   h.update(detail.body ?? "");
   h.update("\n--comments--\n");
   for (const c of detail.comments) {


### PR DESCRIPTION
Closes #79.

## Summary

Triage rubric misclassified issue #33 as `ready: false` because the final comment (`"do B"`) was a short trailing directive that selected from a multi-path proposal in the prior comment. The model weighted comment length when assessing resolution and dropped the 4-character reply, producing a reason that ended in `"left direction unresolved"` — which should have triggered the existing "default to ready when uncertain" clause but did not.

Per the issue's "Suggested directions" list and CLAUDE.md memory ("Triage rubrics must distinguish irreconcilable conflicts from transient dependency signals"), this is a prompt-only fix to `src/orchestrator/triage.ts` plus a cache-invalidation safety net.

## Changes

1. **Rubric — short-directive resolution**: new Pass-through clause covering `"do B"`, `"option a"`, `"yes, A"`, `"+1 to that"`, `"ship it"`, etc., with an explicit instruction not to weight comment length when judging resolution. Includes a worked example mirroring the #33 thread shape.

2. **Rubric — uncertainty default tied to tells**: list specific phrases (`"unresolved"`, `"undecided"`, `"left open"`, `"left direction"`, `"no commitment"`, `"didn't commit"`) that the model is told to recognize as triggers for `ready: true`. Targets the exact failure mode (the haiku's reason ended in `"left direction unresolved"`).

3. **`buildPrompt` — comment ordering**: number comments as `K/N` and label boundary comments with `(oldest)` / `(most recent)`. Ordering becomes a first-class signal in the input rather than implicit in concatenation.

4. **Cache invalidation**: mix `sha256(TRIAGE_SYSTEM_PROMPT)` into the per-issue `contentHash`. Any rubric edit auto-invalidates previously cached verdicts. Without this, today's prompt fix would still serve yesterday's stale `ready: false` for #33 until the issue body or comments mutate — directly addressing the "Operational impact" section of the issue.

## Out of scope

- **Second-pass / re-prompt** when `reason` contains uncertainty markers — bigger architectural change. The combination of (1) explicit short-directive recognition, (2) tying the uncertainty default to the exact tells, and (3) ordering signals should make a second pass unnecessary in the failure mode described.

## Test plan

- [x] `npm run build` clean.
- [x] `npm test` — 35/35 existing tests pass.
- [ ] Manual re-triage of issue #33 once merged: cache auto-invalidates via the new prompt-fingerprint hash; expect `ready: true` with a reason citing the comment-4 directive.
- [ ] Spot-check a handful of other open issues to confirm no regression in already-correct verdicts (`--include-non-ready` continues to work as the override path).

— Rogue Oracle (agent-72c6)
