### PR TITLE
feat(safety-net): broaden partial-branch push to non-clean exits beyond error_max_turns

### DIFF
--- a/src/agent/runIssueCore.ts
+++ b/src/agent/runIssueCore.ts
@@ -9,6 +9,7 @@ import {
 } from "./specialization.js";
 import { isInfraFlake, summarizeFailureRun, summarizeRun, type SummarizerOutput } from "./summarizer.js";
 import { resolveExpiryPolicies } from "../util/sentinels.js";
+import { shouldPushPartial } from "./shouldPushPartial.js";
 import {
   buildIncompleteBranchName,
   createWorktree,
@@ -248,18 +249,19 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
       });
     });
 
-    // Orchestrator-level safety net: when the SDK truncated the run with
-    // `error_max_turns` AND the agent did not finish with a clean implement
-    // decision, push whatever's currently in the worktree to a labeled
-    // `<branch>-incomplete-<runId>` ref so the partial work isn't lost when
-    // `removeWorktree` deletes the local branch in the finally below. The
-    // in-agent recovery pass (codingAgent.ts) attempts the same first, but
-    // can itself fail — this is the deterministic backstop. Skipped in
-    // dry-run because remote pushes are intercepted into echoes. See #88.
+    // Orchestrator-level safety net: when the run ended in a non-clean
+    // exit (per `shouldPushPartial`) AND the agent did not finish with a
+    // clean implement decision, push whatever's currently in the worktree
+    // to a labeled `<branch>-incomplete-<runId>` ref so the partial work
+    // isn't lost when `removeWorktree` deletes the local branch in the
+    // finally below. The in-agent recovery pass (codingAgent.ts) attempts
+    // the same first for `error_max_turns`, but can itself fail — this
+    // is the deterministic backstop. Skipped in dry-run because remote
+    // pushes are intercepted into echoes. See #88, broadened by #95.
     let partialBranchUrl: string | undefined;
     if (
       worktree &&
-      result.errorSubtype === "error_max_turns" &&
+      shouldPushPartial(result) &&
       envelope?.decision !== "implement" &&
       !input.dryRun
     ) {
@@ -271,7 +273,11 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
           worktreeBranch: worktree.branch,
           incompleteBranch,
           runId: input.runId,
-          errorSubtype: result.errorSubtype,
+          // The catch-all branch in `shouldPushPartial` (`isError && !envelope`)
+          // can fire without a tagged subtype; pass a sentinel so the salvage
+          // commit message stays human-readable rather than emitting
+          // `errorSubtype=undefined`.
+          errorSubtype: result.errorSubtype ?? "unknown",
           targetRepo: input.targetRepo,
           logger: input.logger,
           agentId: input.agent.agentId,

--- a/src/agent/shouldPushPartial.test.ts
+++ b/src/agent/shouldPushPartial.test.ts
@@ -1,0 +1,141 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { shouldPushPartial } from "./shouldPushPartial.js";
+import type { ResultEnvelope } from "../types.js";
+
+// Issue #95: the partial-branch safety net (PR #92) was scoped to
+// `errorSubtype === "error_max_turns"`. This predicate broadens it to
+// every non-clean exit shape the SDK can surface today, plus a slot for
+// #86's cost-ceiling abort.
+
+const dummyEnvelope: ResultEnvelope = {
+  decision: "implement",
+  reason: "test",
+  memoryUpdate: { addTags: [] },
+};
+
+test("shouldPushPartial: error_max_turns trips (original PR #92 case)", () => {
+  assert.equal(
+    shouldPushPartial({
+      errorSubtype: "error_max_turns",
+      isError: true,
+      envelope: undefined,
+    }),
+    true,
+  );
+});
+
+test("shouldPushPartial: error_during_execution trips (mid-tool-use throw)", () => {
+  assert.equal(
+    shouldPushPartial({
+      errorSubtype: "error_during_execution",
+      isError: true,
+      envelope: undefined,
+    }),
+    true,
+  );
+});
+
+test("shouldPushPartial: error_max_budget_usd trips (future-proofing for #86)", () => {
+  // The SDK doesn't surface this subtype yet — once #86's cost ceiling
+  // lands and the SDK starts tagging budget-truncated runs, the predicate
+  // matches without further code changes.
+  assert.equal(
+    shouldPushPartial({
+      errorSubtype: "error_max_budget_usd",
+      isError: true,
+      envelope: undefined,
+    }),
+    true,
+  );
+});
+
+test("shouldPushPartial: catch-all isError && !envelope trips when subtype absent", () => {
+  // Generic non-clean exit: SDK didn't tag a known subtype but
+  // `runCodingAgent` flagged the run as failed and produced no parseable
+  // terminal envelope. Without this branch the safety net would silently
+  // skip every untagged failure mode.
+  assert.equal(
+    shouldPushPartial({
+      errorSubtype: undefined,
+      isError: true,
+      envelope: undefined,
+    }),
+    true,
+  );
+});
+
+test("shouldPushPartial: clean implement decision does NOT trip", () => {
+  // Clean run with envelope present and no error — the most common path,
+  // and the one that must stay false to avoid creating spurious
+  // `-incomplete-<runId>` branches alongside successful PRs.
+  assert.equal(
+    shouldPushPartial({
+      errorSubtype: undefined,
+      isError: false,
+      envelope: dummyEnvelope,
+    }),
+    false,
+  );
+});
+
+test("shouldPushPartial: pushback envelope without error does NOT trip", () => {
+  // Agent emitted a clean pushback decision; nothing to salvage.
+  assert.equal(
+    shouldPushPartial({
+      errorSubtype: undefined,
+      isError: false,
+      envelope: { ...dummyEnvelope, decision: "pushback" },
+    }),
+    false,
+  );
+});
+
+test("shouldPushPartial: error envelope (decision='error') with no subtype does NOT trip — orthogonal gate", () => {
+  // Recovery succeeded enough that a structured envelope was parsed but
+  // the decision was "error" and `isError` stayed true (e.g. recovery2b
+  // failed). No envelope-decision check lives in this predicate — the
+  // call site handles `decision !== "implement"` orthogonally — so the
+  // catch-all `isError && !envelope` does NOT match here (envelope is
+  // present). The errorSubtype path is the relevant gate; if neither
+  // matches, the predicate stays false and the call-site gate is the
+  // single source of truth on whether to proceed.
+  assert.equal(
+    shouldPushPartial({
+      errorSubtype: undefined,
+      isError: true,
+      envelope: { ...dummyEnvelope, decision: "error" },
+    }),
+    false,
+  );
+});
+
+test("shouldPushPartial: unknown errorSubtype with isError + envelope present does NOT trip", () => {
+  // Future SDK subtype we haven't whitelisted; envelope was nonetheless
+  // parseable. Conservative default: don't fire the safety net unless
+  // we're sure. Once such a subtype starts appearing in real runs it can
+  // be added explicitly.
+  assert.equal(
+    shouldPushPartial({
+      errorSubtype: "error_some_future_subtype",
+      isError: true,
+      envelope: dummyEnvelope,
+    }),
+    false,
+  );
+});
+
+test("shouldPushPartial: isError=false with no envelope does NOT trip", () => {
+  // Defensive: if `runCodingAgent` somehow returns no envelope without
+  // marking isError, the catch-all explicitly requires `isError` to be
+  // true so we don't salvage from a transient parser blip on an
+  // otherwise-clean run.
+  assert.equal(
+    shouldPushPartial({
+      errorSubtype: undefined,
+      isError: false,
+      envelope: undefined,
+    }),
+    false,
+  );
+});

--- a/src/agent/shouldPushPartial.ts
+++ b/src/agent/shouldPushPartial.ts
@@ -1,0 +1,42 @@
+import type { CodingAgentResult } from "./codingAgent.js";
+
+/**
+ * Predicate gating the orchestrator-level partial-branch safety net
+ * (`pushPartialBranch()` in `runIssueCore.ts`). Returns true when the
+ * coding-agent run ended in a non-clean state where in-flight worktree
+ * edits could be lost without intervention.
+ *
+ * Issue #95 — broaden from the original `error_max_turns`-only check
+ * (PR #92) to every non-clean exit shape the SDK can surface today,
+ * plus a future-proofing slot for #86's cost-ceiling abort.
+ *
+ * Match conditions:
+ *   1. `errorSubtype === "error_max_turns"` — original case (turn-budget
+ *      truncation; the recovery pass in codingAgent.ts may itself fail).
+ *   2. `errorSubtype === "error_during_execution"` — uncaught throw from
+ *      a tool-call mid-run; same value-loss shape.
+ *   3. `errorSubtype === "error_max_budget_usd"` — future-proofing for
+ *      #86's hard cost ceiling. The predicate trips automatically once
+ *      the SDK starts surfacing the subtype.
+ *   4. `isError && !envelope` — catch-all for non-clean exits where the
+ *      SDK didn't tag a known subtype but `runCodingAgent` reported the
+ *      run failed and produced no parseable terminal envelope.
+ *
+ * The labeled-branch shape stays `<branch>-incomplete-<runId>`; the
+ * subtype is encoded only in the salvage commit message (see
+ * `pushPartialBranch()`), preserving PR #92's `VP_DEV_BRANCH_RE`
+ * non-match invariant.
+ *
+ * Note: callers MUST still gate on the orthogonal conditions
+ * (worktree present, not dry-run, envelope decision !== "implement");
+ * those concerns live at the call site, not in this predicate.
+ */
+export function shouldPushPartial(
+  result: Pick<CodingAgentResult, "errorSubtype" | "isError" | "envelope">,
+): boolean {
+  if (result.errorSubtype === "error_max_turns") return true;
+  if (result.errorSubtype === "error_during_execution") return true;
+  if (result.errorSubtype === "error_max_budget_usd") return true;
+  if (result.isError && !result.envelope) return true;
+  return false;
+}

--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -143,8 +143,10 @@ export interface PushPartialBranchResult {
   committed?: boolean;
 }
 
-// Orchestrator-level safety net for non-clean agent exits (today only fired
-// for `error_max_turns`).
+// Orchestrator-level safety net for non-clean agent exits. Fired by
+// `shouldPushPartial()` in runIssueCore.ts for `error_max_turns`,
+// `error_during_execution`, `error_max_budget_usd`, and the catch-all
+// `isError && !envelope` (see issues #88, #95).
 //
 // Why this is a separate orchestrator path even though `runCodingAgent`
 // already runs an in-agent recovery pass (see issue #76, commit d4aadd0):


### PR DESCRIPTION
Closes #95.

## Summary

Broadens the orchestrator-level partial-branch safety net (PR #92) from `error_max_turns`-only to every non-clean exit shape:

- `errorSubtype === "error_max_turns"` (original case)
- `errorSubtype === "error_during_execution"` (mid-tool-use throw)
- `errorSubtype === "error_max_budget_usd"` (future-proofing for #86)
- `isError && !envelope` (catch-all for non-clean exits where the SDK didn't tag a known subtype)

## Implementation

- **New `shouldPushPartial(result)` predicate** in `src/agent/shouldPushPartial.ts`. Pure, side-effect-free, easy to unit-test. The orthogonal gates (`worktree` present, `!dryRun`, `envelope.decision !== "implement"`) stay at the call site so the helper has a single responsibility: decide whether the run shape alone qualifies for salvage.
- **`runIssueCore.ts`** swaps the inlined predicate for the helper; passes `result.errorSubtype ?? "unknown"` to `pushPartialBranch` for the catch-all path so the salvage commit message stays human-readable rather than emitting `errorSubtype=undefined`.
- **`pushPartialBranch` doc-comment** in `src/git/worktree.ts` updated to enumerate the broadened trigger set.
- **`package.json`** test glob now includes `dist/src/agent/*.test.js`.

## Invariants preserved

- The labeled-branch shape stays `<branch>-incomplete-<runId>` — PR #92's `VP_DEV_BRANCH_RE` non-match invariant from the stale-branch sweep regex is preserved (subtype is encoded only in the salvage commit message, not the ref name).
- `pushPartialBranch()` itself untouched — only the predicate that gates its invocation changed.
- Existing `error_max_turns` behavior unchanged.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run build` clean.
- [x] `npm test` — 94 tests pass (9 new in `shouldPushPartial.test.ts`):
  - `error_max_turns` trips (PR #92 case preserved).
  - `error_during_execution` trips.
  - `error_max_budget_usd` trips (future-proofing).
  - Catch-all `isError && !envelope` trips when subtype absent.
  - Clean implement decision does NOT trip.
  - Pushback envelope without error does NOT trip.
  - Error envelope (`decision='error'`) with no subtype does NOT trip — the orthogonal `decision !== "implement"` gate at the call site stays the source of truth on whether to proceed.
  - Unknown errorSubtype with `isError + envelope present` does NOT trip (conservative default).
  - `isError=false` with no envelope does NOT trip (defensive).
- [ ] (manual / future) When #86's cost ceiling lands and the SDK starts surfacing `error_max_budget_usd`, verify the predicate auto-activates without further changes.

— Milgram (agent-98b3)
