### PR TITLE
feat(coding-agent): drop 50-turn ceiling, switch to per-query maxBudgetUsd

### DIFF
--- a/src/agent/codingAgent.ts
+++ b/src/agent/codingAgent.ts
@@ -103,14 +103,26 @@ export async function runCodingAgent(input: CodingAgentInput): Promise<CodingAge
 
   const toolUseTrace: { tool: string; input: string }[] = [];
 
+  // Pass 1 (main coding pass): no `maxTurns` — issue #98 retired the 50-turn
+  // ceiling. The cap was an indirect proxy for cost; once `RunCostTracker`
+  // landed (PR #93) and the SDK's `maxBudgetUsd` option became available we
+  // can hard-stop on the dimension we actually want to bound. Past failure
+  // mode: issue #34's 9-file plan twice hit `error_max_turns` mid-edit
+  // despite making forward progress, burning ~$8.30 with no recovered work.
+  // The remaining-budget computation reads the tracker AT DISPATCH TIME so
+  // pass 1 sees the full budget; recovery passes (2a, 2b) see what's left
+  // after pass 1's cost has been forwarded via `costTracker.add()`. When
+  // no budget was configured (`--max-cost-usd` absent), `remainingBudget()`
+  // returns `undefined` and the SDK runs uncapped — same behavior as the
+  // pre-#98 main pass minus the turn ceiling.
   const pass1 = await runSdkPass({
     input,
     systemPrompt,
     userPrompt,
-    maxTurns: 50,
     canUseTool,
     disallowedTools,
     toolUseTrace,
+    maxBudgetUsd: input.costTracker?.remainingBudget(),
   });
 
   // Forward to the per-run accumulator the moment the SDK reports the
@@ -128,9 +140,9 @@ export async function runCodingAgent(input: CodingAgentInput): Promise<CodingAge
   let parsed = extractEnvelope(finalText);
   let recoveryAttempted = false;
 
-  // Turn-ceiling recovery: when the SDK truncated the run with
-  // `error_max_turns` and we have no parseable envelope, run a two-pass
-  // recovery:
+  // Truncation recovery: when the SDK truncated the run with
+  // `error_max_turns` OR `error_max_budget_usd` and we have no parseable
+  // envelope, run a two-pass recovery:
   //
   //   - Pass 2a (1 turn, no tools): envelope-only. Hard SDK-level guarantee
   //     that a structured terminal envelope is recorded before any tool work
@@ -144,9 +156,22 @@ export async function runCodingAgent(input: CodingAgentInput): Promise<CodingAge
   //     upgrade from `decision: "error"` to `decision: "implement"` with
   //     prUrl when there's recoverable in-flight work.
   //
+  // Issue #98: `error_max_budget_usd` is the cost-shaped twin of
+  // `error_max_turns` — it fires when the SDK exhausts the per-query
+  // `maxBudgetUsd` derived from the tracker's remaining budget. Same
+  // recovery shape applies: drained budget on pass 1 means recovery passes
+  // see `remainingBudget() === 0` and the SDK exits with the same subtype
+  // before tools can fire, so pass 2a still gets its envelope-write budget
+  // off the orchestrator's residual headroom (the run-level budget
+  // continues to accumulate across passes).
+  //
   // Skipped in dry-run because branch / push are intercepted into echoes,
   // leaving no real remote state for reconcile to find. See issue #76.
