### PR TITLE
fix(orchestrator): push partial worktree to labeled branch on error_max_turns

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "typecheck": "tsc --noEmit",
-    "test": "tsc && node --test dist/src/util/*.test.js",
+    "test": "tsc && node --test dist/src/util/*.test.js dist/src/git/*.test.js",
     "vp-dev": "node dist/bin/vp-dev.js"
   },
   "dependencies": {

--- a/src/agent/runIssueCore.ts
+++ b/src/agent/runIssueCore.ts
@@ -10,7 +10,9 @@ import {
 import { isInfraFlake, summarizeFailureRun, summarizeRun, type SummarizerOutput } from "./summarizer.js";
 import { resolveExpireK } from "../util/sentinels.js";
 import {
+  buildIncompleteBranchName,
   createWorktree,
+  pushPartialBranch,
   removeWorktree,
   type WorktreeHandle,
 } from "../git/worktree.js";
@@ -45,6 +47,15 @@ export interface RunIssueCoreResult {
   reconciled?: string;
   /** See CodingAgentResult.branchUrl. */
   branchUrl?: string;
+  /** See CodingAgentResult.errorSubtype — propagated for orchestrator-side branching. */
+  errorSubtype?: string;
+  /**
+   * Set when the orchestrator-level safety net pushed in-flight worktree
+   * edits to a labeled `<branch>-incomplete-<runId>` ref before pruning.
+   * Distinct from `branchUrl` (which describes the agent's primary branch
+   * found via reconcile). See issue #88.
+   */
+  partialBranchUrl?: string;
 }
 
 export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCoreResult> {
@@ -214,6 +225,57 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
       });
     });
 
