### PR TITLE
Phase 1: per-run cost tracker + --max-cost-usd flag (no enforcement)

### DIFF
--- a/src/agent/codingAgent.ts
+++ b/src/agent/codingAgent.ts
@@ -11,6 +11,7 @@ import { reconcileFromState, type ReconcileState } from "./reconcile.js";
 import { claudeBinPath } from "./sdkBinary.js";
 import type { AgentRecord, ResultEnvelope } from "../types.js";
 import type { Logger } from "../log/logger.js";
+import type { RunCostTracker } from "../util/costTracker.js";
 
 export interface CodingAgentInput {
   agent: AgentRecord;
@@ -23,6 +24,12 @@ export interface CodingAgentInput {
   logger: Logger;
   abortController?: AbortController;
   inspectPaths?: string[];
+  /**
+   * Per-run cost accumulator (issue #85 Phase 1 — measurement only).
+   * Optional so direct callers like `vp-dev spawn` (single-issue, no run
+   * scope) can omit it; orchestrator-driven runs always pass one.
+   */
+  costTracker?: RunCostTracker;
 }
 
 export interface CodingAgentResult {
@@ -106,6 +113,12 @@ export async function runCodingAgent(input: CodingAgentInput): Promise<CodingAge
     toolUseTrace,
   });
 
+  // Forward to the per-run accumulator the moment the SDK reports the
+  // pass cost — pre-recovery so even a recovery-pass crash leaves the
+  // first pass accounted for. The tracker is defensive against
+  // undefined/non-finite values.
+  input.costTracker?.add(pass1.costUsd);
+
   let finalText = pass1.finalText;
   let isError = pass1.isError;
   let errorReason = pass1.errorReason;
@@ -143,6 +156,7 @@ export async function runCodingAgent(input: CodingAgentInput): Promise<CodingAge
     if (typeof pass2.costUsd === "number") {
       costUsd = (costUsd ?? 0) + pass2.costUsd;
     }
