### PR TITLE
feat(orchestrator): fail-fast post-mortem comment + triage gate (#100)

### DIFF
--- a/src/github/gh.ts
+++ b/src/github/gh.ts
@@ -1,5 +1,8 @@
 import { promisify } from "node:util";
 import { execFile as execFileCb } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
 import type { IssueRangeSpec, IssueSummary } from "../types.js";
 
 const execFile = promisify(execFileCb);
@@ -107,6 +110,48 @@ export async function getIssueDetail(targetRepo: string, number: number): Promis
     };
   } catch {
     return null;
+  }
+}
+
+/**
+ * Post a comment on a GitHub issue using `gh issue comment ... --body-file`.
+ *
+ * The body is written to a temp file (not passed via `--body`) because
+ * Markdown bodies can include shell metacharacters that the gh CLI's
+ * argv path sometimes mishandles, and large bodies overflow argv limits
+ * on some platforms. Caller is expected to handle thrown errors — the
+ * orchestrator's failure-comment path logs a warning and continues.
+ */
+export async function postIssueComment(
+  targetRepo: string,
+  issueId: number,
+  body: string,
+): Promise<void> {
+  const tmp = path.join(
+    os.tmpdir(),
+    `vp-dev-issue-comment-${process.pid}-${Date.now()}.md`,
+  );
+  await fs.writeFile(tmp, body);
+  try {
+    await execFile(
+      "gh",
+      [
+        "issue",
+        "comment",
+        String(issueId),
+        "--repo",
+        targetRepo,
+        "--body-file",
+        tmp,
+      ],
+      { maxBuffer: 5 * 1024 * 1024 },
+    );
+  } finally {
+    try {
+      await fs.unlink(tmp);
+    } catch {
+      // ignore
+    }
   }
 }
 