-  if (errorSubtype === "error_max_turns" && !parsed.ok && !input.dryRun) {
+  if (
+    (errorSubtype === "error_max_turns" || errorSubtype === "error_max_budget_usd") &&
+    !parsed.ok &&
+    !input.dryRun
+  ) {
     recoveryAttempted = true;
     input.logger.info("agent.recovery_started", {
       agentId: input.agent.agentId,
@@ -167,6 +192,15 @@ export async function runCodingAgent(input: CodingAgentInput): Promise<CodingAge
       canUseTool,
       disallowedTools,
       toolUseTrace,
+      // Recovery passes share the run-level cost ceiling. Re-read the
+      // tracker after pass 1 so pass 2a sees the residual budget, not the
+      // pre-pass-1 budget. When pass 1 itself triggered the recovery via
+      // `error_max_budget_usd`, the residual is 0 — pass 2a then runs
+      // under tight enforcement (the SDK exits with the same subtype as
+      // soon as a cost reading is reported), gracefully degrading rather
+      // than being blocked entirely. The 1-turn `maxTurns` cap is the
+      // primary bound on this pass; budget is the secondary.
+      maxBudgetUsd: input.costTracker?.remainingBudget(),
     });
     if (pass2a.finalText) finalText = pass2a.finalText;
     if (typeof pass2a.costUsd === "number") {
@@ -184,6 +218,9 @@ export async function runCodingAgent(input: CodingAgentInput): Promise<CodingAge
         canUseTool,
         disallowedTools,
         toolUseTrace,
+        // Re-read remaining budget after pass 2a was forwarded so pass 2b
+        // sees what's left for the work-salvage tool calls.
+        maxBudgetUsd: input.costTracker?.remainingBudget(),
       });
       if (typeof pass2b.costUsd === "number") {
         costUsd = (costUsd ?? 0) + pass2b.costUsd;
@@ -297,7 +334,14 @@ interface SdkPassOpts {
   input: CodingAgentInput;
   systemPrompt: string;
   userPrompt: string;
-  maxTurns: number;
+  /**
+   * Optional turn ceiling. Issue #98 dropped the cap for the main coding
+   * pass — cost is the real constraint and the turn cap was an indirect
+   * proxy that fired at a less-meaningful boundary. Recovery passes (2a,
+   * 2b) and single-decision LLM calls keep `maxTurns` because they're
+   * decision-bounded by design.
+   */
+  maxTurns?: number;
   canUseTool: CanUseTool;
   disallowedTools: string[];
   toolUseTrace: { tool: string; input: string }[];
@@ -306,6 +350,15 @@ interface SdkPassOpts {
    * all built-in tools (envelope-only recovery pass; see issue #89).
    */
   tools?: string[];
+  /**
+   * Per-query cost ceiling forwarded to the SDK's `maxBudgetUsd` option.
+   * The SDK exits with `error_max_budget_usd` once the query crosses this
+   * threshold. Computed at dispatch time as `costTracker.remainingBudget()`
+   * so each pass sees the budget that's actually left after prior passes
+   * forwarded their cost via `costTracker.add()`. Undefined when no
+   * run-level budget was configured — the SDK then runs uncapped on cost.
+   */
+  maxBudgetUsd?: number;
 }
 
 interface SdkPassResult {
@@ -359,6 +412,7 @@ async function runSdkPass(opts: SdkPassOpts): Promise<SdkPassResult> {
         env: process.env,
         abortController: input.abortController,
         maxTurns: opts.maxTurns,
+        maxBudgetUsd: opts.maxBudgetUsd,
         settingSources: [],
         persistSession: false,
         pathToClaudeCodeExecutable: claudeBinPath(),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -336,10 +336,17 @@ async function cmdRun(opts: RunOpts): Promise<void> {
 
   // Per-run cost tracker (issue #85, Phase 1). Instantiated here so triage
   // cost (which fires BEFORE the runId is minted on line ~451) accumulates
-  // into the same total as orchestrator + coding-agent spend. Phase 1 is
-  // measurement only — `budgetUsd` is logged but not enforced.
+  // into the same total as orchestrator + coding-agent spend.
+  //
+  // Issue #98: the budget is now threaded into the tracker constructor so
+  // `runCodingAgent` can derive a per-query `maxBudgetUsd` via
+  // `remainingBudget()` and let the SDK hard-stop the agent on cost
+  // exhaustion. This replaces the old `maxTurns: 50` ceiling on pass 1 —
+  // cost is the real constraint, and the turn cap was an indirect proxy
+  // that fired at a less-meaningful boundary (issue #34 hit it mid-edit
+  // on a 9-file plan despite making forward progress).
   const budgetUsd = resolveBudgetUsd({ flag: opts.maxCostUsd, env: process.env });
-  const costTracker = new RunCostTracker();
+  const costTracker = new RunCostTracker({ budgetUsd });
 
   const { open, skippedClosed } = await resolveRangeToIssues(opts.targetRepo, range);
   if (open.length === 0) {

--- a/src/util/costTracker.test.ts
+++ b/src/util/costTracker.test.ts
@@ -7,6 +7,73 @@ test("RunCostTracker: starts at zero", () => {
   assert.equal(t.total(), 0);
 });
 
+test("RunCostTracker: budgetUsd undefined when no constructor arg", () => {
+  const t = new RunCostTracker();
+  assert.equal(t.budgetUsd, undefined);
+});
+
+test("RunCostTracker: budgetUsd carries through when constructed with a value", () => {
+  const t = new RunCostTracker({ budgetUsd: 5 });
+  assert.equal(t.budgetUsd, 5);
+});
+
+test("RunCostTracker: budgetUsd reduces malformed values to undefined", () => {
+  // Defense in depth: cli.ts already filters via resolveBudgetUsd, but a
+  // direct caller (test code, future surfaces) shouldn't poison the SDK
+  // with a NaN/Infinity/negative budget that would either crash the SDK
+  // or be silently misinterpreted as no-cap.
+  assert.equal(new RunCostTracker({ budgetUsd: Number.NaN }).budgetUsd, undefined);
+  assert.equal(
+    new RunCostTracker({ budgetUsd: Number.POSITIVE_INFINITY }).budgetUsd,
+    undefined,
+  );
+  assert.equal(new RunCostTracker({ budgetUsd: -1 }).budgetUsd, undefined);
+});
+
+test("RunCostTracker: zero is a valid budget (Phase-2 decides semantics)", () => {
+  // Mirrors resolveBudgetUsd's treatment — zero is preserved at this
+  // layer so Phase-2 enforcement decides what `--max-cost-usd 0` means
+  // (always-abort vs no-op). The tracker just records.
+  const t = new RunCostTracker({ budgetUsd: 0 });
+  assert.equal(t.budgetUsd, 0);
+});
+
+test("RunCostTracker: remainingBudget undefined when no budget set", () => {
+  // No budget → no per-query cap → SDK runs uncapped on cost. This is
+  // the same behavior the main pass had before issue #98 minus the
+  // 50-turn ceiling.
+  const t = new RunCostTracker();
+  assert.equal(t.remainingBudget(), undefined);
+  t.add(2.5);
+  assert.equal(t.remainingBudget(), undefined);
+});
+
+test("RunCostTracker: remainingBudget shrinks as cost accumulates", () => {
+  const t = new RunCostTracker({ budgetUsd: 10 });
+  assert.equal(t.remainingBudget(), 10);
+  t.add(3);
+  assert.equal(t.remainingBudget(), 7);
+  t.add(4);
+  assert.equal(t.remainingBudget(), 3);
+});
+
+test("RunCostTracker: remainingBudget clamps at zero when exhausted", () => {
+  // Issue #98: returning 0 (rather than a negative) lets callers pass
+  // the value straight to the SDK's maxBudgetUsd, which rejects
+  // negatives. 0 causes the SDK to exit with error_max_budget_usd on
+  // next dispatch — the desired enforcement behavior.
+  const t = new RunCostTracker({ budgetUsd: 5 });
+  t.add(10); // overshoots — reasonable in practice (SDK reports cost
+  // after the query exited, so the tracker can briefly carry a
+  // post-pass value above the budget).
+  assert.equal(t.remainingBudget(), 0);
+});
+
+test("RunCostTracker: remainingBudget zero when budget is zero", () => {
+  const t = new RunCostTracker({ budgetUsd: 0 });
+  assert.equal(t.remainingBudget(), 0);
+});
+
 test("RunCostTracker: accumulates positive values", () => {
   const t = new RunCostTracker();
   t.add(0.25);

--- a/src/util/costTracker.ts
+++ b/src/util/costTracker.ts
@@ -4,6 +4,13 @@
 // only — no enforcement, no `aborted-budget` terminal state, no `break` in
 // `runOrchestrator()`. Phase 2 layers enforcement on top once this lands.
 //
+// Issue #98: the tracker now optionally carries the per-run `budgetUsd` so
+// `runCodingAgent` can compute `remainingBudget()` and forward it to the
+// SDK's `maxBudgetUsd` query option. The SDK then hard-stops the agent on
+// cost exhaustion (returning `error_max_budget_usd`), replacing the old
+// `maxTurns: 50` ceiling on the main pass with a cost-shaped boundary that
+// matches what we actually want to bound.
+//
 // Instantiated once in `cmdRun()` and threaded by reference into every site
 // that calls the SDK's `query()` (codingAgent, dispatcher, triage). Each site
 // reads `msg.total_cost_usd` from the per-result message and forwards it via
@@ -14,6 +21,26 @@
 
 export class RunCostTracker {
   private accumulated = 0;
+  /**
+   * Per-run cost ceiling in USD, or `undefined` when no budget was set
+   * (`--max-cost-usd` flag absent and `VP_DEV_MAX_COST_USD` unset). Read
+   * by `remainingBudget()`; never mutated after construction so callers
+   * can rely on its stability across the run lifetime.
+   */
+  readonly budgetUsd: number | undefined;
+
+  constructor(opts: { budgetUsd?: number } = {}) {
+    // Defensive: a malformed budget (NaN / negative / non-finite) reduces
+    // to "no budget" rather than throwing, so the same guard `cli.ts`
+    // applies via `resolveBudgetUsd` is enforced once more here for any
+    // direct caller (test code, future CLI surfaces).
+    const raw = opts.budgetUsd;
+    if (typeof raw === "number" && Number.isFinite(raw) && raw >= 0) {
+      this.budgetUsd = raw;
+    } else {
+      this.budgetUsd = undefined;
+    }
+  }
 
   /**
    * Forward an SDK cost reading. Defensive: ignores undefined / null /
@@ -40,6 +67,28 @@ export class RunCostTracker {
   exceedsBudget(budgetUsd: number): boolean {
     if (!Number.isFinite(budgetUsd) || budgetUsd < 0) return false;
     return this.accumulated > budgetUsd;
+  }
+
+  /**
+   * USD remaining against the configured `budgetUsd`, clamped to >= 0.
+   * Returns `undefined` when no budget was configured — callers should
+   * pass `undefined` straight through to the SDK's `maxBudgetUsd` (the
+   * SDK treats undefined as no cap, matching the no-budget run shape).
+   *
+   * Issue #98: this is the per-query budget threaded into `runSdkPass`.
+   * Computed at the moment of dispatch so the SDK enforcement window
+   * narrows as the run accumulates spend — pass 1 sees the full remaining
+   * budget, pass 2a sees what's left after pass 1 cost was forwarded to
+   * `add()`, and so on.
+   */
+  remainingBudget(): number | undefined {
+    if (this.budgetUsd === undefined) return undefined;
+    const remaining = this.budgetUsd - this.accumulated;
+    // Clamp at 0: the SDK rejects negative budgets, and conceptually the
+    // budget is exhausted once `accumulated >= budgetUsd`. Returning 0
+    // here causes the SDK to immediately exit with `error_max_budget_usd`
+    // on the next dispatch, which is the desired Phase-2 enforcement.
+    return remaining > 0 ? remaining : 0;
   }
 }
 


### PR DESCRIPTION
Closes #98.

## Summary

The coding agent's main pass (`runCodingAgent()` pass 1) had a hardcoded `maxTurns: 50` that indirectly bounded cost — it fired at a less-meaningful boundary than what we actually want to limit. Issue #34's 9-file plan twice hit `error_max_turns` mid-edit despite making forward progress, burning ~$8.30 total with no recovered work.

Now that [PR #93](https://github.com/szhygulin/vaultpilot-development-agents/pull/93) shipped `RunCostTracker` and the SDK exposes `maxBudgetUsd` on `query()`, replace the turn cap with a cost-shaped one.

## Changes

- **`src/agent/codingAgent.ts`**:
  - Drop `maxTurns: 50` from pass 1. The SDK now runs uncapped on turns and hard-stops on cost via `error_max_budget_usd`.
  - Plumb `maxBudgetUsd: input.costTracker?.remainingBudget()` to all three `runSdkPass()` calls (pass 1, recovery 2a, recovery 2b). Each pass reads the tracker at dispatch time so it sees the budget actually left after prior passes forwarded their cost.
  - Extend the truncation-recovery trigger from `errorSubtype === "error_max_turns"` to also fire on `error_max_budget_usd` — the recovery flow records a structured envelope regardless of which ceiling tripped it. Recovery passes' `maxTurns` (2a: 1, 2b: 4) stay; they're decision-bounded by design.

- **`src/util/costTracker.ts`**:
  - Add `budgetUsd` constructor argument (optional) and stash it as `readonly budgetUsd`. Defensive: NaN / Infinity / negative reduce to `undefined`.
  - Add `remainingBudget()` — returns `budgetUsd - accumulated` clamped to `>= 0`, or `undefined` when no budget was configured. The clamp matters because the SDK rejects negative budgets; returning 0 lets the SDK exit immediately on the next dispatch with `error_max_budget_usd`.

- **`src/cli.ts`**: Pass `budgetUsd` to the `RunCostTracker` constructor.

- **`src/util/costTracker.test.ts`**: 7 new tests covering `budgetUsd` accessor (undefined / value / malformed / zero), `remainingBudget()` behavior (no-budget / accumulating / exhausted / zero-budget).

## Behavior

- **No budget set** (`--max-cost-usd` absent, `VP_DEV_MAX_COST_USD` unset): `remainingBudget()` returns `undefined`, the SDK runs uncapped on cost — same shape as the pre-#98 main pass minus the turn ceiling.
- **Budget set, sufficient headroom**: agent runs to completion or natural envelope emit; turn count no longer matters.
- **Budget exhausted mid-pass-1**: SDK exits with `error_max_budget_usd`; truncation-recovery fires (same shape as `error_max_turns` recovery), pass 2a captures a structured `decision: "error"` envelope, pass 2b best-effort salvages in-flight work.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 93 tests pass (7 new in `costTracker.test.ts`)
- [ ] Smoke: `vp-dev run --max-cost-usd 5.0 --target-repo X --issues N` against an issue whose work would have hit `error_max_turns` under the old cap; agent runs to completion or until cost ceiling exhausts.
- [ ] Smoke: `vp-dev run` without `--max-cost-usd`; agent runs uncapped on both turns and cost.

— Cook (agent-fe90)
