### PR TITLE
feat: cross-agent shared lessons pool with curated promotion

### DIFF
--- a/src/agent/promotion.ts
+++ b/src/agent/promotion.ts
@@ -1,0 +1,153 @@
+// Orchestrator-side promotion flow for cross-agent shared lessons (#33).
+//
+// Walks every active agent's CLAUDE.md, finds `<!-- promote-candidate -->`
+// blocks the summarizer tagged on prior runs, and exposes accept/reject
+// helpers that the `vp-dev lessons review` CLI drives interactively. All
+// reads + writes happen here — the coding agent never touches `.shared/`.
+
+import { promises as fs } from "node:fs";
+import {
+  appendLessonToPool,
+  type AppendLessonOutcome,
+} from "./sharedLessons.js";
+import { agentClaudeMdPath } from "./specialization.js";
+import { withFileLock } from "../state/locks.js";
+import {
+  findPromoteCandidates,
+  formatNotPromotedSentinel,
+  formatPromotedSentinel,
+  rewriteCandidateWrapping,
+  validateEntry,
+  type PromoteCandidate,
+  type ValidationResult,
+} from "../util/promotionMarkers.js";
+import type { AgentRecord } from "../types.js";
+
+export interface PendingCandidate {
+  agentId: string;
+  agentName?: string;
+  candidate: PromoteCandidate;
+  validation: ValidationResult;
+}
+
+/**
+ * Read the per-agent CLAUDE.md for each agent and surface every well-formed
+ * promote-candidate block. Skips agents whose CLAUDE.md is missing (not
+ * yet forked) or unreadable.
+ */
+export async function collectPendingCandidates(
+  agents: AgentRecord[],
+): Promise<PendingCandidate[]> {
+  const out: PendingCandidate[] = [];
+  for (const agent of agents) {
+    let md: string;
+    try {
+      md = await fs.readFile(agentClaudeMdPath(agent.agentId), "utf-8");
+    } catch {
+      continue;
+    }
+    const candidates = findPromoteCandidates(md);
+    for (const candidate of candidates) {
+      out.push({
+        agentId: agent.agentId,
+        agentName: agent.name,
+        candidate,
+        validation: validateEntry(candidate.body),
+      });
+    }
+  }
+  return out;
+}
+
+export interface AcceptResult {
+  appendOutcome: AppendLessonOutcome;
+  /** True only when the source CLAUDE.md was rewritten — i.e. the entry was
+   * appended successfully AND the marker was rewritten. */
+  rewroteSource: boolean;
+}
+
+/**
+ * Append the candidate body to its target pool and rewrite the source
+ * CLAUDE.md so the marker won't resurface. The two writes are NOT atomic
+ * across files — if the pool append succeeds and the source rewrite fails,
+ * the second `vp-dev lessons review` run will still find the same candidate
+ * and the human can rerun it (the pool gets a duplicate entry; this is
+ * acceptable: humans resolve duplicates by editing the pool by hand). The
+ * inverse failure (rewrite without append) is impossible because we only
+ * touch the source after the pool append commits.
+ */
+export async function acceptCandidate(input: {
+  pending: PendingCandidate;
+  ts?: string;
+  issueId?: number;
+}): Promise<AcceptResult> {
+  const ts = input.ts ?? new Date().toISOString();
+  const appendOutcome = await appendLessonToPool({
+    domain: input.pending.candidate.domain,
+    body: input.pending.candidate.body,
+    sourceAgentId: input.pending.agentId,
+    issueId: input.issueId ?? 0,
+    ts,
+  });
+  if (appendOutcome.kind !== "appended") {
+    return { appendOutcome, rewroteSource: false };
+  }
+  await rewriteSourceMarker({
+    agentId: input.pending.agentId,
+    candidate: input.pending.candidate,
+    replacement: formatPromotedSentinel(input.pending.candidate.domain, ts),
+  });
+  return { appendOutcome, rewroteSource: true };
+}
+
+export async function rejectCandidate(input: {
+  pending: PendingCandidate;
+  reason: string;
+  ts?: string;
+}): Promise<void> {
+  const ts = input.ts ?? new Date().toISOString();
+  await rewriteSourceMarker({
+    agentId: input.pending.agentId,
+    candidate: input.pending.candidate,
+    replacement: formatNotPromotedSentinel(input.reason, ts),
+  });
+}
+
+/**
+ * Read the per-agent CLAUDE.md, replace the promote-candidate wrapping with
+ * `replacement`, write back atomically. Held under the same per-file lock
+ * as `appendBlock` (`agentClaudeMdPath(agentId).lock`) so the rewrite is
+ * serialized against any concurrent summarizer-driven append.
+ *
+ * Re-locates the candidate from a fresh read in case the file shifted
+ * between collect time and accept time (another agent run may have
+ * appended a new section). If the marker is no longer present at the
+ * recorded line range (e.g. another reviewer accepted it first), the
+ * rewrite is a no-op.
+ */
+async function rewriteSourceMarker(input: {
+  agentId: string;
+  candidate: PromoteCandidate;
+  replacement: string;
+}): Promise<void> {
+  const filePath = agentClaudeMdPath(input.agentId);
+  await withFileLock(filePath, async () => {
+    let current: string;
+    try {
+      current = await fs.readFile(filePath, "utf-8");
+    } catch {
+      return;
+    }
+    const fresh = findPromoteCandidates(current);
+    const match = fresh.find(
+      (c) =>
+        c.domain === input.candidate.domain &&
+        c.body === input.candidate.body,
+    );
+    if (!match) return;
+    const next = rewriteCandidateWrapping(current, match, input.replacement);
+    const tmp = `${filePath}.tmp.${process.pid}`;
+    await fs.writeFile(tmp, next);
+    await fs.rename(tmp, filePath);
+  });
+}

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { readAgentClaudeMd, readSeedClaudeMd } from "./specialization.js";
+import { readSharedLessonsForDomains } from "./sharedLessons.js";
 import { renderWorkflow, type WorkflowVars } from "./workflow.js";
 import type { AgentRecord } from "../types.js";
 