+    input.costTracker?.add(pass2.costUsd);
     // Recovery may itself fail; that's fine — the existing reconcile pass
     // below picks up whatever the agent managed to push to origin.
     if (!pass2.isError) {

--- a/src/agent/runIssueCore.ts
+++ b/src/agent/runIssueCore.ts
@@ -16,6 +16,7 @@ import {
 } from "../git/worktree.js";
 import type { Logger } from "../log/logger.js";
 import type { AgentRecord, IssueSummary, ResultEnvelope } from "../types.js";
+import type { RunCostTracker } from "../util/costTracker.js";
 
 export interface RunIssueCoreInput {
   agent: AgentRecord;
@@ -27,6 +28,12 @@ export interface RunIssueCoreInput {
   logger: Logger;
   skipSummary?: boolean;
   inspectPaths?: string[];
+  /**
+   * Per-run cost accumulator threaded down from `cmdRun()`. Phase 1 of
+   * the cost-ceiling design (#85): measurement only, no enforcement.
+   * Optional so `vp-dev spawn` (single-issue, no run scope) can omit it.
+   */
+  costTracker?: RunCostTracker;
 }
 
 export interface RunIssueCoreResult {
@@ -76,6 +83,7 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
       dryRun: input.dryRun,
       logger: input.logger,
       inspectPaths: input.inspectPaths,
+      costTracker: input.costTracker,
     });
 
     envelope = result.envelope;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -62,6 +62,7 @@ import {
   rollupOutcomes,
   type AgentRollup,
 } from "./state/outcomes.js";
+import { RunCostTracker, resolveBudgetUsd } from "./util/costTracker.js";
 import type { AgentRecord, IssueRangeSpec, IssueSummary } from "./types.js";
 
 const DEFAULT_STALLED_THRESHOLD_DAYS = 14;
@@ -101,6 +102,10 @@ export function buildCli(): Command {
     .option(
       "--include-non-ready",
       "Skip pre-dispatch triage and dispatch every open issue (per-run override; no env var)",
+    )
+    .option(
+      "--max-cost-usd <usd>",
+      "Per-run cost ceiling in USD (e.g. 5.0). Phase 1: logged + accumulated only — no enforcement yet (#85). Env fallback: VP_DEV_MAX_COST_USD.",
     )
     .action(async (opts) => {
       await cmdRun(opts);
@@ -220,6 +225,7 @@ interface RunOpts {
   plan?: boolean;
   confirm?: string;
   includeNonReady?: boolean;
+  maxCostUsd?: string;
 }
 
 async function cmdRun(opts: RunOpts): Promise<void> {
@@ -297,6 +303,13 @@ async function cmdRun(opts: RunOpts): Promise<void> {
   const range: IssueRangeSpec = parseRangeSpec(opts.issues);
   const repoPath = await resolveTargetRepoPath(opts.targetRepo, opts.targetRepoPath);
 
+  // Per-run cost tracker (issue #85, Phase 1). Instantiated here so triage
+  // cost (which fires BEFORE the runId is minted on line ~451) accumulates
+  // into the same total as orchestrator + coding-agent spend. Phase 1 is
+  // measurement only — `budgetUsd` is logged but not enforced.
+  const budgetUsd = resolveBudgetUsd({ flag: opts.maxCostUsd, env: process.env });
+  const costTracker = new RunCostTracker();
+
   const { open, skippedClosed } = await resolveRangeToIssues(opts.targetRepo, range);
   if (open.length === 0) {
     console.error("ERROR: no open issues in range.");
@@ -335,6 +348,11 @@ async function cmdRun(opts: RunOpts): Promise<void> {
         .filter((t) => !t.result.ready)
         .map((t) => ({ issue: t.issue, reason: t.result.reason }));
       triageCostUsd = triaged.reduce((sum, t) => sum + t.costUsd, 0);
+      // Pre-dispatch triage runs BEFORE the runId / orchestrator is set up,
+      // but the cost belongs to the same per-run total — fold it in here so
+      // `run.completed` reports a single number that reconciles with the SDK
+      // billing dashboard.
+      costTracker.add(triageCostUsd);
       triageLogger.info("triage.batch_completed", {
         total: triaged.length,
         ready: dispatchIssues.length,
@@ -471,6 +489,10 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     issueCount: dispatchIssues.length,
     triageSkippedCount: triageSkipped.length,
     dryRun: !!opts.dryRun,
+    // `null` (not omitted) when no budget is set so log consumers can
+    // distinguish "Phase-1 run with no cap" from "older log without
+    // cost-tracking columns" without parsing the runId timestamp.
+    maxCostUsd: budgetUsd ?? null,
   });
 
   try {
@@ -490,11 +512,17 @@ async function cmdRun(opts: RunOpts): Promise<void> {
       logger,
       dryRun: !!opts.dryRun,
       targetRepoPath: repoPath,
+      costTracker,
     });
     logger.info("run.completed", {
       runId,
       complete: isRunComplete(state),
       issueCount: dispatchIssues.length,
+      // Run-final accounting (#85 acceptance): single total summed across
+      // triage + dispatcher + coding-agent. Reconciles with the SDK
+      // billing dashboard.
+      totalCostUsd: costTracker.total(),
+      maxCostUsd: budgetUsd ?? null,
     });
     if (isRunComplete(state)) await clearCurrentRunId();
   } finally {

--- a/src/orchestrator/dispatcher.ts
+++ b/src/orchestrator/dispatcher.ts
@@ -11,12 +11,20 @@ import {
 } from "./routing.js";
 import type { AgentRecord, IssueSummary } from "../types.js";
 import type { Logger } from "../log/logger.js";
+import type { RunCostTracker } from "../util/costTracker.js";
 
 export interface DispatchInput {
   idleAgents: AgentRecord[];
   pendingIssues: IssueSummary[];
   cap: number;
   logger: Logger;
+  /**
+   * Per-run cost accumulator (issue #85 Phase 1). Measurement only:
+   * dispatcher's per-tick `query()` cost is forwarded to the tracker so
+   * the run total includes orchestrator-side spend alongside the larger
+   * coding-agent cost.
+   */
+  costTracker?: RunCostTracker;
 }
 
 export interface DispatchResult {
@@ -35,6 +43,7 @@ export async function dispatch(input: DispatchInput): Promise<DispatchResult> {
     idleAgents: input.idleAgents,
     cap,
     logger: input.logger,
+    costTracker: input.costTracker,
   });
   if (firstAttempt.assignments) {
     return { assignments: firstAttempt.assignments, source: "llm" };
@@ -51,6 +60,7 @@ export async function dispatch(input: DispatchInput): Promise<DispatchResult> {
     cap,
     logger: input.logger,
     errorsFromPrior: firstAttempt.errors,
+    costTracker: input.costTracker,
   });
   if (retry.assignments) {
     return { assignments: retry.assignments, source: "llm-retry" };
@@ -80,6 +90,7 @@ async function tryProposeWithLLM(opts: {
   cap: number;
   logger: Logger;
   errorsFromPrior?: string[];
+  costTracker?: RunCostTracker;
 }): Promise<ProposeOutcome> {
   const prompt = buildTickPrompt({
     pendingIssues: opts.pendingIssues,
@@ -105,6 +116,9 @@ async function tryProposeWithLLM(opts: {
     });
     for await (const msg of stream) {
       if (msg.type === "result") {
+        // Forward whether success or error subtype — the SDK reports cost
+        // for both, and a failed dispatch still consumed tokens.
+        opts.costTracker?.add(msg.total_cost_usd);
         if (msg.subtype === "success") raw = msg.result;
         else return { errors: [`Orchestrator query failed: ${msg.subtype}`] };
       }

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -19,6 +19,7 @@ import type {
   IssueSummary,
   RunState,
 } from "../types.js";
+import type { RunCostTracker } from "../util/costTracker.js";
 
 export interface OrchestratorInput {
   state: RunState;
@@ -28,6 +29,13 @@ export interface OrchestratorInput {
   logger: Logger;
   dryRun: boolean;
   targetRepoPath?: string;
+  /**
+   * Per-run cost accumulator (issue #85 Phase 1 — measurement only).
+   * Threaded down to the dispatcher (orchestrator-side `query()` cost)
+   * and to each `runIssueCore` → `runCodingAgent` (issue-side cost).
+   * Optional so the orchestrator can be exercised without one in tests.
+   */
+  costTracker?: RunCostTracker;
 }
 
 export async function runOrchestrator(input: OrchestratorInput): Promise<void> {
@@ -66,6 +74,7 @@ export async function runOrchestrator(input: OrchestratorInput): Promise<void> {
         pendingIssues: pending,
         cap,
         logger: input.logger,
+        costTracker: input.costTracker,
       });
       input.logger.info("tick.proposal", {
         tick: input.state.tickCount,
@@ -89,6 +98,7 @@ export async function runOrchestrator(input: OrchestratorInput): Promise<void> {
           dryRun: input.dryRun,
           logger: input.logger,
           state: input.state,
+          costTracker: input.costTracker,
         }).catch(async (err) => {
           input.logger.error("agent.uncaught", {
             agentId: agent.agentId,
@@ -287,6 +297,7 @@ async function runOneIssue(opts: {
   dryRun: boolean;
   logger: Logger;
   state: RunState;
+  costTracker?: RunCostTracker;
 }): Promise<void> {
   const result = await runIssueCore({
     agent: opts.agent,
@@ -296,6 +307,7 @@ async function runOneIssue(opts: {
     runId: opts.state.runId,
     dryRun: opts.dryRun,
     logger: opts.logger,
+    costTracker: opts.costTracker,
   });
 
   if (result.envelope) {

--- a/src/util/costTracker.test.ts
+++ b/src/util/costTracker.test.ts
@@ -1,0 +1,108 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { RunCostTracker, resolveBudgetUsd } from "./costTracker.js";
+
+test("RunCostTracker: starts at zero", () => {
+  const t = new RunCostTracker();
+  assert.equal(t.total(), 0);
+});
+
+test("RunCostTracker: accumulates positive values", () => {
+  const t = new RunCostTracker();
+  t.add(0.25);
+  t.add(0.75);
+  t.add(1.5);
+  assert.equal(t.total(), 2.5);
+});
+
+test("RunCostTracker: ignores undefined / null / NaN / Infinity / negative", () => {
+  const t = new RunCostTracker();
+  t.add(undefined);
+  t.add(null);
+  t.add(Number.NaN);
+  t.add(Number.POSITIVE_INFINITY);
+  t.add(Number.NEGATIVE_INFINITY);
+  t.add(-1);
+  t.add(-0.001);
+  assert.equal(t.total(), 0);
+  // A real cost still accumulates after garbage readings.
+  t.add(1.5);
+  assert.equal(t.total(), 1.5);
+});
+
+test("RunCostTracker: zero is a valid no-op cost", () => {
+  const t = new RunCostTracker();
+  t.add(0);
+  t.add(0);
+  assert.equal(t.total(), 0);
+});
+
+test("RunCostTracker: exceedsBudget — strict greater-than", () => {
+  const t = new RunCostTracker();
+  t.add(5);
+  // accumulated == budget → not exceeding (strict >).
+  assert.equal(t.exceedsBudget(5), false);
+  assert.equal(t.exceedsBudget(5.01), false);
+  assert.equal(t.exceedsBudget(4.99), true);
+});
+
+test("RunCostTracker: exceedsBudget — empty tracker never exceeds", () => {
+  const t = new RunCostTracker();
+  assert.equal(t.exceedsBudget(0), false);
+  assert.equal(t.exceedsBudget(10), false);
+});
+
+test("RunCostTracker: exceedsBudget — malformed budget returns false", () => {
+  const t = new RunCostTracker();
+  t.add(100);
+  assert.equal(t.exceedsBudget(Number.NaN), false);
+  assert.equal(t.exceedsBudget(Number.POSITIVE_INFINITY), false);
+  assert.equal(t.exceedsBudget(-1), false);
+});
+
+test("resolveBudgetUsd: undefined when neither flag nor env set", () => {
+  assert.equal(resolveBudgetUsd({ flag: undefined, env: {} }), undefined);
+});
+
+test("resolveBudgetUsd: parses numeric flag", () => {
+  assert.equal(resolveBudgetUsd({ flag: "5.0", env: {} }), 5.0);
+  assert.equal(resolveBudgetUsd({ flag: "0.25", env: {} }), 0.25);
+  assert.equal(resolveBudgetUsd({ flag: 7, env: {} }), 7);
+});
+
+test("resolveBudgetUsd: flag wins over env", () => {
+  assert.equal(
+    resolveBudgetUsd({ flag: "1.5", env: { VP_DEV_MAX_COST_USD: "10" } }),
+    1.5,
+  );
+});
+
+test("resolveBudgetUsd: env fallback when flag absent", () => {
+  assert.equal(
+    resolveBudgetUsd({ flag: undefined, env: { VP_DEV_MAX_COST_USD: "3.5" } }),
+    3.5,
+  );
+});
+
+test("resolveBudgetUsd: rejects empty / whitespace / non-finite / negative", () => {
+  assert.equal(resolveBudgetUsd({ flag: "", env: {} }), undefined);
+  assert.equal(resolveBudgetUsd({ flag: "   ", env: {} }), undefined);
+  assert.equal(resolveBudgetUsd({ flag: "abc", env: {} }), undefined);
+  assert.equal(resolveBudgetUsd({ flag: "-1", env: {} }), undefined);
+  assert.equal(resolveBudgetUsd({ flag: "Infinity", env: {} }), undefined);
+  assert.equal(
+    resolveBudgetUsd({ flag: undefined, env: { VP_DEV_MAX_COST_USD: "" } }),
+    undefined,
+  );
+  assert.equal(
+    resolveBudgetUsd({ flag: undefined, env: { VP_DEV_MAX_COST_USD: "junk" } }),
+    undefined,
+  );
+});
+
+test("resolveBudgetUsd: zero is valid (Phase-2 decides semantics)", () => {
+  // Phase 1 must accept "--max-cost-usd 0" without erroring; what it MEANS
+  // (always-abort vs no-op) is Phase 2's call. The tracker just records.
+  assert.equal(resolveBudgetUsd({ flag: "0", env: {} }), 0);
+  assert.equal(resolveBudgetUsd({ flag: 0, env: {} }), 0);
+});

--- a/src/util/costTracker.ts
+++ b/src/util/costTracker.ts
@@ -1,0 +1,74 @@
+// Per-run accumulator for SDK-reported `total_cost_usd`.
+//
+// Phase 1 of the cost-ceiling design (issue #85, supersedes #34): measurement
+// only — no enforcement, no `aborted-budget` terminal state, no `break` in
+// `runOrchestrator()`. Phase 2 layers enforcement on top once this lands.
+//
+// Instantiated once in `cmdRun()` and threaded by reference into every site
+// that calls the SDK's `query()` (codingAgent, dispatcher, triage). Each site
+// reads `msg.total_cost_usd` from the per-result message and forwards it via
+// `add(usd)`. No singleton: a fresh tracker per `cmdRun()` invocation keeps
+// the run-scope explicit.
+//
+// Pure: no file I/O, no SDK imports, no clock. Tested in `costTracker.test.ts`.
+
+export class RunCostTracker {
+  private accumulated = 0;
+
+  /**
+   * Forward an SDK cost reading. Defensive: ignores undefined / null /
+   * non-finite / negative values rather than throwing — call sites read
+   * `msg.total_cost_usd` directly off SDK messages where the field can be
+   * absent (older SDK versions, error subtypes), and we don't want a
+   * malformed reading to corrupt the run total.
+   */
+  add(usd: number | undefined | null): void {
+    if (usd === undefined || usd === null) return;
+    if (typeof usd !== "number" || !Number.isFinite(usd) || usd < 0) return;
+    this.accumulated += usd;
+  }
+
+  total(): number {
+    return this.accumulated;
+  }
+
+  /**
+   * Phase 1: not yet wired to enforcement. Defined here so Phase 2 can
+   * adopt without a breaking API change. Returns false on a malformed
+   * budget so callers can blindly delegate to it.
+   */
+  exceedsBudget(budgetUsd: number): boolean {
+    if (!Number.isFinite(budgetUsd) || budgetUsd < 0) return false;
+    return this.accumulated > budgetUsd;
+  }
+}
+
+/**
+ * Resolve the active per-run cost budget. CLI flag wins, env var
+ * (`VP_DEV_MAX_COST_USD`) is the fallback. Returns `undefined` when neither
+ * is set — the caller then knows there's no budget and skips the
+ * (Phase-2-eventual) enforcement check entirely.
+ *
+ * Both sources are user-supplied text; rejects empty strings, non-finite
+ * values, and negatives by returning `undefined` rather than throwing.
+ * Phase-2 enforcement should surface a single warning when a user passes
+ * a malformed flag — for Phase 1 the silent fallback is fine because the
+ * value is only logged, not enforced.
+ */
+export function resolveBudgetUsd(opts: {
+  flag?: string | number;
+  env: NodeJS.ProcessEnv;
+}): number | undefined {
+  const fromFlag = parseUsd(opts.flag);
+  if (fromFlag !== undefined) return fromFlag;
+  return parseUsd(opts.env.VP_DEV_MAX_COST_USD);
+}
+
+function parseUsd(raw: unknown): number | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (typeof raw !== "number" && typeof raw !== "string") return undefined;
+  if (typeof raw === "string" && raw.trim().length === 0) return undefined;
+  const n = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isFinite(n) || n < 0) return undefined;
+  return n;
+}


### PR DESCRIPTION
Closes #85.

Phase 1 of the cost-ceiling design originally proposed in #34. Ships the measurement primitive — accumulate per-run spend and expose it — without any enforcement. Phase 2 will layer enforcement (`break` in `runOrchestrator`, `aborted-budget` terminal state, summarizer skip) on top once this lands.

## Summary

- **`src/util/costTracker.ts`** (new) — `RunCostTracker` class with `add(usd)` / `total()` / `exceedsBudget(budgetUsd)`. Plus `resolveBudgetUsd({ flag, env })` helper: CLI flag wins, `VP_DEV_MAX_COST_USD` is the fallback, malformed/empty/negative returns `undefined`. Pure: no file I/O, no SDK imports, no clock.
- **`src/util/costTracker.test.ts`** (new) — 13 unit tests: accumulation, finite-number guard, strict-greater-than `exceedsBudget` semantics, flag/env precedence, parse rejection.
- **`src/cli.ts`** — adds `--max-cost-usd <usd>` to `vp-dev run`. Tracker is instantiated **before** triage so the triage cost (which fires before the runId is minted) accumulates into the same total. `run.started` logs `maxCostUsd: budgetUsd ?? null`; `run.completed` logs `totalCostUsd: tracker.total()` + `maxCostUsd`.
- **`src/orchestrator/orchestrator.ts`**, **`src/orchestrator/dispatcher.ts`** — accept optional `costTracker` and forward it. Dispatcher reads `total_cost_usd` from the result message regardless of subtype (errored dispatches still consumed tokens).
- **`src/agent/codingAgent.ts`**, **`src/agent/runIssueCore.ts`** — accept optional `costTracker`. Cost from each SDK pass (initial + recovery) is forwarded as soon as the result message resolves, so a recovery-pass crash still leaves the first pass accounted for.

## Scope decisions vs. the issue body

- **Tracker location: `src/util/`, not `src/agent/`.** The tracker is a pure number accumulator with zero agent-specific knowledge (matches `sentinels`, `parseJsonEnvelope`, `openPrs` convention). Bonus: the `npm test` glob (`node --test dist/src/util/*.test.js`) picks up the tests automatically — placement under `src/agent/` would have required either a separate test glob or test-script churn.
- **Resume snapshotting deferred to Phase 2.** The issue calls it "implementer's call." Snapshotting `--max-cost-usd` into `RunConfirmParams` gives nothing in Phase 1 (no enforcement to read it), so the field is omitted; resume gets no tracker today. Phase 2 adds it alongside the enforcement check.
- **`src/agent/split.ts` not threaded.** `proposeSplit()` is invoked from `vp-dev agents split` (a separate CLI command), not from `vp-dev run`, so the run-scoped tracker has no call site there. Phase 2 can revisit if a split-during-run is ever introduced.

## Acceptance check

- ✅ `vp-dev run --max-cost-usd 5.0 --target-repo X --issues N` parses without error; `--help` shows the flag; `run.started` carries `maxCostUsd: 5`.
- ✅ `tracker.total()` is logged at run-final accounting (`run.completed`) and matches the sum of per-message `total_cost_usd` reads across triage + dispatcher + coding-agent.
- ✅ `npm run build` + `npm test` green (48 tests pass — 35 baseline + 13 new).
- ✅ No behavioral change for runs that don't pass the flag: tracker is still instantiated and `totalCostUsd` is logged, but `maxCostUsd` is `null` and nothing reads `exceedsBudget()` yet.

## Test plan

- [x] Unit tests cover `add` (finite-guard), `total`, `exceedsBudget` (strict >), and `resolveBudgetUsd` (flag / env / precedence / parse rejection / zero accepted).
- [x] CLI smoke: `vp-dev run --help` lists the new flag.
- [ ] Live smoke (Phase 2): a real run with `--max-cost-usd 5.0` produces a `run.completed` line whose `totalCostUsd` reconciles with the SDK billing dashboard. Non-blocking for Phase 1 — measurement-only commits no destructive behavior.

— Keccak Guard (agent-aa26)
