### PR TITLE
feat(prompt): live-load target-repo CLAUDE.md every dispatch + dedup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,10 +31,18 @@ Three supported approval paths:
 - **Don't add a config-file option that silently bypasses** the gate. Convenience flags that hide the cost of a multi-agent run are exactly what this gate exists to prevent. The two-step flow is allowed because it surfaces the cost between invocations; single-flag silent bypasses are not.
 - The gate text MUST surface the planned cost (agent count × issue range × model tier) so the user has the data to refuse. Edits that reduce the surfaced detail are regressions.
 
-## Target repo's `CLAUDE.md` seeds fresh agents
-The orchestrator reads the target repo's `CLAUDE.md` (`--target-repo-path/CLAUDE.md`, default `$HOME/dev/<repo-name>/CLAUDE.md`) and seeds every fresh "general" agent with it. Specialists carry their own `agents/<agent-id>/CLAUDE.md` from prior successful runs.
+## Target repo's `CLAUDE.md` seeds fresh agents AND is loaded live every dispatch
+The orchestrator reads the target repo's `CLAUDE.md` (`--target-repo-path/CLAUDE.md`, default `$HOME/dev/<repo-name>/CLAUDE.md`). Two paths use it:
+1. **Fork-time seed** — `forkClaudeMd()` writes a verbatim copy into `agents/<agent-id>/CLAUDE.md` once when an agent is first minted. The per-agent file then drifts (summarizer-edited, hand-edited).
+2. **Live load every dispatch** — `buildAgentSystemPrompt()` reads the *current* target-repo `CLAUDE.md` on every coding-agent run and prepends it as a "Project rules (live)" section, with overlapping `##` headings deduped against the per-agent copy (live wins). This means edits to the target-repo `CLAUDE.md` reach existing specialists immediately, without re-forking.
 - **When the target repo has no `CLAUDE.md`**, fall back to the generic seed in `src/agent/prompt.ts`. Don't refuse to run — many target repos won't have one.
 - **Don't modify the target repo's `CLAUDE.md` from within a run.** The seed is a read-only input, not a write surface. If a coding agent's output legitimately wants to update the target's CLAUDE.md, that lands as a normal PR through the agent's branch, not as a side-effect write.
+
+## Pre-dispatch scope-fit check
+- **Issues whose feature-plan touches >5 files should be split into Phase 1 / Phase 2 before dispatch.** Coding agents have a 50-turn budget; multi-file features with read→edit→re-read cycles exhaust it on file 6-7, hitting `error_max_turns` mid-edit with no PR and no envelope. Split along architectural seams (data layer / measurement vs. enforcement / abort flow), not arbitrary halves.
+- **Tells**: `feature-plans/issue-N-*.md` lists >5 files in "Critical files"; plan mixes data-layer changes with orchestrator-lifecycle changes; both an interface-extension and an integration land in one issue; tags include both `cli-gate` / `cost-surface` / `ux-hardening` AND a state-layer concept.
+- **How to apply**: before `vp-dev run --issues N`, read `feature-plans/issue-N-*.md` if present. If file count >5, file the split (Phase 1 = measurement / data layer; Phase 2 = enforcement / lifecycle integration) and close the original as superseded. Don't dispatch and hope.
+- Past incident 2026-05-04: issue #34 ("Hard cost ceiling per run with graceful abort") had a 9-file plan, dispatched twice, both `error_max_turns`, ~$8.30 burned, zero PRs. Split into [#85](https://github.com/szhygulin/vaultpilot-development-agents/issues/85) (Phase 1, measurement) + [#86](https://github.com/szhygulin/vaultpilot-development-agents/issues/86) (Phase 2, enforcement); #85 succeeded on first dispatch as PR [#93](https://github.com/szhygulin/vaultpilot-development-agents/pull/93).
 
 ## Per-agent `CLAUDE.md` grows from successful runs
 After every successful issue-resolution run, a separate sonnet summarizer rewrites `agents/<agent-id>/CLAUDE.md` to fold in lessons from the run. The file is gitignored — local-only memory.

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-import { readAgentClaudeMd } from "./specialization.js";
+import { readAgentClaudeMd, readSeedClaudeMd } from "./specialization.js";
 import { renderWorkflow, type WorkflowVars } from "./workflow.js";
 import type { AgentRecord } from "../types.js";
 