+    // Orchestrator-level safety net: when the SDK truncated the run with
+    // `error_max_turns` AND the agent did not finish with a clean implement
+    // decision, push whatever's currently in the worktree to a labeled
+    // `<branch>-incomplete-<runId>` ref so the partial work isn't lost when
+    // `removeWorktree` deletes the local branch in the finally below. The
+    // in-agent recovery pass (codingAgent.ts) attempts the same first, but
+    // can itself fail — this is the deterministic backstop. Skipped in
+    // dry-run because remote pushes are intercepted into echoes. See #88.
+    let partialBranchUrl: string | undefined;
+    if (
+      worktree &&
+      result.errorSubtype === "error_max_turns" &&
+      envelope?.decision !== "implement" &&
+      !input.dryRun
+    ) {
+      const incompleteBranch = buildIncompleteBranchName(worktree.branch, input.runId);
+      try {
+        const pushResult = await pushPartialBranch({
+          repoPath: input.targetRepoPath,
+          worktreePath: worktree.path,
+          worktreeBranch: worktree.branch,
+          incompleteBranch,
+          runId: input.runId,
+          errorSubtype: result.errorSubtype,
+          targetRepo: input.targetRepo,
+          logger: input.logger,
+          agentId: input.agent.agentId,
+          issueId: input.issue.id,
+        });
+        if (pushResult.pushed) {
+          partialBranchUrl = pushResult.branchUrl;
+        } else {
+          input.logger.info("worktree.partial_branch_skipped", {
+            agentId: input.agent.agentId,
+            issueId: input.issue.id,
+            reason: pushResult.reason,
+          });
+        }
+      } catch (err) {
+        // Defensive: the helper already catches its own failures and returns
+        // structured `reason`. If something throws anyway (e.g. an unexpected
+        // type-error in the helper itself), surface as a warn and continue —
+        // never block the main failure path on the safety net.
+        input.logger.warn("worktree.partial_branch_unexpected_error", {
+          agentId: input.agent.agentId,
+          issueId: input.issue.id,
+          err: (err as Error).message,
+        });
+      }
+    }
+
     return {
       envelope,
       finalText: result.finalText,
@@ -228,6 +290,8 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
       branchName: worktree?.branch,
       reconciled: result.reconciled,
       branchUrl: result.branchUrl,
+      errorSubtype: result.errorSubtype,
+      partialBranchUrl,
     };
   } finally {
     if (worktree) {

--- a/src/git/worktree.test.ts
+++ b/src/git/worktree.test.ts
@@ -1,0 +1,56 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildIncompleteBranchName } from "./worktree.js";
+
+// Canonical runId shape from `makeRunId()`:
+// `run-2026-05-04T16-53-06-188Z` — alphanumerics, `-`, `T`, `Z`. Already
+// git-ref-safe; the helper passes it through.
+test("preserves canonical run-<iso> runId verbatim", () => {
+  const branch = buildIncompleteBranchName(
+    "vp-dev/agent-72c6/issue-88",
+    "run-2026-05-04T16-53-06-188Z",
+  );
+  assert.equal(
+    branch,
+    "vp-dev/agent-72c6/issue-88-incomplete-run-2026-05-04T16-53-06-188Z",
+  );
+});
+
+test("sanitizes runId chars that aren't alphanumeric or '-'", () => {
+  // Hypothetical future runId formats with `:`, `.`, `/` etc. would break
+  // git ref rules — the helper must scrub them.
+  const branch = buildIncompleteBranchName(
+    "vp-dev/agent-aa26/issue-34",
+    "run-2026:05:04T17.48.07/803Z",
+  );
+  // `:` `.` `/` all mapped to `-`. The original branch slashes stay.
+  assert.equal(
+    branch,
+    "vp-dev/agent-aa26/issue-34-incomplete-run-2026-05-04T17-48-07-803Z",
+  );
+});
+
+test("does not match the stale-branch sweep regex (anchored vp-dev pattern)", () => {
+  // Defensive check: the existing prune sweep uses
+  //   /^vp-dev\/(agent-[a-z0-9]+)\/issue-(\d+)$/
+  // The trailing `$` plus the `-incomplete-<runId>` suffix means our
+  // labeled refs are NOT auto-cleaned by the sweep. Encoded here so a
+  // future regex tweak in worktree.ts doesn't silently start eating the
+  // salvage branches.
+  const sweepRegex = /^vp-dev\/(agent-[a-z0-9]+)\/issue-(\d+)$/;
+  const incomplete = buildIncompleteBranchName(
+    "vp-dev/agent-72c6/issue-88",
+    "run-2026-05-04T16-53-06-188Z",
+  );
+  assert.equal(sweepRegex.test(incomplete), false);
+  // Sanity: the original (pre-suffix) branch DOES match the sweep regex.
+  assert.equal(sweepRegex.test("vp-dev/agent-72c6/issue-88"), true);
+});
+
+test("preserves multi-digit issue numbers and lowercase agent ids", () => {
+  const branch = buildIncompleteBranchName(
+    "vp-dev/agent-ef41/issue-1234",
+    "run-X",
+  );
+  assert.equal(branch, "vp-dev/agent-ef41/issue-1234-incomplete-run-X");
+});

--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -111,6 +111,197 @@ export async function createWorktree(opts: {
   return { path: wtPath, branch };
 }
 
+// Build the labeled ref for the safety-net partial push. The original branch
+// shape `vp-dev/<agent>/issue-<N>` matches `VP_DEV_BRANCH_RE` (anchored `$`),
+// so appending `-incomplete-<runId>` keeps the new ref OUT of the stale-branch
+// sweep — incomplete branches are evidence for human inspection, not auto-
+// cleaned. Sanitized to git-ref rules (alphanumerics + `-` + `/`).
+export function buildIncompleteBranchName(originalBranch: string, runId: string): string {
+  const safeRunId = runId.replace(/[^a-zA-Z0-9-]/g, "-");
+  return `${originalBranch}-incomplete-${safeRunId}`;
+}
+
+export interface PushPartialBranchOpts {
+  repoPath: string;
+  worktreePath: string;
+  worktreeBranch: string;
+  incompleteBranch: string;
+  runId: string;
+  errorSubtype: string;
+  targetRepo: string;
+  logger?: Logger;
+  agentId: string;
+  issueId: number;
+}
+
+export interface PushPartialBranchResult {
+  pushed: boolean;
+  branchUrl?: string;
+  /** Set when pushed === false. */
+  reason?: string;
+  /** True if a salvage commit was created on top of existing tree state. */
+  committed?: boolean;
+}
+
+// Orchestrator-level safety net for non-clean agent exits (today only fired
+// for `error_max_turns`).
+//
+// Why this is a separate orchestrator path even though `runCodingAgent`
+// already runs an in-agent recovery pass (see issue #76, commit d4aadd0):
+// the recovery pass itself can fail — it consumes its own 5-turn budget,
+// hits permission denials, or simply doesn't complete the push. When that
+// happens, the existing `removeWorktree({ deleteBranch: true })` call below
+// silently nukes the local branch and any uncommitted edits. This helper is
+// the deterministic backstop that runs whether or not the agent recovered:
+// shell-level git, no LLM in the loop. See issue #88.
+//
+// Steps:
+//   1. `git status --porcelain` to detect uncommitted work in the worktree.
+//   2. If anything uncommitted → `git add -A && git commit -m <salvage msg>`
+//      so the in-flight edits are captured as a commit.
+//   3. Compare HEAD against `origin/main` — if HEAD has at least one new
+//      commit (the salvage commit, or pre-existing agent commits that were
+//      never pushed), `git push -u origin HEAD:<incompleteBranch>`.
+//   4. If the worktree is clean and there are no commits ahead of origin/main,
+//      skip the push (nothing to preserve).
+//
+// Failure modes are surfaced via the `reason` field — the orchestrator never
+// throws on partial-push failure; the agent's primary failure path is the
+// authoritative outcome. Push-protection invariant: this never targets `main`
+// (incompleteBranch always carries the `-incomplete-<runId>` suffix).
+export async function pushPartialBranch(
+  opts: PushPartialBranchOpts,
+): Promise<PushPartialBranchResult> {
+  // Reject anything resembling a `main` push at the helper boundary.
+  // Belt-and-suspenders against future callers; the canonical caller in
+  // runIssueCore always passes a `-incomplete-<runId>` suffixed name.
+  if (opts.incompleteBranch === "main" || opts.incompleteBranch.endsWith("/main")) {
+    return { pushed: false, reason: "refusing to push partial branch to main" };
+  }
+
+  // 1. Detect uncommitted work.
+  let uncommitted = false;
+  try {
+    const { stdout } = await execFile("git", ["status", "--porcelain"], {
+      cwd: opts.worktreePath,
+    });
+    uncommitted = stdout.trim().length > 0;
+  } catch (err) {
+    opts.logger?.warn("worktree.partial_push_status_failed", {
+      agentId: opts.agentId,
+      issueId: opts.issueId,
+      err: (err as Error).message,
+    });
+    return {
+      pushed: false,
+      reason: `git status failed: ${(err as Error).message}`,
+    };
+  }
+
+  // 2. Stage + commit if there are uncommitted edits.
+  let committed = false;
+  if (uncommitted) {
+    try {
+      await execFile("git", ["add", "-A"], { cwd: opts.worktreePath });
+      // Empty author/committer env to inherit local git config; commit
+      // message documents the salvage origin so a human pulling the branch
+      // can grep `git log` for the runId.
+      await execFile(
+        "git",
+        [
+          "commit",
+          "-m",
+          `chore(salvage): partial work from runId=${opts.runId} (errorSubtype=${opts.errorSubtype})\n\nIn-flight edits captured by orchestrator safety net before worktree prune. Not finished work — review and discard or build on as appropriate.`,
+        ],
+        { cwd: opts.worktreePath },
+      );
+      committed = true;
+    } catch (err) {
+      // Hooks failing, identity-not-set, etc. Surface and bail — without
+      // the commit, push has nothing new to carry.
+      opts.logger?.warn("worktree.partial_push_commit_failed", {
+        agentId: opts.agentId,
+        issueId: opts.issueId,
+        err: (err as { stderr?: string }).stderr ?? (err as Error).message,
+      });
+      return {
+        pushed: false,
+        reason: `salvage commit failed: ${
+          (err as { stderr?: string }).stderr ?? (err as Error).message
+        }`,
+      };
+    }
+  }
+
+  // 3. Anything to push? Compare HEAD vs origin/main. If we have commits
+  // ahead (salvage, or pre-existing unpushed agent commits) we push; else
+  // the worktree was a no-op and there's nothing to preserve.
+  let aheadCount = 0;
+  try {
+    const { stdout } = await execFile(
+      "git",
+      ["rev-list", "--count", "origin/main..HEAD"],
+      { cwd: opts.worktreePath },
+    );
+    aheadCount = parseInt(stdout.trim(), 10) || 0;
+  } catch {
+    // Best-effort; if rev-list fails we still attempt the push — push will
+    // succeed iff the ref differs from any existing remote.
+    aheadCount = committed ? 1 : 0;
+  }
+
+  if (aheadCount === 0) {
+    return {
+      pushed: false,
+      committed,
+      reason: "no commits ahead of origin/main; nothing to preserve",
+    };
+  }
+
+  // 4. Push HEAD to the labeled incomplete branch on origin.
+  try {
+    await execFile(
+      "git",
+      [
+        "push",
+        "-u",
+        "origin",
+        `HEAD:refs/heads/${opts.incompleteBranch}`,
+      ],
+      { cwd: opts.worktreePath },
+    );
+  } catch (err) {
+    opts.logger?.warn("worktree.partial_push_failed", {
+      agentId: opts.agentId,
+      issueId: opts.issueId,
+      branch: opts.incompleteBranch,
+      err: (err as { stderr?: string }).stderr ?? (err as Error).message,
+    });
+    return {
+      pushed: false,
+      committed,
+      reason: `git push failed: ${
+        (err as { stderr?: string }).stderr ?? (err as Error).message
+      }`,
+    };
+  }
+
+  const branchUrl = `https://github.com/${opts.targetRepo}/tree/${encodeURIComponent(
+    opts.incompleteBranch,
+  )}`;
+  opts.logger?.info("worktree.partial_branch_pushed", {
+    agentId: opts.agentId,
+    issueId: opts.issueId,
+    branch: opts.incompleteBranch,
+    branchUrl,
+    committed,
+    aheadCount,
+    errorSubtype: opts.errorSubtype,
+    runId: opts.runId,
+  });
+  return { pushed: true, committed, branchUrl };
+}
+
 export async function removeWorktree(opts: {
   repoPath: string;
   worktree: WorktreeHandle;

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -306,11 +306,15 @@ async function runOneIssue(opts: {
       outcome: env.decision,
       prUrl: env.prUrl,
       commentUrl: env.commentUrl,
+      partialBranchUrl: result.partialBranchUrl,
     };
   } else {
     // Reconciliation found a branch on remote without a PR — surface it in
     // the failure record so the user can salvage with one `gh pr create`
-    // instead of grepping run logs for the orphan branch name.
+    // instead of grepping run logs for the orphan branch name. The partial
+    // branch (issue #88) is a separate, labeled ref pushed by the safety
+    // net; it lives in `partialBranchUrl` so post-run audits can find it
+    // without parsing free-form `error` strings.
     const baseError = result.parseError ?? result.errorReason ?? "Unknown agent failure";
     const error = result.branchUrl
       ? `${baseError} | orphan branch: ${result.branchUrl}`
@@ -320,6 +324,7 @@ async function runOneIssue(opts: {
       agentId: opts.agent.agentId,
       outcome: "error",
       error,
+      partialBranchUrl: result.partialBranchUrl,
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,12 @@ export interface RunIssueEntry {
   prUrl?: string;
   commentUrl?: string;
   error?: string;
+  // Set when the orchestrator's safety-net pushed in-flight worktree edits
+  // to a labeled `<branch>-incomplete-<runId>` ref after a non-clean exit
+  // (today: `error_max_turns`). The agent's primary branch may also have
+  // been deleted by the post-run cleanup; this URL preserves the partial
+  // work for human inspection. See issue #88.
+  partialBranchUrl?: string;
 }
 
 // A `vp-dev/agent-*/issue-*` branch the stale-branch sweep determined was


### PR DESCRIPTION
Closes #88.

## Summary

When the SDK truncates an agent run with `error_max_turns`, the worktree's local branch is currently deleted by the post-run cleanup, taking any uncommitted edits with it. The in-agent recovery pass (#76 / d4aadd0) tries to commit + push first, but it can itself run out of budget or hit a permission denial — at which point the safety net is gone.

This PR adds a deterministic, shell-level safety net at the orchestrator boundary so partial work survives whether or not the in-agent recovery pass finished:

- `pushPartialBranch()` in `src/git/worktree.ts` — `git status` → optional `git add -A && git commit` → `git push -u origin HEAD:refs/heads/<branch>-incomplete-<runId>`. Returns a structured `{ pushed, branchUrl, reason, committed }`; never throws.
- `runIssueCore` invokes it before return when `errorSubtype === "error_max_turns"` AND `envelope?.decision !== "implement"`. Skipped in dry-run (push is intercepted into echoes there).
- `RunIssueEntry` gains `partialBranchUrl?: string`; the orchestrator copies it into `state.issues[N]` whether or not an envelope exists, so post-run audits can find salvage refs via `state/<runId>.json` instead of free-form error strings.
- The `<branch>-incomplete-<runId>` shape intentionally fails the anchored `VP_DEV_BRANCH_RE`, so `pruneStaleAgentBranches` won't auto-clean it. Encoded as a test in `worktree.test.ts`.

In scope per the issue: default ON for `error_max_turns` only. Out of scope (filed separately if/when needed): broader "any non-clean exit" gating, auto-resume, periodic cleanup of `-incomplete-*` branches, partial-push on clean exits.

## Test plan

- [x] `npm run build` — passes (no type errors).
- [x] `npm test` — 39 tests pass, including 4 new `buildIncompleteBranchName` cases (canonical runId pass-through, char sanitization, sweep-regex non-match invariant, multi-digit issues).
- [ ] End-to-end: trigger `error_max_turns` on a real issue (or simulate via a low `maxTurns` override) and verify `state/<runId>.json` carries `partialBranchUrl` and the `vp-dev/agent-XXXX/issue-N-incomplete-<runId>` ref appears on `origin`.
- [ ] Confirm `pruneStaleAgentBranches` does not delete an `-incomplete-*` branch on a subsequent run.

— Rogue Oracle (agent-72c6)