@@ -26,6 +27,13 @@ export async function buildAgentSystemPrompt(opts: {
     issueId: opts.workflow.issueId,
   });
 
+  // Cross-agent shared lessons (#33). Pulled from `agents/.shared/lessons/`,
+  // matched against the agent's current tag fingerprint. Each pool file is
+  // capped at MAX_POOL_LINES so multi-tag agents stay bounded. Maintained by
+  // the orchestrator via `vp-dev lessons review`; never written by the
+  // coding agent — see the workflow guard in `workflow.ts`.
+  const sharedLessons = await readSharedLessonsForDomains(opts.agent.tags);
+
   const sections: string[] = [
     "# Project rules (live target-repo CLAUDE.md — current as of this dispatch)",
     "",
@@ -38,6 +46,21 @@ export async function buildAgentSystemPrompt(opts: {
     dedupedPerAgent.trim() || "(no agent-specific sections beyond live project rules)",
     "",
   ];
+
+  if (sharedLessons.length > 0) {
+    for (const pool of sharedLessons) {
+      sections.push(
+        "---",
+        "",
+        `## Shared lessons (${pool.domain})`,
+        "",
+        "Cross-agent observations curated by the orchestrator. Read-only — do NOT modify or copy back into your own CLAUDE.md.",
+        "",
+        pool.content.trim(),
+        "",
+      );
+    }
+  }
 
   if (plan) {
     sections.push(

--- a/src/agent/sharedLessons.ts
+++ b/src/agent/sharedLessons.ts
@@ -1,0 +1,183 @@
+// Cross-agent shared-lessons pool — read-only at agent runtime, write-only
+// via curated promotion (`vp-dev lessons review`). See feature plan in
+// `feature-plans/issue-33-shared-lessons-pool.md`.
+//
+// Layout: `agents/.shared/lessons/<domain>.md`. Domain == any tag the
+// agent fingerprint exposes (lowercase, dash-separated, e.g. `solana`,
+// `eip-712`). The directory lives under the same `agents/` tree that is
+// already gitignored, so pool files never leak into the target repo.
+//
+// Boundary preservation: appendLessonToPool is invoked exclusively by the
+// orchestrator-side review CLI. The coding-agent workflow (`renderWorkflow`
+// in `workflow.ts`) carries an explicit "never write to agents/.shared/"
+// guard, and the agent's worktree CWD is outside this path anyway.
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { ensureDir, withFileLock } from "../state/locks.js";
+import { AGENTS_ROOT } from "./specialization.js";
+import {
+  isValidDomain,
+  validateEntry,
+  type ValidationResult,
+} from "../util/promotionMarkers.js";
+
+export const SHARED_LESSONS_DIR = path.join(AGENTS_ROOT, ".shared", "lessons");
+
+/**
+ * Pool-file size cap. Once exceeded, append refuses with a "trim first"
+ * outcome so prompt seeding stays bounded for every agent that loads this
+ * domain.
+ */
+export const MAX_POOL_LINES = 200;
+
+export function sharedLessonsPath(domain: string): string {
+  if (!isValidDomain(domain)) {
+    throw new Error(`Invalid domain '${domain}': expected lowercase dash-separated tag.`);
+  }
+  return path.join(SHARED_LESSONS_DIR, `${domain}.md`);
+}
+
+export interface PoolSummary {
+  domain: string;
+  filePath: string;
+  totalLines: number;
+  bytes: number;
+}
+
+export async function listSharedLessonDomains(): Promise<PoolSummary[]> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(SHARED_LESSONS_DIR);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+  const out: PoolSummary[] = [];
+  for (const e of entries.sort()) {
+    if (!e.endsWith(".md")) continue;
+    const domain = e.slice(0, -3);
+    if (!isValidDomain(domain)) continue;
+    const filePath = path.join(SHARED_LESSONS_DIR, e);
+    try {
+      const content = await fs.readFile(filePath, "utf-8");
+      out.push({
+        domain,
+        filePath,
+        totalLines: content.split("\n").length,
+        bytes: Buffer.byteLength(content, "utf-8"),
+      });
+    } catch {
+      // skip unreadable
+    }
+  }
+  return out;
+}
+
+export interface DomainContent {
+  domain: string;
+  content: string;
+}
+
+/**
+ * Load every pool whose domain matches a tag in `domains`. Missing files
+ * are skipped silently (a domain may simply not have an accumulated pool
+ * yet). Returns in caller-provided domain order so prompt seeding is
+ * deterministic.
+ */
+export async function readSharedLessonsForDomains(
+  domains: string[],
+): Promise<DomainContent[]> {
+  const out: DomainContent[] = [];
+  const seen = new Set<string>();
+  for (const domain of domains) {
+    if (!isValidDomain(domain) || seen.has(domain)) continue;
+    seen.add(domain);
+    try {
+      const content = await fs.readFile(sharedLessonsPath(domain), "utf-8");
+      if (content.trim().length > 0) {
+        out.push({ domain, content });
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    }
+  }
+  return out;
+}
+
+export interface AppendLessonInput {
+  domain: string;
+  body: string;
+  sourceAgentId: string;
+  issueId: number;
+  ts?: string;
+}
+
+export type AppendLessonOutcome =
+  | { kind: "appended"; totalLines: number; filePath: string }
+  | { kind: "rejected-pool-full"; totalLines: number; filePath: string }
+  | { kind: "rejected-validation"; validation: ValidationResult };
+
+export async function appendLessonToPool(
+  input: AppendLessonInput,
+): Promise<AppendLessonOutcome> {
+  const validation = validateEntry(input.body);
+  if (!validation.ok) {
+    return { kind: "rejected-validation", validation };
+  }
+  const ts = input.ts ?? new Date().toISOString();
+  const filePath = sharedLessonsPath(input.domain);
+  return withFileLock(filePath, async () => {
+    await ensureDir(SHARED_LESSONS_DIR);
+    let current = "";
+    try {
+      current = await fs.readFile(filePath, "utf-8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    }
+    if (current.length === 0) {
+      current = poolHeader(input.domain);
+    }
+    const entry = formatEntryBlock({
+      sourceAgentId: input.sourceAgentId,
+      issueId: input.issueId,
+      ts,
+      body: input.body,
+    });
+    const next = current.endsWith("\n") ? current + entry : current + "\n" + entry;
+    const totalLines = next.split("\n").length;
+    if (totalLines > MAX_POOL_LINES) {
+      return { kind: "rejected-pool-full", totalLines, filePath };
+    }
+    const tmp = `${filePath}.tmp.${process.pid}`;
+    await fs.writeFile(tmp, next);
+    await fs.rename(tmp, filePath);
+    return { kind: "appended", totalLines, filePath };
+  });
+}
+
+function poolHeader(domain: string): string {
+  return [
+    `# Shared lessons: ${domain}`,
+    "",
+    `Curated cross-agent lessons for the \`${domain}\` domain. Read-only at`,
+    "agent runtime; entries promoted via `vp-dev lessons review` after the",
+    "human reviewer accepts a `<!-- promote-candidate -->` block from a",
+    "sibling agent's CLAUDE.md.",
+    "",
+    "",
+  ].join("\n");
+}
+
+function formatEntryBlock(input: {
+  sourceAgentId: string;
+  issueId: number;
+  ts: string;
+  body: string;
+}): string {
+  return [
+    `<!-- entry source:${input.sourceAgentId} issue:#${input.issueId} ts:${input.ts} -->`,
+    input.body.trim(),
+    "",
+  ].join("\n");
+}

--- a/src/agent/summarizer.ts
+++ b/src/agent/summarizer.ts
@@ -217,6 +217,16 @@ const SUMMARIZER_SYSTEM_PROMPT = `You are a distillation agent. After a coding a
 
 Style: match the dense rule-form of an existing CLAUDE.md section. Lead with the rule itself in bold. Then a **Why:** line (the reason — often a past incident, a hidden constraint, a strong preference). Then a **How to apply:** line (when this guidance kicks in). Use **Tells:** sparingly to list signals of the situation. Markdown hyperlinks (\`[label](url)\`) over raw URLs.
 
+Cross-agent promotion (optional, gated by human review):
+- If a piece of the lesson would help SIBLING agents in the same domain — not just THIS agent — wrap that piece inside the \`body\` between two HTML comments:
+    <!-- promote-candidate:<domain> -->
+    <descriptive observation, multiple lines OK>
+    <!-- /promote-candidate -->
+- The \`<domain>\` MUST be one of the agent's current tags listed under "Pre-run agent tags" or "Tags added this run" — that's how we keep domain taxonomy stable.
+- The wrapped content must read as a DESCRIPTIVE OBSERVATION, not an instruction to other agents. Avoid "you must / should", "the agent must" — use indicative voice: "Solana RPC X behaves like Y" / "ERC-4626 rounds shares DOWN on deposit".
+- Cap the wrapped content at ~40 non-empty lines / ~1500 chars. Anything longer is too coarse to share.
+- Promote-candidates are queued for human review; they do NOT auto-promote. Use sparingly — most lessons stay agent-local.
+
 Hard rules:
 - If there is no GENERALIZABLE lesson — only a one-off fix, a routine implementation, a trivial pushback — return {"skip": true, "skipReason": "<one short sentence>"}. Empty learnings beat noisy ones.
 - If the agent failed (decision="error"), default to skip unless there's a clear lesson about the failure mode itself.

--- a/src/agent/workflow.ts
+++ b/src/agent/workflow.ts
@@ -25,7 +25,7 @@ ${v.inspectPaths.map((p) => `- \`${p}\``).join("\n")}
   return `# Workflow
 
 You are an autonomous coding agent working on a single GitHub issue in ${v.targetRepo}.
-Your worktree is ${v.worktreePath} on branch ${v.branchName}. Your shell already starts in this directory for every Bash invocation — the cwd is preset. **Never prefix Bash commands with \`cd ${v.worktreePath} && …\`**: the leading word becomes \`cd\` (not on the gate's allowlist) and the call is denied. Run commands directly: \`npm run build\`, \`git status\`, \`git diff\`. **For text search, use the \`Grep\` tool (any path, any pattern) — bash \`grep\` is not allowlisted and will be denied.** Stay inside the worktree. Never push to main.${dryNote}${inspectNote}
+Your worktree is ${v.worktreePath} on branch ${v.branchName}. Your shell already starts in this directory for every Bash invocation — the cwd is preset. **Never prefix Bash commands with \`cd ${v.worktreePath} && …\`**: the leading word becomes \`cd\` (not on the gate's allowlist) and the call is denied. Run commands directly: \`npm run build\`, \`git status\`, \`git diff\`. **For text search, use the \`Grep\` tool (any path, any pattern) — bash \`grep\` is not allowlisted and will be denied.** Stay inside the worktree. Never push to main. **Never write to \`agents/.shared/\`** — that path holds curated cross-agent lessons maintained by the orchestrator via \`vp-dev lessons review\`. Read-only from your perspective; if a "Shared lessons (...)" section appears in your seed, treat it as reference material like the target-repo CLAUDE.md.${dryNote}${inspectNote}
 
 ## Step 1 — Read the issue and ALL comments
 Run BOTH:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,6 +57,16 @@ import {
   type ApplyResult as PruneApplyResult,
 } from "./agent/prune.js";
 import {
+  acceptCandidate,
+  collectPendingCandidates,
+  rejectCandidate,
+  type PendingCandidate,
+} from "./agent/promotion.js";
+import {
+  listSharedLessonDomains,
+  MAX_POOL_LINES,
+} from "./agent/sharedLessons.js";
+import {
   loadAllOutcomes,
   pollOutcomes,
   rollupOutcomes,
@@ -207,6 +217,27 @@ export function buildCli(): Command {
         }),
     );
   program.addCommand(agentsCmd);
+
+  const lessonsCmd = new Command("lessons")
+    .description("Cross-agent shared lessons pool: list pool files + review promote-candidate blocks queued by the summarizer")
+    .addCommand(
+      new Command("list")
+        .description("List all shared-lesson pool files (agents/.shared/lessons/) with size + line count")
+        .option("--json", "Print machine-readable JSON")
+        .action(async (opts) => {
+          await cmdLessonsList(opts);
+        }),
+    )
+    .addCommand(
+      new Command("review")
+        .description("Walk every agent's CLAUDE.md for `<!-- promote-candidate:<domain> -->` blocks and accept/reject each interactively")
+        .option("--json", "Print machine-readable JSON listing of pending candidates and exit (no mutation)")
+        .option("--yes", "Auto-accept every candidate that passes validation (non-interactive use only)")
+        .action(async (opts) => {
+          await cmdLessonsReview(opts);
+        }),
+    );
+  program.addCommand(lessonsCmd);
 
   return program;
 }
@@ -1244,6 +1275,191 @@ async function cmdAgentsStats(opts: AgentsStatsOpts): Promise<void> {
     String(r.medianCiCycles),
   ]);
   printTable(headers, rows);
+}
+
+interface LessonsListOpts {
+  json?: boolean;
+}
+
+async function cmdLessonsList(opts: LessonsListOpts): Promise<void> {
+  const pools = await listSharedLessonDomains();
+  if (opts.json) {
+    process.stdout.write(JSON.stringify({ pools, maxPoolLines: MAX_POOL_LINES }, null, 2) + "\n");
+    return;
+  }
+  if (pools.length === 0) {
+    process.stdout.write(
+      "No shared-lesson pools yet. Run `vp-dev lessons review` after a summarizer pass tags a promote-candidate.\n",
+    );
+    return;
+  }
+  const headers = ["domain", "lines", "bytes", "path"];
+  const rows = pools.map((p) => [
+    p.domain,
+    `${p.totalLines}/${MAX_POOL_LINES}`,
+    String(p.bytes),
+    p.filePath,
+  ]);
+  printTable(headers, rows);
+}
+
+interface LessonsReviewOpts {
+  json?: boolean;
+  yes?: boolean;
+}
+
+async function cmdLessonsReview(opts: LessonsReviewOpts): Promise<void> {
+  const reg = await loadRegistry();
+  // Don't filter archived agents — the candidate may have been tagged before
+  // a split, and we still want to surface it. The boundary that matters is
+  // the human-review gate, not the agent's lifecycle status.
+  const pending = await collectPendingCandidates(reg.agents);
+
+  if (opts.json) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          pending: pending.map((p) => ({
+            agentId: p.agentId,
+            agentName: p.agentName,
+            domain: p.candidate.domain,
+            startLine: p.candidate.startLine,
+            endLine: p.candidate.endLine,
+            body: p.candidate.body,
+            validation: p.validation,
+          })),
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    return;
+  }
+
+  if (pending.length === 0) {
+    process.stdout.write("No promote-candidate blocks pending review.\n");
+    return;
+  }
+
+  process.stdout.write(`${pending.length} promote-candidate block(s) pending review.\n\n`);
+
+  if (opts.yes) {
+    await runAutoAcceptLoop(pending);
+    return;
+  }
+
+  if (!process.stdin.isTTY) {
+    process.stderr.write(
+      "ERROR: stdin is not a TTY and --yes was not passed. Re-run with --yes to auto-accept everything that validates, or pipe to a TTY.\n",
+    );
+    process.exit(2);
+  }
+
+  await runInteractiveReview(pending);
+}
+
+async function runAutoAcceptLoop(pending: PendingCandidate[]): Promise<void> {
+  let acceptedCount = 0;
+  let rejectedCount = 0;
+  let skippedCount = 0;
+  for (const p of pending) {
+    if (!p.validation.ok) {
+      const reason = `validation failed: ${p.validation.errors.join("; ")}`;
+      await rejectCandidate({ pending: p, reason });
+      process.stdout.write(`rejected (validation) ${p.agentId} -> ${p.candidate.domain}: ${reason}\n`);
+      rejectedCount += 1;
+      continue;
+    }
+    const result = await acceptCandidate({ pending: p });
+    if (result.appendOutcome.kind === "appended") {
+      process.stdout.write(
+        `accepted ${p.agentId} -> ${p.candidate.domain} (${result.appendOutcome.totalLines}/${MAX_POOL_LINES} lines)\n`,
+      );
+      acceptedCount += 1;
+    } else if (result.appendOutcome.kind === "rejected-pool-full") {
+      process.stdout.write(
+        `skipped (pool full) ${p.agentId} -> ${p.candidate.domain}: ${result.appendOutcome.totalLines}/${MAX_POOL_LINES} lines. Trim the pool by hand and re-run review.\n`,
+      );
+      skippedCount += 1;
+    } else {
+      process.stdout.write(
+        `skipped (validation) ${p.agentId} -> ${p.candidate.domain}\n`,
+      );
+      skippedCount += 1;
+    }
+  }
+  process.stdout.write(
+    `\nDone: accepted=${acceptedCount} rejected=${rejectedCount} skipped=${skippedCount}\n`,
+  );
+}
+
+async function runInteractiveReview(pending: PendingCandidate[]): Promise<void> {
+  const { createInterface } = await import("node:readline/promises");
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  let acceptedCount = 0;
+  let rejectedCount = 0;
+  let skippedCount = 0;
+  try {
+    for (let i = 0; i < pending.length; i++) {
+      const p = pending[i];
+      process.stdout.write(`\n--- candidate ${i + 1}/${pending.length} ---\n`);
+      const sourceLabel = p.agentName ? `${p.agentName} (${p.agentId})` : p.agentId;
+      process.stdout.write(`source:  ${sourceLabel}\n`);
+      process.stdout.write(`domain:  ${p.candidate.domain}\n`);
+      process.stdout.write(`source CLAUDE.md lines ${p.candidate.startLine + 1}..${p.candidate.endLine + 1}\n`);
+      if (p.validation.errors.length > 0) {
+        process.stdout.write(`errors:  ${p.validation.errors.join("; ")}\n`);
+      }
+      if (p.validation.warnings.length > 0) {
+        process.stdout.write(`warnings: ${p.validation.warnings.join("; ")}\n`);
+      }
+      process.stdout.write("\n--- body ---\n");
+      process.stdout.write(p.candidate.body + "\n");
+      process.stdout.write("--- /body ---\n\n");
+
+      const allowAccept = p.validation.ok;
+      const choices = allowAccept ? "[a]ccept / [r]eject / [s]kip" : "[r]eject / [s]kip (validation failed; cannot accept)";
+      const answer = (await rl.question(`Action ${choices}? `)).trim().toLowerCase();
+      if (answer === "a" || answer === "accept") {
+        if (!allowAccept) {
+          process.stdout.write("Cannot accept — validation failed. Treating as skip.\n");
+          skippedCount += 1;
+          continue;
+        }
+        const result = await acceptCandidate({ pending: p });
+        if (result.appendOutcome.kind === "appended") {
+          process.stdout.write(
+            `Accepted: appended to ${result.appendOutcome.filePath} (${result.appendOutcome.totalLines}/${MAX_POOL_LINES} lines).\n`,
+          );
+          acceptedCount += 1;
+        } else if (result.appendOutcome.kind === "rejected-pool-full") {
+          process.stdout.write(
+            `POOL FULL: ${result.appendOutcome.filePath} reached ${result.appendOutcome.totalLines}/${MAX_POOL_LINES} lines. Trim the pool file by hand and re-run review for this candidate. (Marker left in source CLAUDE.md.)\n`,
+          );
+          skippedCount += 1;
+        } else {
+          process.stdout.write(`Append refused (validation): ${result.appendOutcome.validation.errors.join("; ")}\n`);
+          skippedCount += 1;
+        }
+        continue;
+      }
+      if (answer === "r" || answer === "reject") {
+        const reason = (await rl.question("Reason (one short sentence): ")).trim() || "no reason given";
+        await rejectCandidate({ pending: p, reason });
+        process.stdout.write("Rejected. Source marker rewritten.\n");
+        rejectedCount += 1;
+        continue;
+      }
+      // anything else == skip
+      process.stdout.write("Skipped — marker left in source CLAUDE.md, will resurface next review.\n");
+      skippedCount += 1;
+    }
+  } finally {
+    rl.close();
+  }
+  process.stdout.write(
+    `\nReview complete: accepted=${acceptedCount} rejected=${rejectedCount} skipped=${skippedCount}\n`,
+  );
 }
 
 function printTable(headers: string[], rows: string[][]): void {

--- a/src/util/promotionMarkers.test.ts
+++ b/src/util/promotionMarkers.test.ts
@@ -1,0 +1,177 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  MAX_ENTRY_CHARS,
+  MAX_ENTRY_LINES,
+  findPromoteCandidates,
+  formatNotPromotedSentinel,
+  formatPromotedSentinel,
+  isValidDomain,
+  rewriteCandidateWrapping,
+  validateEntry,
+} from "./promotionMarkers.js";
+
+test("isValidDomain: accepts lowercase dash-separated tags", () => {
+  assert.equal(isValidDomain("solana"), true);
+  assert.equal(isValidDomain("eip-712"), true);
+  assert.equal(isValidDomain("ledger-firmware"), true);
+});
+
+test("isValidDomain: rejects uppercase, spaces, leading digit, empty", () => {
+  assert.equal(isValidDomain("Solana"), false);
+  assert.equal(isValidDomain("ledger firmware"), false);
+  assert.equal(isValidDomain("712-eip"), false);
+  assert.equal(isValidDomain(""), false);
+  assert.equal(isValidDomain("foo_bar"), false);
+});
+
+test("findPromoteCandidates: single block", () => {
+  const md = [
+    "## Heading",
+    "",
+    "Body line.",
+    "",
+    "<!-- promote-candidate:solana -->",
+    "Solana RPC X behaves like Y.",
+    "Confirm with `getRecentBlockhash`.",
+    "<!-- /promote-candidate -->",
+    "",
+    "Trailing line.",
+  ].join("\n");
+  const found = findPromoteCandidates(md);
+  assert.equal(found.length, 1);
+  assert.equal(found[0].domain, "solana");
+  assert.equal(found[0].startLine, 4);
+  assert.equal(found[0].endLine, 7);
+  assert.equal(
+    found[0].body,
+    "Solana RPC X behaves like Y.\nConfirm with `getRecentBlockhash`.",
+  );
+});
+
+test("findPromoteCandidates: multiple blocks across the file", () => {
+  const md = [
+    "<!-- promote-candidate:aave -->",
+    "Aave fact.",
+    "<!-- /promote-candidate -->",
+    "intermezzo",
+    "<!-- promote-candidate:eip-712 -->",
+    "EIP-712 fact.",
+    "<!-- /promote-candidate -->",
+  ].join("\n");
+  const found = findPromoteCandidates(md);
+  assert.equal(found.length, 2);
+  assert.equal(found[0].domain, "aave");
+  assert.equal(found[1].domain, "eip-712");
+});
+
+test("findPromoteCandidates: orphan open marker is skipped", () => {
+  const md = [
+    "<!-- promote-candidate:lonely -->",
+    "no close.",
+    "more text.",
+  ].join("\n");
+  assert.deepEqual(findPromoteCandidates(md), []);
+});
+
+test("findPromoteCandidates: nested open invalidates outer; inner is matched", () => {
+  const md = [
+    "<!-- promote-candidate:outer -->",
+    "outer body",
+    "<!-- promote-candidate:inner -->",
+    "inner body",
+    "<!-- /promote-candidate -->",
+  ].join("\n");
+  // Outer is malformed (encounters another open before its close) and is
+  // skipped. The single close terminates the inner, which IS a valid block.
+  const found = findPromoteCandidates(md);
+  assert.equal(found.length, 1);
+  assert.equal(found[0].domain, "inner");
+});
+
+test("findPromoteCandidates: ignores blocks with invalid domain shape", () => {
+  const md = [
+    "<!-- promote-candidate:Bad-Domain -->",
+    "body",
+    "<!-- /promote-candidate -->",
+  ].join("\n");
+  assert.deepEqual(findPromoteCandidates(md), []);
+});
+
+test("validateEntry: empty body fails", () => {
+  const r = validateEntry("   \n  \n");
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.includes("empty")));
+});
+
+test("validateEntry: oversize line count fails", () => {
+  const body = Array.from({ length: MAX_ENTRY_LINES + 5 }, (_, i) => `line ${i}`).join("\n");
+  const r = validateEntry(body);
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.includes("MAX_ENTRY_LINES")));
+});
+
+test("validateEntry: oversize char count fails", () => {
+  const body = "x".repeat(MAX_ENTRY_CHARS + 100);
+  const r = validateEntry(body);
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.includes("MAX_ENTRY_CHARS")));
+});
+
+test("validateEntry: imperative phrasing produces warning, not error", () => {
+  const r = validateEntry("You must always re-verify the nonce before broadcast.");
+  assert.equal(r.ok, true);
+  assert.ok(r.warnings.some((w) => w.toLowerCase().includes("imperative")));
+});
+
+test("validateEntry: descriptive observation passes clean", () => {
+  const r = validateEntry(
+    "ERC-4626 vaults round share calculations DOWN on deposit and UP on withdraw — small-balance edge cases hit the rounding ledge.",
+  );
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.warnings, []);
+});
+
+test("rewriteCandidateWrapping: replaces wrapping, preserves body", () => {
+  const md = [
+    "header",
+    "<!-- promote-candidate:solana -->",
+    "Solana fact.",
+    "Another line.",
+    "<!-- /promote-candidate -->",
+    "footer",
+  ].join("\n");
+  const found = findPromoteCandidates(md);
+  assert.equal(found.length, 1);
+  const out = rewriteCandidateWrapping(md, found[0], "<!-- promoted:solana:T -->");
+  const expected = [
+    "header",
+    "<!-- promoted:solana:T -->",
+    "Solana fact.",
+    "Another line.",
+    "footer",
+  ].join("\n");
+  assert.equal(out, expected);
+});
+
+test("rewriteCandidateWrapping: re-running findPromoteCandidates on rewritten content yields none", () => {
+  const md = [
+    "<!-- promote-candidate:aave -->",
+    "Aave fact.",
+    "<!-- /promote-candidate -->",
+  ].join("\n");
+  const [c] = findPromoteCandidates(md);
+  const rewritten = rewriteCandidateWrapping(md, c, formatPromotedSentinel("aave", "T"));
+  assert.deepEqual(findPromoteCandidates(rewritten), []);
+});
+
+test("formatPromotedSentinel and formatNotPromotedSentinel produce stable shapes", () => {
+  assert.equal(
+    formatPromotedSentinel("solana", "2026-05-04T00:00:00.000Z"),
+    "<!-- promoted:solana:2026-05-04T00:00:00.000Z -->",
+  );
+  assert.equal(
+    formatNotPromotedSentinel("imperative phrasing", "2026-05-04T00:00:00.000Z"),
+    "<!-- not-promoted:imperative phrasing:2026-05-04T00:00:00.000Z -->",
+  );
+});

--- a/src/util/promotionMarkers.ts
+++ b/src/util/promotionMarkers.ts
@@ -1,0 +1,163 @@
+// Pure parsing + validation helpers for cross-agent lesson promotion markers.
+//
+// Marker formats embedded into a per-agent CLAUDE.md by the summarizer:
+//   <!-- promote-candidate:<domain> -->
+//   <descriptive observation body, multi-line ok>
+//   <!-- /promote-candidate -->
+//
+// After human review, the wrapping comment pair is rewritten in place to a
+// single sentinel so the candidate doesn't resurface in the next review pass:
+//   <!-- promoted:<domain>:<ts> -->        (accepted; body kept above)
+//   <!-- not-promoted:<reason>:<ts> -->    (rejected)
+//
+// All file I/O lives in `src/agent/sharedLessons.ts` and `src/cli.ts`. Tested
+// in `promotionMarkers.test.ts` (test runner globs `dist/src/util/*.test.js`).
+//
+// Format constraints applied at promotion time (per #33 path B + agent-6100's
+// trust-boundary observation): cap each pool entry to MAX_ENTRY_LINES /
+// MAX_ENTRY_CHARS, refuse empty bodies, surface imperative-voice phrasing as a
+// warning so a human reviewer can think twice before accepting an entry that
+// reads like instructions to a sibling agent.
+
+const DOMAIN_RE = /^[a-z][a-z0-9-]*$/;
+const PROMOTE_OPEN_RE = /^\s*<!--\s*promote-candidate:([a-z][a-z0-9-]*)\s*-->\s*$/;
+const PROMOTE_CLOSE_RE = /^\s*<!--\s*\/promote-candidate\s*-->\s*$/;
+
+export const MAX_ENTRY_LINES = 40;
+export const MAX_ENTRY_CHARS = 1500;
+
+export function isValidDomain(s: string): boolean {
+  return DOMAIN_RE.test(s);
+}
+
+export interface PromoteCandidate {
+  domain: string;
+  body: string;
+  /** 0-based line index of the opening `<!-- promote-candidate:... -->`. */
+  startLine: number;
+  /** 0-based line index of the closing `<!-- /promote-candidate -->` (inclusive). */
+  endLine: number;
+}
+
+/**
+ * Walk markdown content and return every well-formed promote-candidate block.
+ * Malformed pairs (missing close, nested open) are silently skipped — the
+ * review CLI surfaces a count of skipped vs found so the human notices.
+ */
+export function findPromoteCandidates(content: string): PromoteCandidate[] {
+  const lines = content.split("\n");
+  const out: PromoteCandidate[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const open = lines[i].match(PROMOTE_OPEN_RE);
+    if (!open) {
+      i += 1;
+      continue;
+    }
+    const domain = open[1];
+    let close = -1;
+    for (let j = i + 1; j < lines.length; j++) {
+      // Reject nested opens — treat as malformed and skip the outer.
+      if (PROMOTE_OPEN_RE.test(lines[j])) {
+        close = -2;
+        break;
+      }
+      if (PROMOTE_CLOSE_RE.test(lines[j])) {
+        close = j;
+        break;
+      }
+    }
+    if (close < 0) {
+      // No matching close (or nested open). Advance past the open so we don't
+      // re-scan it; the human can fix the markup and re-run review.
+      i += 1;
+      continue;
+    }
+    const body = lines.slice(i + 1, close).join("\n");
+    out.push({ domain, body, startLine: i, endLine: close });
+    i = close + 1;
+  }
+  return out;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+/**
+ * Hard rules (errors, append refused):
+ *   - body trimmed must be non-empty
+ *   - non-empty line count ≤ MAX_ENTRY_LINES
+ *   - char count ≤ MAX_ENTRY_CHARS
+ *
+ * Soft rules (warnings, append allowed but flagged):
+ *   - imperative second-person phrasing ("you must", "you should", "the agent
+ *     must") — descriptive-observation rule from #33 plan; reviewers see the
+ *     warning and can downgrade language before accepting.
+ */
+export function validateEntry(body: string): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const trimmed = body.trim();
+  if (trimmed.length === 0) {
+    errors.push("entry body is empty");
+    return { ok: false, errors, warnings };
+  }
+  const lines = trimmed.split("\n").filter((l) => l.trim().length > 0);
+  if (lines.length > MAX_ENTRY_LINES) {
+    errors.push(
+      `entry has ${lines.length} non-empty lines, exceeds MAX_ENTRY_LINES=${MAX_ENTRY_LINES}`,
+    );
+  }
+  if (trimmed.length > MAX_ENTRY_CHARS) {
+    errors.push(
+      `entry has ${trimmed.length} chars, exceeds MAX_ENTRY_CHARS=${MAX_ENTRY_CHARS}`,
+    );
+  }
+  const imperative =
+    /\b(?:you (?:must|should|need to)|agents? (?:must|should)|the agent (?:must|should))\b/i;
+  if (imperative.test(trimmed)) {
+    warnings.push(
+      "imperative phrasing detected — pool entries should be descriptive observations, not instructions to sibling agents",
+    );
+  }
+  return { ok: errors.length === 0, errors, warnings };
+}
+
+/**
+ * Replace a `<!-- promote-candidate -->...<!-- /promote-candidate -->` pair
+ * in `content` with `replacement` (a single line, e.g. a `<!-- promoted -->`
+ * sentinel). Lines between the markers ARE preserved — the review flow keeps
+ * the lesson body in the source CLAUDE.md as historical record; only the
+ * candidacy markers are rewritten. The replacement line takes the slot of the
+ * opening marker; the closing marker is dropped.
+ */
+export function rewriteCandidateWrapping(
+  content: string,
+  candidate: PromoteCandidate,
+  replacement: string,
+): string {
+  const lines = content.split("\n");
+  if (candidate.startLine < 0 || candidate.endLine >= lines.length) {
+    throw new Error(
+      `candidate range (${candidate.startLine}..${candidate.endLine}) out of bounds (${lines.length})`,
+    );
+  }
+  const before = lines.slice(0, candidate.startLine);
+  const body = lines.slice(candidate.startLine + 1, candidate.endLine);
+  const after = lines.slice(candidate.endLine + 1);
+  return [...before, replacement, ...body, ...after].join("\n");
+}
+
+export function formatPromotedSentinel(domain: string, ts: string): string {
+  return `<!-- promoted:${domain}:${ts} -->`;
+}
+
+export function formatNotPromotedSentinel(reason: string, ts: string): string {
+  // Reasons may include spaces — the parser doesn't need to round-trip these,
+  // they're informational only.
+  const safe = reason.replace(/-->/g, "—>");
+  return `<!-- not-promoted:${safe}:${ts} -->`;
+}


### PR DESCRIPTION
Closes #33.

Implements the full plan from `feature-plans/issue-33-shared-lessons-pool.md` (path B per the user's "do B" decision in [issue #33](https://github.com/szhygulin/vaultpilot-development-agents/issues/33#issuecomment-4371893494)) with the format constraints raised by [agent-6100](https://github.com/szhygulin/vaultpilot-development-agents/issues/33#issuecomment-4363601111): per-entry length cap, descriptive-observation rule, imperative-phrasing warning.

## What lands

**Read path** (every agent run, automatic):
- `buildAgentSystemPrompt()` loads `agents/.shared/lessons/<domain>.md` for every domain matching the agent's current tags, splices each pool under a `## Shared lessons (<domain>)` heading between the agent's own CLAUDE.md and the workflow.

**Promotion (write) path** (orchestrator-side only):
- The summarizer prompt is extended with an optional `<!-- promote-candidate:<domain> -->...<!-- /promote-candidate -->` wrapping mechanism. The summarizer chooses the domain from the agent's existing tag fingerprint — no second taxonomy.
- `vp-dev lessons review` walks every agent's CLAUDE.md, surfaces every well-formed candidate block, and asks the human to accept / reject / skip. On accept, the body lands in the pool and the wrapping markers in the source CLAUDE.md are rewritten to a `<!-- promoted:<domain>:<ts> -->` sentinel. On reject, the markers become `<!-- not-promoted:<reason>:<ts> -->`.
- `vp-dev lessons list` shows pool sizes against the 200-line cap.

**Boundary preservation:**
- Coding agents never write to `agents/.shared/` — `renderWorkflow()` carries an explicit guard sentence to that effect.
- All pool writes happen inside `acceptCandidate()` (orchestrator-side), held under the same per-file lock as `appendBlock`.
- The two-step rewrite (pool first, source second) is non-atomic across files; on partial failure (rare) the marker resurfaces on the next review and the human resolves the duplicate by hand.

**Format constraints (agent-6100's residual-risk note):**
- Per-entry: ≤ 40 non-empty lines, ≤ 1500 chars (errors — append refused).
- Imperative second-person phrasing ("you must", "agents should") surfaces as a soft warning so a human reviewer can downgrade the language before accepting.
- Pool size: ≤ 200 lines (rejection forces manual trim before further accepts).

## Files

- `src/util/promotionMarkers.ts` — pure parser, format validators, marker rewriters. 17 unit tests in `promotionMarkers.test.ts`.
- `src/agent/sharedLessons.ts` — pool I/O, locked, with cap + validation.
- `src/agent/promotion.ts` — orchestrator-side accept/reject helpers.
- `src/agent/prompt.ts` — read-path integration.
- `src/agent/summarizer.ts` — summarizer prompt extension (the `<!-- promote-candidate -->` mechanic + format guidance).
- `src/agent/workflow.ts` — explicit "never write to `agents/.shared/`" guard for coding agents.
- `src/cli.ts` — `vp-dev lessons list` + `vp-dev lessons review` (interactive + `--yes` + `--json`).

## Verification

- `npm run build` clean.
- `npm test` — 50 tests, 50 passing (was 35, +15 new tests covering marker parsing, validation, rewrite idempotency, and the `formatPromotedSentinel` round-trip).
- Smoke-tested both subcommands against the empty initial state:
  - `vp-dev lessons list` → "No shared-lesson pools yet. Run `vp-dev lessons review` after a summarizer pass tags a promote-candidate."
  - `vp-dev lessons review --json` → `{ "pending": [] }`.

## Out of scope (per the plan)

- Cross-target-repo lesson sharing.
- Auto-promotion (defeats the boundary).
- LLM-driven trim (manual editing first).
- Failure-derived candidates (#32 lands first, then the same `<!-- promote-candidate -->` mechanism extends).

— Safe Forensics (agent-e22f)