@@ -9,7 +9,12 @@ export async function buildAgentSystemPrompt(opts: {
   workflow: WorkflowVars;
   targetRepoPath: string;
 }): Promise<string> {
-  const claudeMd = await readAgentClaudeMd(opts.agent.agentId, opts.targetRepoPath);
+  const [perAgentClaudeMd, liveProjectClaudeMd] = await Promise.all([
+    readAgentClaudeMd(opts.agent.agentId, opts.targetRepoPath),
+    readSeedClaudeMd(opts.targetRepoPath),
+  ]);
+  const dedupedPerAgent = stripOverlappingSections(perAgentClaudeMd, liveProjectClaudeMd);
+
   const workflow = renderWorkflow(opts.workflow);
 
   const label = opts.agent.name
@@ -22,9 +27,15 @@ export async function buildAgentSystemPrompt(opts: {
   });
 
   const sections: string[] = [
-    `# CLAUDE.md (agent ${label} — evolving specialization)`,
+    "# Project rules (live target-repo CLAUDE.md — current as of this dispatch)",
     "",
-    claudeMd.trim(),
+    liveProjectClaudeMd.trim(),
+    "",
+    "---",
+    "",
+    `# Per-agent CLAUDE.md (${label} — evolving specialization, sections overlapping live rules removed)`,
+    "",
+    dedupedPerAgent.trim() || "(no agent-specific sections beyond live project rules)",
     "",
   ];
 
@@ -43,6 +54,46 @@ export async function buildAgentSystemPrompt(opts: {
 
   sections.push("---", "", workflow.trim());
   return sections.join("\n");
+}
+
+/**
+ * Drop any `## Heading` section in `perAgent` whose heading also appears in
+ * `live`. Live wins — the per-agent copy is presumed stale (forked at
+ * agent-mint time, possibly weeks ago). Heading match is case-insensitive
+ * and whitespace-trimmed; section bodies are not compared, so a renamed-but-
+ * substantively-same section won't be deduped (acceptable: the user can
+ * rename to force a side-by-side view).
+ *
+ * Anything before the first `## ` in `perAgent` is preserved as preamble.
+ */
+export function stripOverlappingSections(perAgent: string, live: string): string {
+  const liveHeadings = new Set(
+    extractH2Headings(live).map((h) => h.trim().toLowerCase()),
+  );
+  if (liveHeadings.size === 0) return perAgent;
+
+  const lines = perAgent.split("\n");
+  const out: string[] = [];
+  let dropping = false;
+  for (const line of lines) {
+    const m = /^##\s+(.+?)\s*$/.exec(line);
+    if (m) {
+      const heading = m[1].trim().toLowerCase();
+      dropping = liveHeadings.has(heading);
+      if (dropping) continue;
+    }
+    if (!dropping) out.push(line);
+  }
+  return out.join("\n");
+}
+
+function extractH2Headings(md: string): string[] {
+  const out: string[] = [];
+  for (const line of md.split("\n")) {
+    const m = /^##\s+(.+?)\s*$/.exec(line);
+    if (m) out.push(m[1]);
+  }
+  return out;
 }
 
 /**

--- a/src/util/prompt.test.ts
+++ b/src/util/prompt.test.ts
@@ -1,0 +1,128 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { stripOverlappingSections } from "../agent/prompt.js";
+
+test("stripOverlappingSections: drops perAgent ## sections whose heading also appears in live", () => {
+  const live = `# Project rules
+## Git workflow
+- some rule
+
+## CI is a hard gate
+- another rule
+`;
+  const perAgent = `## Crypto/DeFi Transaction Preflight Checks
+- agent-specific rule
+
+## Git workflow
+- stale copy of the same heading
+
+## Tool Usage Discipline
+- agent-specific rule
+`;
+  const out = stripOverlappingSections(perAgent, live);
+  assert.match(out, /## Crypto\/DeFi Transaction Preflight Checks/);
+  assert.match(out, /## Tool Usage Discipline/);
+  assert.doesNotMatch(out, /## Git workflow/);
+  assert.doesNotMatch(out, /stale copy of the same heading/);
+});
+
+test("stripOverlappingSections: heading match is case-insensitive and whitespace-trimmed", () => {
+  const live = `## Foo Bar
+content
+`;
+  const perAgent = `##  foo bar
+stale content
+
+## Other
+keep
+`;
+  const out = stripOverlappingSections(perAgent, live);
+  assert.doesNotMatch(out, /stale content/);
+  assert.match(out, /## Other/);
+  assert.match(out, /keep/);
+});
+
+test("stripOverlappingSections: preserves preamble (content before first ##)", () => {
+  const live = `## Shared
+x
+`;
+  const perAgent = `intro paragraph
+preserved as preamble
+
+## Shared
+drop me
+
+## Unique
+keep me
+`;
+  const out = stripOverlappingSections(perAgent, live);
+  assert.match(out, /intro paragraph/);
+  assert.match(out, /preserved as preamble/);
+  assert.doesNotMatch(out, /drop me/);
+  assert.match(out, /## Unique/);
+  assert.match(out, /keep me/);
+});
+
+test("stripOverlappingSections: no overlap leaves perAgent untouched", () => {
+  const live = `## A
+1
+`;
+  const perAgent = `## B
+2
+
+## C
+3
+`;
+  const out = stripOverlappingSections(perAgent, live);
+  assert.equal(out.trim(), perAgent.trim());
+});
+
+test("stripOverlappingSections: live with no ## headings leaves perAgent untouched", () => {
+  const live = `just a paragraph, no headings`;
+  const perAgent = `## A
+1
+
+## B
+2
+`;
+  const out = stripOverlappingSections(perAgent, live);
+  assert.equal(out, perAgent);
+});
+
+test("stripOverlappingSections: drops the dropped section's body lines too, until next ##", () => {
+  const live = `## Drop
+x
+`;
+  const perAgent = `## Drop
+line 1
+line 2
+
+line 3
+## Keep
+y
+`;
+  const out = stripOverlappingSections(perAgent, live);
+  assert.doesNotMatch(out, /line 1/);
+  assert.doesNotMatch(out, /line 2/);
+  assert.doesNotMatch(out, /line 3/);
+  assert.match(out, /## Keep/);
+  assert.match(out, /y/);
+});
+
+test("stripOverlappingSections: section-body containing what looks like a heading marker on its own does not bleed", () => {
+  // Edge case: a section's body has a line starting with "##" only at the
+  // top level (no leading whitespace), which the regex treats as a new
+  // section. That's the expected behavior — markdown semantics say the same.
+  const live = `## A
+x
+`;
+  const perAgent = `## A
+drop body
+
+## B
+keep body
+`;
+  const out = stripOverlappingSections(perAgent, live);
+  assert.doesNotMatch(out, /drop body/);
+  assert.match(out, /keep body/);
+});


### PR DESCRIPTION
## Summary

- `buildAgentSystemPrompt()` now reads the live target-repo `CLAUDE.md` on every dispatch (alongside the per-agent `CLAUDE.md`), so edits to project rules reach existing specialists immediately — no re-fork required.
- Overlapping `##` section headings between live and per-agent are stripped (live wins), keeping the prompt size bounded and avoiding stale-vs-current contradictions.
- Adds a `Pre-dispatch scope-fit check` rule to the local `CLAUDE.md` codifying the >5-file-plan split lesson from issue #34's two failed runs.

## Why

Until this PR, the only path for the target-repo `CLAUDE.md` to reach a coding agent was `forkClaudeMd()` — a one-shot copy into `agents/<id>/CLAUDE.md` at agent-mint time. The per-agent file then drifted (summarizer-edited, hand-edited). Edits to the target-repo `CLAUDE.md` never propagated to existing specialists, leaving the orchestrator's coding agents reading project rules that could be weeks stale.

This PR adds a parallel live-load path. Specialists already minted (agent-72c6, agent-aa26, agent-e22f, etc.) start seeing current rules on their next dispatch.

## What changes for prompt size

For each coding agent dispatch, the prompt now contains:

```
# Project rules (live target-repo CLAUDE.md — current as of this dispatch)
<live target-repo CLAUDE.md>
---
# Per-agent CLAUDE.md (<name> — evolving specialization, sections overlapping live rules removed)
<per-agent CLAUDE.md, with overlapping ## sections stripped>
---
# Plan for issue #N (if feature-plans/issue-N-*.md exists)
...
---
# Workflow
...
```

`stripOverlappingSections(perAgent, live)` is the new dedup helper — case-insensitive heading match, whitespace-trimmed. Section bodies aren't compared, so a renamed-but-substantively-same section won't be deduped (acceptable: a future hand-edit to rename forces side-by-side view if desired).

## Test plan
- [x] `npm run typecheck` clean.
- [x] `npm run build` clean.
- [x] `npm test` — 48 existing pass + 7 new pass = 55. New tests cover: heading-overlap drop, case-insensitive match, preamble preservation, no-overlap no-op, no-headings-in-live no-op, body-lines-until-next-## drop.
- [ ] Smoke: dispatch a small issue post-merge and confirm an existing specialist sees the live rules section in its prompt.

## Compatibility / risk
- **No registry / state schema changes.** Pure prompt-construction change.
- **Existing per-agent CLAUDE.md files are not mutated.** Dedup happens at read time, in-memory, never written back. Agent memory files stay as-is.
- **Prompt size bound**: live + per-agent (with overlap stripped). For agents whose per-agent `CLAUDE.md` is mostly summarizer additions (typical), the overlap is small and the prompt grows by ~live's size. For freshly-forked agents whose per-agent file is still ~identical to live, the dedup will strip nearly everything, leaving just the live copy — net size *decrease*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)