--- a/src/orchestrator/failurePostMortem.test.ts
+++ b/src/orchestrator/failurePostMortem.test.ts
@@ -1,0 +1,175 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  composeFailurePostMortem,
+  detectPendingPostMortem,
+  POST_MORTEM_SENTINEL,
+} from "./failurePostMortem.js";
+import type { IssueComment } from "../github/gh.js";
+
+// ---- composeFailurePostMortem -------------------------------------------
+
+test("composeFailurePostMortem: header carries the canonical sentinel + run/agent ids", () => {
+  const body = composeFailurePostMortem({
+    runId: "run-2026-05-05T10-00-00",
+    agentId: "agent-72c6",
+    errorSubtype: "error_max_turns",
+    costUsd: 4.51,
+    durationMs: 7 * 60_000,
+    partialBranchUrl: "https://github.com/x/y/tree/vp-dev/agent-72c6/issue-42-incomplete-run-2026-05-05T10-00-00",
+  });
+  // First line MUST start with the canonical sentinel — triage relies on
+  // the `^## ` anchor for detection.
+  const firstLine = body.split("\n")[0];
+  assert.ok(POST_MORTEM_SENTINEL.test(firstLine), `sentinel should match: ${firstLine}`);
+  assert.ok(firstLine.includes("run-2026-05-05T10-00-00"));
+  assert.ok(firstLine.includes("agent-72c6"));
+  assert.ok(body.includes("`error_max_turns`"));
+  assert.ok(body.includes("$4.51"));
+  assert.ok(body.includes("7.0 min"));
+  assert.ok(body.includes("Partial branch"));
+});
+
+test("composeFailurePostMortem: missing partial branch and cost is rendered without errors", () => {
+  const body = composeFailurePostMortem({
+    runId: "run-x",
+    agentId: "agent-ab",
+    errorSubtype: "error_during_execution",
+  });
+  assert.ok(POST_MORTEM_SENTINEL.test(body));
+  assert.ok(!body.includes("Partial branch"));
+  assert.ok(!body.includes("Cost burned"));
+  assert.ok(body.includes("error_during_execution"));
+  // Likely-cause heuristic still rendered.
+  assert.ok(/Likely cause/i.test(body));
+});
+
+test("composeFailurePostMortem: errorReason fallback when errorSubtype absent", () => {
+  const body = composeFailurePostMortem({
+    runId: "run-x",
+    agentId: "agent-ab",
+    errorReason: "child stream closed",
+  });
+  assert.ok(body.includes("`child stream closed`"));
+});
+
+test("composeFailurePostMortem: 'unknown' fallback when neither subtype nor reason given", () => {
+  const body = composeFailurePostMortem({ runId: "run-x", agentId: "agent-ab" });
+  assert.ok(body.includes("`unknown`"));
+});
+
+// ---- detectPendingPostMortem --------------------------------------------
+
+function comment(body: string, createdAt = "2026-05-05T10:00:00Z", author = "vp-dev"): IssueComment {
+  return { author, body, createdAt };
+}
+
+test("detectPendingPostMortem: returns pending=false when no post-mortem comment exists", () => {
+  const result = detectPendingPostMortem([
+    comment("Looks good!", "2026-05-04T10:00:00Z", "alice"),
+    comment("Updated spec.", "2026-05-04T11:00:00Z", "bob"),
+  ]);
+  assert.equal(result.pending, false);
+});
+
+test("detectPendingPostMortem: detects most-recent post-mortem with no follow-up", () => {
+  const result = detectPendingPostMortem([
+    comment("Initial scope", "2026-05-04T10:00:00Z", "alice"),
+    comment(
+      "## vp-dev failure post-mortem (run-2026-05-05, agent-72c6)\n\n- error: error_max_turns",
+      "2026-05-05T10:00:00Z",
+      "vp-dev",
+    ),
+  ]);
+  assert.equal(result.pending, true);
+  assert.ok(result.reason?.includes("run-2026-05-05"));
+});
+
+test("detectPendingPostMortem: resolution keyword in later comment flips back to ready", () => {
+  const result = detectPendingPostMortem([
+    comment(
+      "## vp-dev failure post-mortem (run-A, agent-1)\n\n- error: error_max_turns",
+      "2026-05-05T10:00:00Z",
+      "vp-dev",
+    ),
+    comment("retry — split into Phase 1/2", "2026-05-05T11:00:00Z", "alice"),
+  ]);
+  assert.equal(result.pending, false);
+});
+
+test("detectPendingPostMortem: case-insensitive sentinel match", () => {
+  const result = detectPendingPostMortem([
+    comment(
+      "## VP-DEV FAILURE POST-MORTEM (run-X, agent-1)\n\nfailed",
+      "2026-05-05T10:00:00Z",
+    ),
+  ]);
+  assert.equal(result.pending, true);
+});
+
+test("detectPendingPostMortem: anchored sentinel — quoted text inside another comment is not a false positive", () => {
+  // A reviewer quoting the sentinel inline (NOT at the start of a line)
+  // must not trip the gate. The sentinel regex anchors to `^## `.
+  const result = detectPendingPostMortem([
+    comment(
+      "I saw the bot write '## vp-dev failure post-mortem' but that was last week.",
+      "2026-05-05T10:00:00Z",
+      "alice",
+    ),
+  ]);
+  assert.equal(result.pending, false);
+});
+
+test("detectPendingPostMortem: sentinel at the start of any line counts (multi-paragraph comment)", () => {
+  // The sentinel matches `^## ` with the `m` flag so a post-mortem
+  // comment that has a leading preamble paragraph still detects.
+  const result = detectPendingPostMortem([
+    comment(
+      "Heads up:\n\n## vp-dev failure post-mortem (run-X, agent-1)\n\n- error",
+      "2026-05-05T10:00:00Z",
+    ),
+  ]);
+  assert.equal(result.pending, true);
+});
+
+test("detectPendingPostMortem: a SECOND post-mortem after the first does NOT resolve the gate", () => {
+  // Two failed runs in a row — second post-mortem cannot count as a
+  // resolution signal because it's vp-dev's own failure record.
+  const result = detectPendingPostMortem([
+    comment(
+      "## vp-dev failure post-mortem (run-A, agent-1)\n\nfailed",
+      "2026-05-05T10:00:00Z",
+    ),
+    comment(
+      "## vp-dev failure post-mortem (run-B, agent-2)\n\nfailed again",
+      "2026-05-06T10:00:00Z",
+    ),
+  ]);
+  assert.equal(result.pending, true);
+  // Reason cites the MOST RECENT post-mortem (run-B), not the first.
+  assert.ok(result.reason?.includes("run-B"));
+});
+
+test("detectPendingPostMortem: 'fix landed' resolution keyword (multi-word) is recognized", () => {
+  const result = detectPendingPostMortem([
+    comment(
+      "## vp-dev failure post-mortem (run-A, agent-1)\n\nfailed",
+      "2026-05-05T10:00:00Z",
+    ),
+    comment("fix landed in #87 — try again", "2026-05-05T11:00:00Z", "alice"),
+  ]);
+  assert.equal(result.pending, false);
+});
+
+test("detectPendingPostMortem: an ambient unrelated comment does NOT lift the gate", () => {
+  // A human comment that does NOT contain a resolution keyword leaves the
+  // gate in place. Only explicit signals lift it.
+  const result = detectPendingPostMortem([
+    comment(
+      "## vp-dev failure post-mortem (run-A, agent-1)\n\nfailed",
+      "2026-05-05T10:00:00Z",
+    ),
+    comment("yeah this is annoying, will look later", "2026-05-05T11:00:00Z", "alice"),
+  ]);
+  assert.equal(result.pending, true);
+});

--- a/src/orchestrator/failurePostMortem.ts
+++ b/src/orchestrator/failurePostMortem.ts
@@ -1,0 +1,179 @@
+// Failure post-mortem comment helpers — issue #100.
+//
+// When a coding-agent run terminates non-cleanly (no envelope, decision="error",
+// or the SDK truncated with `error_max_turns`), the orchestrator posts a
+// structured Markdown comment on the GitHub issue so the next `vp-dev run` can
+// detect the prior attempt and skip re-dispatch until a human resolves the
+// blocker. Issue #34 burned ~$8.30 across two re-dispatches before a manual
+// split — this gate prevents the loop.
+//
+// The marker line `## vp-dev failure post-mortem` is the canonical sentinel.
+// Triage detects it case-insensitively, anchored to `^## ` so quoted text
+// in unrelated comments cannot trigger a false positive.
+//
+// Resolution: a non-bot human comment posted *after* the most recent
+// post-mortem containing one of the resolution keywords below flips triage
+// back to `ready: true`. The override `--include-non-ready` (which bypasses
+// triage entirely) also lifts the gate.
+
+import type { IssueComment } from "../github/gh.js";
+
+/** Anchored sentinel: starts a line, case-insensitive. */
+export const POST_MORTEM_SENTINEL = /^## vp-dev failure post-mortem\b/im;
+
+/**
+ * Resolution keywords. Lowercase, matched case-insensitively against a
+ * later comment's body. Word-boundary anchored so "fix landed" inside an
+ * unrelated sentence ("hope a fix landed somewhere") still resolves —
+ * intentional: a human writing such a sentence is signaling progress.
+ */
+export const RESOLUTION_KEYWORDS = [
+  "retry",
+  "fix landed",
+  "scope changed",
+  "unblock",
+  "proceed",
+] as const;
+
+export interface FailurePostMortemInput {
+  runId: string;
+  agentId: string;
+  /** SDK error subtype (e.g. `error_max_turns`). */
+  errorSubtype?: string;
+  /** Free-form human reason. */
+  errorReason?: string;
+  /** Per-agent total cost in USD. */
+  costUsd?: number;
+  /** Wall-clock duration in milliseconds. */
+  durationMs?: number;
+  /** Labeled `<branch>-incomplete-<runId>` URL when the safety net pushed. */
+  partialBranchUrl?: string;
+}
+
+/**
+ * Compose the Markdown body of a failure post-mortem comment.
+ *
+ * The first line MUST start with `## vp-dev failure post-mortem` so the
+ * triage gate can detect it. The format is intentionally compact — the
+ * comment is read by humans during triage, not parsed by tooling (the
+ * sentinel + run-state JSON are the structured surfaces).
+ */
+export function composeFailurePostMortem(input: FailurePostMortemInput): string {
+  const cause = input.errorSubtype ?? input.errorReason ?? "unknown";
+  const lines: string[] = [];
+  lines.push(`## vp-dev failure post-mortem (${input.runId}, ${input.agentId})`);
+  lines.push("");
+  lines.push(`- **Error subtype**: \`${cause}\``);
+  if (input.errorReason && input.errorSubtype && input.errorReason !== input.errorSubtype) {
+    lines.push(`- **Error reason**: ${truncate(input.errorReason, 240)}`);
+  }
+  if (typeof input.costUsd === "number" && Number.isFinite(input.costUsd)) {
+    const dur = formatDuration(input.durationMs);
+    lines.push(`- **Cost burned**: $${input.costUsd.toFixed(2)}${dur ? ` (${dur})` : ""}`);
+  } else if (input.durationMs !== undefined) {
+    const dur = formatDuration(input.durationMs);
+    if (dur) lines.push(`- **Duration**: ${dur}`);
+  }
+  if (input.partialBranchUrl) {
+    lines.push(`- **Partial branch**: ${input.partialBranchUrl}`);
+  }
+  lines.push(`- **Likely cause**: ${inferLikelyCause(input.errorSubtype)}`);
+  lines.push("");
+  lines.push(
+    "This issue is now flagged as awaiting human review. Re-dispatch will be skipped by triage until either:",
+  );
+  lines.push(
+    "- A human posts a follow-up comment indicating the structural blocker is resolved (`retry`, `fix landed in #N`, `scope changed`, `unblock`, `proceed`).",
+  );
+  lines.push("- The operator passes `--include-non-ready` to override.");
+  return lines.join("\n");
+}
+
+function inferLikelyCause(errorSubtype: string | undefined): string {
+  switch (errorSubtype) {
+    case "error_max_turns":
+      return "feature scope exceeds the 50-turn budget — split along architectural seams (CLAUDE.md \"Pre-dispatch scope-fit check\").";
+    case "error_max_budget_usd":
+      return "per-run cost ceiling tripped before the agent finished — review the cost-ceiling and the issue's expected complexity.";
+    case "error_during_execution":
+      return "SDK transport or runtime error during the agent run — re-dispatch may succeed if transient.";
+    default:
+      return "non-clean exit with no envelope — see run-state JSON for full diagnostic fields.";
+  }
+}
+
+function formatDuration(ms: number | undefined): string {
+  if (ms === undefined || !Number.isFinite(ms) || ms < 0) return "";
+  const sec = Math.round(ms / 1000);
+  if (sec < 60) return `${sec}s`;
+  const min = sec / 60;
+  return `${min.toFixed(1)} min`;
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 3) + "...";
+}
+
+export interface PostMortemDetection {
+  /** True when a pending post-mortem is the latest agent-attempt signal. */
+  pending: boolean;
+  /** Triage reason string when `pending` is true. */
+  reason?: string;
+}
+
+/**
+ * Inspect a comment thread for an unresolved failure post-mortem.
+ *
+ * `pending` is true when:
+ *   1. At least one comment matches `POST_MORTEM_SENTINEL`, AND
+ *   2. No comment after the most recent post-mortem contains a
+ *      resolution keyword (case-insensitive substring match).
+ *
+ * Comments are processed in chronological order — caller passes them
+ * exactly as `getIssueDetail()` returns them (oldest → newest).
+ */
+export function detectPendingPostMortem(
+  comments: ReadonlyArray<IssueComment>,
+): PostMortemDetection {
+  // Find the index of the most recent post-mortem comment.
+  let lastPostMortemIdx = -1;
+  let lastPostMortemBody = "";
+  for (let i = 0; i < comments.length; i++) {
+    if (POST_MORTEM_SENTINEL.test(comments[i].body)) {
+      lastPostMortemIdx = i;
+      lastPostMortemBody = comments[i].body;
+    }
+  }
+  if (lastPostMortemIdx < 0) return { pending: false };
+
+  // Look at every comment AFTER the last post-mortem for a resolution
+  // signal. Resolution requires the comment NOT itself be a post-mortem
+  // (vp-dev posting another failure cannot resolve a prior failure).
+  for (let i = lastPostMortemIdx + 1; i < comments.length; i++) {
+    const c = comments[i];
+    if (POST_MORTEM_SENTINEL.test(c.body)) continue;
+    if (containsResolutionKeyword(c.body)) {
+      return { pending: false };
+    }
+  }
+
+  // Pending. Extract the run-id from the post-mortem header for the reason
+  // string so the triage gate cites which run flagged the issue.
+  const runId = extractRunId(lastPostMortemBody);
+  const reason = runId
+    ? `awaiting human review of prior failure post-mortem (${runId})`
+    : "awaiting human review of prior failure post-mortem";
+  return { pending: true, reason };
+}
+
+function containsResolutionKeyword(body: string): boolean {
+  const lower = body.toLowerCase();
+  return RESOLUTION_KEYWORDS.some((kw) => lower.includes(kw));
+}
+
+function extractRunId(body: string): string | undefined {
+  // Header shape: `## vp-dev failure post-mortem (run-2026-..., agent-72c6)`
+  const m = /\(\s*(run-[^,)\s]+)/i.exec(body);
+  return m ? m[1] : undefined;
+}

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -12,6 +12,8 @@ import {
   fetchOriginMain,
   resolveTargetRepoPath,
 } from "../git/worktree.js";
+import { postIssueComment } from "../github/gh.js";
+import { composeFailurePostMortem } from "./failurePostMortem.js";
 import type { Logger } from "../log/logger.js";
 import type {
   AgentRecord,
@@ -359,6 +361,11 @@ async function runOneIssue(opts: {
     costTracker: opts.costTracker,
   });
 
+  // Track whether this run was a non-clean exit so the post-mortem comment
+  // step below can fire after the run-state entry is settled. Two failure
+  // shapes count: (a) no envelope at all, (b) envelope with decision="error".
+  let nonCleanExit = false;
+
   if (result.envelope) {
     const env = result.envelope;
     opts.state.issues[String(opts.issue.id)] = {
@@ -369,6 +376,7 @@ async function runOneIssue(opts: {
       commentUrl: env.commentUrl,
       partialBranchUrl: result.partialBranchUrl,
     };
+    nonCleanExit = env.decision === "error";
   } else {
     // Reconciliation found a branch on remote without a PR — surface it in
     // the failure record so the user can salvage with one `gh pr create`
@@ -387,9 +395,43 @@ async function runOneIssue(opts: {
       ...failure,
       partialBranchUrl: result.partialBranchUrl,
     };
+    nonCleanExit = true;
   }
 
   const stateAgent = opts.state.agents.find((a) => a.agentId === opts.agent.agentId);
   if (stateAgent) stateAgent.status = "idle";
   await saveRunState(opts.state);
+
+  // Issue #100: post a fail-fast post-mortem comment on the GitHub issue
+  // after a non-clean exit. The triage gate on the next `vp-dev run` reads
+  // this comment and skips re-dispatch until a human resolves the blocker
+  // (or `--include-non-ready` overrides). Skipped in dry-run because gh
+  // calls in dry-run runs are intercepted into echoes; failing to post
+  // logs a warning but never aborts the run.
+  if (nonCleanExit && !opts.dryRun) {
+    const body = composeFailurePostMortem({
+      runId: opts.state.runId,
+      agentId: opts.agent.agentId,
+      errorSubtype: result.errorSubtype,
+      errorReason: result.errorReason,
+      costUsd: result.costUsd,
+      durationMs: result.durationMs,
+      partialBranchUrl: result.partialBranchUrl,
+    });
+    try {
+      await postIssueComment(opts.state.targetRepo, opts.issue.id, body);
+      opts.logger.info("orchestrator.post_mortem_posted", {
+        agentId: opts.agent.agentId,
+        issueId: opts.issue.id,
+        runId: opts.state.runId,
+      });
+    } catch (err) {
+      opts.logger.warn("orchestrator.post_mortem_failed", {
+        agentId: opts.agent.agentId,
+        issueId: opts.issue.id,
+        runId: opts.state.runId,
+        err: (err as Error).message,
+      });
+    }
+  }
 }

--- a/src/orchestrator/triage.ts
+++ b/src/orchestrator/triage.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import { ensureDir } from "../state/locks.js";
 import { getIssueDetail, type IssueComment, type IssueDetail } from "../github/gh.js";
+import { detectPendingPostMortem } from "./failurePostMortem.js";
 import type { IssueSummary } from "../types.js";
 import type { Logger } from "../log/logger.js";
 
@@ -71,6 +72,27 @@ async function triageOne(input: TriageOneInput): Promise<TriagedIssue> {
     return {
       issue: input.issue,
       result: { ready: true, reason: "triage skipped: issue detail unavailable" },
+      fromCache: false,
+      costUsd: 0,
+    };
+  }
+
+  // Issue #100: deterministic gate. A `## vp-dev failure post-mortem` comment
+  // on the issue means a prior agent attempted-and-failed; without this check
+  // the next `vp-dev run` re-dispatches the same issue and burns budget on
+  // the same structural blocker. Resolution keywords (`retry`, `fix landed`,
+  // `scope changed`, `unblock`, `proceed`) in any later non-post-mortem
+  // comment lift the gate. `--include-non-ready` bypasses triage entirely
+  // and therefore also overrides this check (see cli.ts:369).
+  const pendingPostMortem = detectPendingPostMortem(detail.comments);
+  if (pendingPostMortem.pending && pendingPostMortem.reason) {
+    input.logger.info("triage.post_mortem_gate", {
+      issueId: input.issue.id,
+      reason: pendingPostMortem.reason,
+    });
+    return {
+      issue: input.issue,
+      result: { ready: false, reason: pendingPostMortem.reason },
       fromCache: false,
       costUsd: 0,
     };


### PR DESCRIPTION
Closes #100.

## Summary

Across-dispatch fail-fast for non-clean exits. When a coding-agent run finishes without a clean implement (no envelope, `decision="error"`, or SDK truncation), the orchestrator posts a structured `## vp-dev failure post-mortem` comment on the GitHub issue. The triage gate on the next `vp-dev run` reads that comment deterministically and marks the issue `ready: false` until a human posts a resolution signal (`retry`, `fix landed`, `scope changed`, `unblock`, `proceed`) or the operator passes `--include-non-ready`.

Issue #34 burned ~$8.30 across two re-dispatches of a 9-file plan before the user manually noticed and split it. This gate makes that loop deterministic-prevented.

## Files

- `src/orchestrator/failurePostMortem.ts` (new) — `composeFailurePostMortem()` (Markdown body) + `detectPendingPostMortem()` (sentinel + resolution-keyword scan). Sentinel is `^## vp-dev failure post-mortem` (case-insensitive, line-anchored — quoted text inside other comments cannot trigger).
- `src/orchestrator/orchestrator.ts` — call site in `runOneIssue` after the run-state entry settles. Skipped in dry-run; failure to post logs `orchestrator.post_mortem_failed` but does not abort the run.
- `src/orchestrator/triage.ts` — deterministic pre-model gate in `triageOne`. Saves the LLM call when the post-mortem is pending.
- `src/github/gh.ts` — `postIssueComment(targetRepo, issueId, body)` helper (uses `--body-file` via tmp file for safe Markdown handling).
- `src/orchestrator/failurePostMortem.test.ts` (new) — 13 unit tests: sentinel anchoring, case-insensitive detection, resolution-keyword recognition (single + multi-word), second-post-mortem-doesn't-resolve-the-first, ambient-comment doesn't lift the gate, multi-paragraph post-mortem detection.

## Behavior change

**Before**: Agent fails on #N → state JSON records it, partial branch pushed → next run re-dispatches #N → fails again → repeat.

**After**: Agent fails on #N → state JSON records it → orchestrator posts post-mortem on the issue → next run's triage detects the comment, returns `ready: false` with reason `awaiting human review of prior failure post-mortem (run-XXX)`, surfaced in the preview's `triageSkipped` block. Human posts a resolution comment or passes `--include-non-ready` to override.

## Test plan

- [x] `npm run build` — clean.
- [x] `npm run typecheck` — clean.
- [x] `npm test` — 98/98 passing (13 new + 85 existing).
- [ ] End-to-end: a `vp-dev run` against an issue with a simulated `error_max_turns` failure posts the comment and the next run's preview lists the issue under `triageSkipped`.

— Fibonacci (agent-41bd)
