### PR TITLE
Generalize sentinel expiry to per-kind policies

### DIFF
--- a/src/agent/runIssueCore.ts
+++ b/src/agent/runIssueCore.ts
@@ -3,12 +3,12 @@ import { ensureAgent, mutateRegistry } from "../state/registry.js";
 import { runCodingAgent } from "./codingAgent.js";
 import {
   appendBlock,
-  expireFailureLessons,
+  expireSentinels,
   forkClaudeMd,
   type AppendOutcome,
 } from "./specialization.js";
 import { isInfraFlake, summarizeFailureRun, summarizeRun, type SummarizerOutput } from "./summarizer.js";
-import { resolveExpireK } from "../util/sentinels.js";
+import { resolveExpiryPolicies } from "../util/sentinels.js";
 import {
   buildIncompleteBranchName,
   createWorktree,
@@ -153,25 +153,34 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
         appendOutcome = appendResult.appendOutcome;
         summarySkipReason = appendResult.summarySkipReason;
 
-        // Failure-lesson expiry: after a successful implement run has
-        // been recorded, walk the agent's CLAUDE.md and drop any
-        // failure-lesson sentinel that ≥ K subsequent implements with
-        // overlapping tags have superseded. Only fires for implement —
-        // pushback / failure-lesson runs don't trigger expiry. K is
-        // env-configurable (`VP_DEV_FAILURE_LESSON_EXPIRE_K`, default 3).
+        // Sentinel expiry: after a successful implement run has been
+        // recorded, walk the agent's CLAUDE.md and drop sentinels that
+        // newer blocks have superseded. Per-kind policies cover
+        // failure-lessons (K newer overlapping implements), success
+        // implements (K newer Jaccard-≥-0.5 implements), and pushback
+        // (preserved by default). Only fires after `implement` —
+        // pushback / failure-lesson runs don't trigger expiry. Policies
+        // are env-configurable via VP_DEV_{FAILURE,SUCCESS,PUSHBACK}_LESSON_EXPIRE_K.
         if (
           envelope.decision === "implement" &&
           appendOutcome?.kind === "appended"
         ) {
           try {
-            const k = resolveExpireK();
-            const expired = await expireFailureLessons(input.agent.agentId, k);
+            const policies = resolveExpiryPolicies();
+            const expired = await expireSentinels(
+              input.agent.agentId,
+              policies,
+            );
             if (expired.kind === "expired") {
               input.logger.info("specialization.expired", {
                 agentId: input.agent.agentId,
                 issueId: input.issue.id,
-                k,
+                policies: policies.map((p) => ({
+                  kind: p.kind,
+                  k: Number.isFinite(p.k) ? p.k : "infinity",
+                })),
                 droppedCount: expired.dropped.length,
+                droppedKinds: expired.dropped.map((h) => h.outcome),
                 droppedIssues: expired.dropped.map((h) => h.issueId),
                 totalBytes: expired.totalBytes,
               });

--- a/src/agent/specialization.ts
+++ b/src/agent/specialization.ts
@@ -2,8 +2,9 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { ensureDir, withFileLock } from "../state/locks.js";
 import {
-  expireFailureLessonsInContent,
+  expireSentinelsInContent,
   formatSentinelHeader,
+  type ExpiryPolicy,
   type SentinelHeader,
 } from "../util/sentinels.js";
 
@@ -154,20 +155,19 @@ export type ExpireOutcome =
   | { kind: "expired"; dropped: SentinelHeader[]; totalBytes: number };
 
 /**
- * Walk the agent's CLAUDE.md and drop `outcome:failure-lesson` blocks
- * that have ≥ k subsequent `outcome:implement` blocks sharing at least
- * one tag with the lesson. Idempotent — re-running on the same content
- * with the same `k` is a no-op. Conservative on legacy sentinels with
- * no `tags:` field: those are never expired.
+ * Walk the agent's CLAUDE.md and drop sentinel blocks per the supplied
+ * policies. Idempotent — re-running on the same content with the same
+ * policies is a no-op. Conservative on legacy sentinels with no `tags:`
+ * field: those are never expired.
  *
  * Wired from `runIssueCore` after a successful implement run, matching
  * the issue's "summarizer rewrites the file after a successful run"
  * trigger. Shares the same per-file lock as `appendBlock` so the
  * read-rewrite-write sequence is atomic against concurrent appends.
  */
-export async function expireFailureLessons(
+export async function expireSentinels(
   agentId: string,
-  k: number,
+  policies: ExpiryPolicy[],
 ): Promise<ExpireOutcome> {
   const filePath = agentClaudeMdPath(agentId);
   return withFileLock(filePath, async () => {
@@ -179,7 +179,7 @@ export async function expireFailureLessons(
       // forkClaudeMd / appendBlock's job.
       return { kind: "no-op" };
     }
-    const result = expireFailureLessonsInContent(current, k);
+    const result = expireSentinelsInContent(current, policies);
     if (result.droppedHeaders.length === 0) return { kind: "no-op" };
 
     const tmp = `${filePath}.tmp.${process.pid}`;
@@ -191,4 +191,23 @@ export async function expireFailureLessons(
       totalBytes: Buffer.byteLength(result.content, "utf-8"),
     };
   });
+}
+
+/**
+ * Backward-compatible wrapper: drop only failure-lesson blocks with the
+ * legacy single-K rule. New callers should use `expireSentinels` with
+ * `resolveExpiryPolicies()` to cover all sentinel kinds.
+ */
+export async function expireFailureLessons(
+  agentId: string,
+  k: number,
+): Promise<ExpireOutcome> {
+  return expireSentinels(agentId, [
+    {
+      kind: "failure-lesson",
+      k,
+      supersededBy: ["implement"],
+      overlap: { mode: "any-shared-tag" },
+    },
+  ]);
 }

--- a/src/util/sentinels.test.ts
+++ b/src/util/sentinels.test.ts
@@ -2,11 +2,17 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   DEFAULT_FAILURE_LESSON_EXPIRE_K,
+  DEFAULT_PUSHBACK_LESSON_EXPIRE_K,
+  DEFAULT_SUCCESS_LESSON_EXPIRE_K,
   decideExpiry,
+  decideExpiryWithPolicies,
   expireFailureLessonsInContent,
+  expireSentinelsInContent,
   formatSentinelHeader,
   parseSentinelHeader,
   resolveExpireK,
+  resolveExpiryPolicies,
+  type ExpiryPolicy,
 } from "./sentinels.js";
 
 test("parseSentinelHeader: legacy sentinel without tags", () => {
@@ -318,5 +324,370 @@ test("resolveExpireK: falls back on garbage", () => {
   assert.equal(
     resolveExpireK({ VP_DEV_FAILURE_LESSON_EXPIRE_K: "-2" }),
     DEFAULT_FAILURE_LESSON_EXPIRE_K,
+  );
+});
+
+// ── Generalized per-kind expiry ────────────────────────────────────────
+
+const successPolicy: ExpiryPolicy = {
+  kind: "implement",
+  k: 5,
+  supersededBy: ["implement"],
+  overlap: { mode: "jaccard", minScore: 0.5 },
+};
+
+const pushbackPreservePolicy: ExpiryPolicy = {
+  kind: "pushback",
+  k: Number.POSITIVE_INFINITY,
+  supersededBy: ["pushback"],
+  overlap: { mode: "any-shared-tag" },
+};
+
+test("decideExpiryWithPolicies: drops success with K newer high-Jaccard implements", () => {
+  // 5 newer implements all sharing tags ["auth"] (Jaccard 1.0 with first).
+  const headers = Array.from({ length: 6 }, (_, i) => ({
+    runId: `r${i}`,
+    issueId: i,
+    outcome: "implement",
+    ts: `t${i}`,
+    tags: ["auth"],
+  }));
+  const d = decideExpiryWithPolicies(headers, [successPolicy]);
+  // Only the very first block has 5 newer; later blocks have <5.
+  assert.deepEqual(d.drop, [0]);
+});
+
+test("decideExpiryWithPolicies: keeps success when Jaccard < 0.5", () => {
+  // Candidate ["auth"]; successors ["auth","x","y","z"] → Jaccard
+  // 1/4 = 0.25, below threshold.
+  const headers: Parameters<typeof decideExpiryWithPolicies>[0] = [
+    { runId: "r0", issueId: 0, outcome: "implement", ts: "t0", tags: ["auth"] },
+    {
+      runId: "r1",
+      issueId: 1,
+      outcome: "implement",
+      ts: "t1",
+      tags: ["auth", "x", "y", "z"],
+    },
+    {
+      runId: "r2",
+      issueId: 2,
+      outcome: "implement",
+      ts: "t2",
+      tags: ["auth", "x", "y", "z"],
+    },
+    {
+      runId: "r3",
+      issueId: 3,
+      outcome: "implement",
+      ts: "t3",
+      tags: ["auth", "x", "y", "z"],
+    },
+    {
+      runId: "r4",
+      issueId: 4,
+      outcome: "implement",
+      ts: "t4",
+      tags: ["auth", "x", "y", "z"],
+    },
+    {
+      runId: "r5",
+      issueId: 5,
+      outcome: "implement",
+      ts: "t5",
+      tags: ["auth", "x", "y", "z"],
+    },
+  ];
+  const d = decideExpiryWithPolicies(headers, [successPolicy]);
+  assert.deepEqual(d.drop, []);
+});
+
+test("decideExpiryWithPolicies: Jaccard ≥ 0.5 with overlap of 1/2 boundary", () => {
+  // Candidate ["a","b"]; successors each ["a","b"] (Jaccard 1.0).
+  const headers = Array.from({ length: 6 }, (_, i) => ({
+    runId: `r${i}`,
+    issueId: i,
+    outcome: "implement",
+    ts: `t${i}`,
+    tags: ["a", "b"],
+  }));
+  const d = decideExpiryWithPolicies(headers, [successPolicy]);
+  assert.deepEqual(d.drop, [0]);
+});
+
+test("decideExpiryWithPolicies: Jaccard exactly 0.5 dropped (boundary inclusive)", () => {
+  // Candidate ["a","b"]; successors ["a","b","c"] → Jaccard 2/3 ≈ 0.67 ✓.
+  // Candidate ["a","b"]; successors ["a","c"] → Jaccard 1/3 ≈ 0.33 ✗.
+  // For exact 0.5: candidate ["a"]; successor ["a","b"] → 1/2 = 0.5.
+  const headers: Parameters<typeof decideExpiryWithPolicies>[0] = [
+    { runId: "r0", issueId: 0, outcome: "implement", ts: "t0", tags: ["a"] },
+    {
+      runId: "r1",
+      issueId: 1,
+      outcome: "implement",
+      ts: "t1",
+      tags: ["a", "b"],
+    },
+    {
+      runId: "r2",
+      issueId: 2,
+      outcome: "implement",
+      ts: "t2",
+      tags: ["a", "b"],
+    },
+    {
+      runId: "r3",
+      issueId: 3,
+      outcome: "implement",
+      ts: "t3",
+      tags: ["a", "b"],
+    },
+    {
+      runId: "r4",
+      issueId: 4,
+      outcome: "implement",
+      ts: "t4",
+      tags: ["a", "b"],
+    },
+    {
+      runId: "r5",
+      issueId: 5,
+      outcome: "implement",
+      ts: "t5",
+      tags: ["a", "b"],
+    },
+  ];
+  const d = decideExpiryWithPolicies(headers, [successPolicy]);
+  assert.deepEqual(d.drop, [0]);
+});
+
+test("decideExpiryWithPolicies: pushback default policy preserves all", () => {
+  const headers = Array.from({ length: 10 }, (_, i) => ({
+    runId: `r${i}`,
+    issueId: i,
+    outcome: "pushback",
+    ts: `t${i}`,
+    tags: ["scope-creep"],
+  }));
+  const d = decideExpiryWithPolicies(headers, [pushbackPreservePolicy]);
+  assert.deepEqual(d.drop, []);
+});
+
+test("decideExpiryWithPolicies: pushback with finite K does drop overlapping", () => {
+  const headers = Array.from({ length: 5 }, (_, i) => ({
+    runId: `r${i}`,
+    issueId: i,
+    outcome: "pushback",
+    ts: `t${i}`,
+    tags: ["scope-creep"],
+  }));
+  const finitePushback: ExpiryPolicy = {
+    kind: "pushback",
+    k: 3,
+    supersededBy: ["pushback"],
+    overlap: { mode: "any-shared-tag" },
+  };
+  const d = decideExpiryWithPolicies(headers, [finitePushback]);
+  // Indices 0 and 1 each have ≥ 3 newer overlapping pushbacks.
+  assert.deepEqual(d.drop, [0, 1]);
+});
+
+test("decideExpiryWithPolicies: legacy implement without tags is never dropped", () => {
+  const headers = [
+    { runId: "r0", issueId: 0, outcome: "implement", ts: "t0", tags: [] },
+    ...Array.from({ length: 5 }, (_, i) => ({
+      runId: `r${i + 1}`,
+      issueId: i + 1,
+      outcome: "implement",
+      ts: `t${i + 1}`,
+      tags: ["auth"],
+    })),
+  ];
+  const d = decideExpiryWithPolicies(headers, [successPolicy]);
+  assert.deepEqual(d.drop, []);
+});
+
+test("decideExpiryWithPolicies: combined policies preserve cross-kind boundaries", () => {
+  // failure-lesson with overlapping successes → drop.
+  // success block in same domain is the supersession source, NOT a candidate.
+  // pushback block with overlapping pushbacks (K=Infinity) → keep.
+  const policies: ExpiryPolicy[] = [
+    {
+      kind: "failure-lesson",
+      k: 3,
+      supersededBy: ["implement"],
+      overlap: { mode: "any-shared-tag" },
+    },
+    successPolicy,
+    pushbackPreservePolicy,
+  ];
+  const headers: Parameters<typeof decideExpiryWithPolicies>[0] = [
+    {
+      runId: "r0",
+      issueId: 0,
+      outcome: "failure-lesson",
+      ts: "t0",
+      tags: ["auth"],
+    },
+    { runId: "r1", issueId: 1, outcome: "implement", ts: "t1", tags: ["auth"] },
+    { runId: "r2", issueId: 2, outcome: "implement", ts: "t2", tags: ["auth"] },
+    { runId: "r3", issueId: 3, outcome: "implement", ts: "t3", tags: ["auth"] },
+    {
+      runId: "r4",
+      issueId: 4,
+      outcome: "pushback",
+      ts: "t4",
+      tags: ["scope"],
+    },
+    {
+      runId: "r5",
+      issueId: 5,
+      outcome: "pushback",
+      ts: "t5",
+      tags: ["scope"],
+    },
+  ];
+  const d = decideExpiryWithPolicies(headers, policies);
+  // Only the failure-lesson at index 0 should be dropped.
+  // Implements at 1/2 don't have ≥5 newer; pushbacks preserved.
+  assert.deepEqual(d.drop, [0]);
+});
+
+test("expireSentinelsInContent: drops superseded success block, idempotent", () => {
+  const content = [
+    "# Agent CLAUDE.md",
+    "",
+    "<!-- run:r0 issue:#0 outcome:implement ts:2026-05-01T00:00:00.000Z tags:auth -->",
+    "## Auth lesson 0",
+    "",
+    "Body 0.",
+    "",
+    "<!-- run:r1 issue:#1 outcome:implement ts:2026-05-02T00:00:00.000Z tags:auth -->",
+    "## Auth lesson 1",
+    "",
+    "Body 1.",
+    "",
+    "<!-- run:r2 issue:#2 outcome:implement ts:2026-05-03T00:00:00.000Z tags:auth -->",
+    "## Auth lesson 2",
+    "",
+    "Body 2.",
+    "",
+    "<!-- run:r3 issue:#3 outcome:implement ts:2026-05-04T00:00:00.000Z tags:auth -->",
+    "## Auth lesson 3",
+    "",
+    "Body 3.",
+    "",
+    "<!-- run:r4 issue:#4 outcome:implement ts:2026-05-05T00:00:00.000Z tags:auth -->",
+    "## Auth lesson 4",
+    "",
+    "Body 4.",
+    "",
+    "<!-- run:r5 issue:#5 outcome:implement ts:2026-05-06T00:00:00.000Z tags:auth -->",
+    "## Auth lesson 5",
+    "",
+    "Body 5.",
+    "",
+  ].join("\n");
+
+  const r1 = expireSentinelsInContent(content, [successPolicy]);
+  // Block 0 has 5 newer high-Jaccard implements → drop.
+  assert.equal(r1.droppedHeaders.length, 1);
+  assert.equal(r1.droppedHeaders[0].issueId, 0);
+  assert.ok(!r1.content.includes("## Auth lesson 0"));
+  assert.ok(r1.content.includes("## Auth lesson 1"));
+  assert.ok(r1.content.includes("## Auth lesson 5"));
+
+  // Idempotent.
+  const r2 = expireSentinelsInContent(r1.content, [successPolicy]);
+  assert.equal(r2.droppedHeaders.length, 0);
+  assert.equal(r2.content, r1.content);
+});
+
+test("expireSentinelsInContent: pushback default policy preserves the file", () => {
+  const content = [
+    "# Agent CLAUDE.md",
+    "",
+    "<!-- run:r1 issue:#1 outcome:pushback ts:t1 tags:scope -->",
+    "## P1",
+    "",
+    "<!-- run:r2 issue:#2 outcome:pushback ts:t2 tags:scope -->",
+    "## P2",
+    "",
+    "<!-- run:r3 issue:#3 outcome:pushback ts:t3 tags:scope -->",
+    "## P3",
+    "",
+    "<!-- run:r4 issue:#4 outcome:pushback ts:t4 tags:scope -->",
+    "## P4",
+    "",
+  ].join("\n");
+
+  const r = expireSentinelsInContent(content, [pushbackPreservePolicy]);
+  assert.equal(r.droppedHeaders.length, 0);
+  assert.equal(r.content, content);
+});
+
+test("expireFailureLessonsInContent: still works as a thin wrapper", () => {
+  // Original behavior: failure-lesson with 3 overlapping implements → drop.
+  const content = [
+    "<!-- run:r1 issue:#1 outcome:failure-lesson ts:t1 tags:auth -->",
+    "## L",
+    "",
+    "<!-- run:r2 issue:#2 outcome:implement ts:t2 tags:auth -->",
+    "## S1",
+    "",
+    "<!-- run:r3 issue:#3 outcome:implement ts:t3 tags:auth -->",
+    "## S2",
+    "",
+    "<!-- run:r4 issue:#4 outcome:implement ts:t4 tags:auth -->",
+    "## S3",
+    "",
+  ].join("\n");
+  const r = expireFailureLessonsInContent(content, 3);
+  assert.equal(r.droppedHeaders.length, 1);
+  assert.equal(r.droppedHeaders[0].outcome, "failure-lesson");
+});
+
+test("resolveExpiryPolicies: defaults", () => {
+  const policies = resolveExpiryPolicies({});
+  const failure = policies.find((p) => p.kind === "failure-lesson");
+  const success = policies.find((p) => p.kind === "implement");
+  const pushback = policies.find((p) => p.kind === "pushback");
+  assert.equal(failure?.k, DEFAULT_FAILURE_LESSON_EXPIRE_K);
+  assert.equal(success?.k, DEFAULT_SUCCESS_LESSON_EXPIRE_K);
+  assert.equal(pushback?.k, DEFAULT_PUSHBACK_LESSON_EXPIRE_K);
+  assert.equal(pushback?.k, Number.POSITIVE_INFINITY);
+  assert.deepEqual(success?.overlap, { mode: "jaccard", minScore: 0.5 });
+});
+
+test("resolveExpiryPolicies: env overrides", () => {
+  const policies = resolveExpiryPolicies({
+    VP_DEV_FAILURE_LESSON_EXPIRE_K: "2",
+    VP_DEV_SUCCESS_LESSON_EXPIRE_K: "10",
+    VP_DEV_PUSHBACK_LESSON_EXPIRE_K: "4",
+  });
+  assert.equal(policies.find((p) => p.kind === "failure-lesson")?.k, 2);
+  assert.equal(policies.find((p) => p.kind === "implement")?.k, 10);
+  assert.equal(policies.find((p) => p.kind === "pushback")?.k, 4);
+});
+
+test("resolveExpiryPolicies: pushback explicit disable strings", () => {
+  for (const v of ["off", "disabled", "infinity", "Infinity", "INFINITY"]) {
+    const policies = resolveExpiryPolicies({
+      VP_DEV_PUSHBACK_LESSON_EXPIRE_K: v,
+    });
+    assert.equal(
+      policies.find((p) => p.kind === "pushback")?.k,
+      Number.POSITIVE_INFINITY,
+    );
+  }
+});
+
+test("resolveExpiryPolicies: pushback garbage falls back to default Infinity", () => {
+  const policies = resolveExpiryPolicies({
+    VP_DEV_PUSHBACK_LESSON_EXPIRE_K: "garbage",
+  });
+  assert.equal(
+    policies.find((p) => p.kind === "pushback")?.k,
+    DEFAULT_PUSHBACK_LESSON_EXPIRE_K,
   );
 });

--- a/src/util/sentinels.ts
+++ b/src/util/sentinels.ts
@@ -84,43 +84,103 @@ export interface ExpireDecision {
 }
 
 /**
- * Decide which `outcome:failure-lesson` blocks to drop. A block is dropped
- * when ≥ k subsequent `outcome:implement` blocks each share at least one
- * tag with the failure-lesson's tag-fingerprint.
+ * Per-kind expiry policy. A sentinel of kind `kind` is dropped when at
+ * least `k` newer sentinels (whose outcome ∈ `supersededBy`) satisfy the
+ * `overlap` predicate against the candidate's tag-fingerprint.
  *
- * Conservative on missing tags: a failure-lesson with `tags: []` (legacy
- * sentinel from before tag embedding) never overlaps with any implement
- * sentinel and is therefore never expired. An `implement` block with
- * `tags: []` likewise contributes nothing to any expiry count. Better to
- * keep stale lessons than evict still-relevant ones.
+ * `k <= 0` or `k = Infinity` disables expiry for this kind. The
+ * `supersededBy` list lets a kind be superseded by either itself
+ * (success-lessons → success-lessons) or by a different kind
+ * (failure-lessons → implements).
+ */
+export interface ExpiryPolicy {
+  kind: string;
+  k: number;
+  supersededBy: string[];
+  overlap:
+    | { mode: "any-shared-tag" }
+    | { mode: "jaccard"; minScore: number };
+}
+
+function tagsOverlap(
+  candidateTags: Set<string>,
+  successorTags: string[],
+  rule: ExpiryPolicy["overlap"],
+): boolean {
+  if (candidateTags.size === 0 || successorTags.length === 0) return false;
+  if (rule.mode === "any-shared-tag") {
+    return successorTags.some((t) => candidateTags.has(t));
+  }
+  // Jaccard: |A ∩ B| / |A ∪ B|
+  const succSet = new Set(successorTags);
+  let intersect = 0;
+  for (const t of candidateTags) if (succSet.has(t)) intersect++;
+  const union = candidateTags.size + succSet.size - intersect;
+  if (union === 0) return false;
+  return intersect / union >= rule.minScore;
+}
+
+/**
+ * Generalized supersession-based expiry. For each header, look up its
+ * policy by `outcome`; if ≥ `policy.k` newer headers of a kind in
+ * `policy.supersededBy` satisfy the policy's tag-overlap rule, drop the
+ * candidate.
  *
- * Out-of-order writes are not a concern: blocks accumulate by file
- * append, so file order matches chronological order — no need to re-sort
- * by `ts`.
+ * Conservative on missing tags: a candidate with `tags: []` is never
+ * dropped, and successors with `tags: []` never count toward supersession.
+ * Idempotent: re-applying on already-pruned content drops nothing.
+ *
+ * Out-of-order writes are not a concern — blocks accumulate by file
+ * append, so file order matches chronological order.
+ */
+export function decideExpiryWithPolicies(
+  headers: SentinelHeader[],
+  policies: ExpiryPolicy[],
+): ExpireDecision {
+  const drop: number[] = [];
+  const policyByKind = new Map<string, ExpiryPolicy>();
+  for (const p of policies) policyByKind.set(p.kind, p);
+
+  for (let i = 0; i < headers.length; i++) {
+    const h = headers[i];
+    const policy = policyByKind.get(h.outcome);
+    if (!policy) continue;
+    if (!Number.isFinite(policy.k) || policy.k <= 0) continue;
+    if (h.tags.length === 0) continue; // legacy / no fingerprint — keep
+
+    const candidateTags = new Set(h.tags);
+    const allowedSuccessors = new Set(policy.supersededBy);
+    let overlaps = 0;
+    for (let j = i + 1; j < headers.length; j++) {
+      const succ = headers[j];
+      if (!allowedSuccessors.has(succ.outcome)) continue;
+      if (succ.tags.length === 0) continue;
+      if (tagsOverlap(candidateTags, succ.tags, policy.overlap)) overlaps += 1;
+      if (overlaps >= policy.k) break;
+    }
+    if (overlaps >= policy.k) drop.push(i);
+  }
+  return { drop, all: headers };
+}
+
+/**
+ * Backward-compatible wrapper: decide which `outcome:failure-lesson`
+ * blocks to drop using the legacy single-K rule (any-shared-tag overlap
+ * against `outcome:implement` successors). Equivalent to
+ * `decideExpiryWithPolicies(headers, [failure-lesson policy])`.
  */
 export function decideExpiry(
   headers: SentinelHeader[],
   k: number,
 ): ExpireDecision {
-  const drop: number[] = [];
-  if (k <= 0) return { drop, all: headers };
-  for (let i = 0; i < headers.length; i++) {
-    const h = headers[i];
-    if (h.outcome !== "failure-lesson") continue;
-    if (h.tags.length === 0) continue; // legacy / no fingerprint — keep
-    const lessonTags = new Set(h.tags);
-    let overlaps = 0;
-    for (let j = i + 1; j < headers.length; j++) {
-      const succ = headers[j];
-      if (succ.outcome !== "implement") continue;
-      if (succ.tags.length === 0) continue;
-      const intersects = succ.tags.some((t) => lessonTags.has(t));
-      if (intersects) overlaps += 1;
-      if (overlaps >= k) break;
-    }
-    if (overlaps >= k) drop.push(i);
-  }
-  return { drop, all: headers };
+  return decideExpiryWithPolicies(headers, [
+    {
+      kind: "failure-lesson",
+      k,
+      supersededBy: ["implement"],
+      overlap: { mode: "any-shared-tag" },
+    },
+  ]);
 }
 
 export interface ExpireResult {
@@ -129,21 +189,21 @@ export interface ExpireResult {
 }
 
 /**
- * Walk the agent's CLAUDE.md content, drop expired failure-lesson blocks,
- * and return the rewritten content. Idempotent — re-applying on the
- * returned content with the same `k` drops nothing.
+ * Walk content, drop expired sentinel blocks per the supplied policies,
+ * return the rewritten content. Idempotent — re-applying on already-pruned
+ * content with the same policies drops nothing.
  */
-export function expireFailureLessonsInContent(
+export function expireSentinelsInContent(
   content: string,
-  k: number,
+  policies: ExpiryPolicy[],
 ): ExpireResult {
   const lines = content.split("\n");
   const located = locateSentinels(lines);
   if (located.length === 0) return { content, droppedHeaders: [] };
 
-  const decision = decideExpiry(
+  const decision = decideExpiryWithPolicies(
     located.map((l) => l.header),
-    k,
+    policies,
   );
   if (decision.drop.length === 0) return { content, droppedHeaders: [] };
 
@@ -176,17 +236,116 @@ export function expireFailureLessonsInContent(
 }
 
 /**
- * Resolve `K` from env (`VP_DEV_FAILURE_LESSON_EXPIRE_K`) with a default
- * of 3. Non-positive / non-numeric env values fall back to the default
- * rather than disabling expiry silently — set the env to a large number
- * to effectively disable.
+ * Backward-compatible wrapper: drop expired `failure-lesson` blocks using
+ * the legacy single-K rule. Delegates to `expireSentinelsInContent` with
+ * the failure-lesson policy only.
+ */
+export function expireFailureLessonsInContent(
+  content: string,
+  k: number,
+): ExpireResult {
+  return expireSentinelsInContent(content, [
+    {
+      kind: "failure-lesson",
+      k,
+      supersededBy: ["implement"],
+      overlap: { mode: "any-shared-tag" },
+    },
+  ]);
+}
+
+/**
+ * Defaults for per-kind expiry. Failure-lessons stay at K=3 (cheap signal
+ * superseded by even one overlapping success). Success-lessons need a
+ * higher K=5 because they're individually weaker signals — and use Jaccard
+ * ≥ 0.5 so a barely-overlapping later success doesn't supersede a
+ * topically-distinct earlier one. Pushback lessons are preserved
+ * indefinitely (Infinity) — they capture push-back-worthy patterns and
+ * aren't superseded by a single newer pushback.
  */
 export const DEFAULT_FAILURE_LESSON_EXPIRE_K = 3;
+export const DEFAULT_SUCCESS_LESSON_EXPIRE_K = 5;
+export const DEFAULT_PUSHBACK_LESSON_EXPIRE_K = Number.POSITIVE_INFINITY;
 
-export function resolveExpireK(env: NodeJS.ProcessEnv = process.env): number {
-  const raw = env.VP_DEV_FAILURE_LESSON_EXPIRE_K;
-  if (raw == null || raw === "") return DEFAULT_FAILURE_LESSON_EXPIRE_K;
+function parseEnvFiniteK(
+  raw: string | undefined,
+  fallback: number,
+): number {
+  if (raw == null || raw === "") return fallback;
   const n = Number(raw);
-  if (!Number.isFinite(n) || n <= 0) return DEFAULT_FAILURE_LESSON_EXPIRE_K;
+  if (!Number.isFinite(n) || n <= 0) return fallback;
   return Math.floor(n);
+}
+
+function parseEnvKAllowInfinity(
+  raw: string | undefined,
+  fallback: number,
+): number {
+  if (raw == null || raw === "") return fallback;
+  const trimmed = raw.trim().toLowerCase();
+  if (trimmed === "infinity" || trimmed === "off" || trimmed === "disabled") {
+    return Number.POSITIVE_INFINITY;
+  }
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return Math.floor(n);
+}
+
+/**
+ * Resolve `K` for the failure-lesson policy from env
+ * (`VP_DEV_FAILURE_LESSON_EXPIRE_K`) with a default of 3. Non-positive /
+ * non-numeric env values fall back to the default rather than disabling
+ * expiry silently — set the env to a large number to effectively disable.
+ *
+ * Kept for backward compatibility; new callers should prefer
+ * `resolveExpiryPolicies()` which covers all sentinel kinds.
+ */
+export function resolveExpireK(env: NodeJS.ProcessEnv = process.env): number {
+  return parseEnvFiniteK(
+    env.VP_DEV_FAILURE_LESSON_EXPIRE_K,
+    DEFAULT_FAILURE_LESSON_EXPIRE_K,
+  );
+}
+
+/**
+ * Resolve the full set of per-kind expiry policies from environment
+ * variables, with sane defaults. Knobs:
+ *   - VP_DEV_FAILURE_LESSON_EXPIRE_K (default 3)
+ *   - VP_DEV_SUCCESS_LESSON_EXPIRE_K (default 5)
+ *   - VP_DEV_PUSHBACK_LESSON_EXPIRE_K (default Infinity / disabled;
+ *     accepts a positive integer to enable, or "off"/"disabled"/
+ *     "infinity" to disable explicitly)
+ */
+export function resolveExpiryPolicies(
+  env: NodeJS.ProcessEnv = process.env,
+): ExpiryPolicy[] {
+  return [
+    {
+      kind: "failure-lesson",
+      k: parseEnvFiniteK(
+        env.VP_DEV_FAILURE_LESSON_EXPIRE_K,
+        DEFAULT_FAILURE_LESSON_EXPIRE_K,
+      ),
+      supersededBy: ["implement"],
+      overlap: { mode: "any-shared-tag" },
+    },
+    {
+      kind: "implement",
+      k: parseEnvFiniteK(
+        env.VP_DEV_SUCCESS_LESSON_EXPIRE_K,
+        DEFAULT_SUCCESS_LESSON_EXPIRE_K,
+      ),
+      supersededBy: ["implement"],
+      overlap: { mode: "jaccard", minScore: 0.5 },
+    },
+    {
+      kind: "pushback",
+      k: parseEnvKAllowInfinity(
+        env.VP_DEV_PUSHBACK_LESSON_EXPIRE_K,
+        DEFAULT_PUSHBACK_LESSON_EXPIRE_K,
+      ),
+      supersededBy: ["pushback"],
+      overlap: { mode: "any-shared-tag" },
+    },
+  ];
 }


### PR DESCRIPTION
Closes #97

## Summary

Generalizes the failure-lesson-only expiry rule from PR #75 into a per-kind `ExpiryPolicy` model. Each sentinel kind names its own K, supersession sources, and tag-overlap rule. The new `decideExpiryWithPolicies` / `expireSentinelsInContent` functions are policy-driven; `decideExpiry` and `expireFailureLessonsInContent` are kept as thin backward-compat wrappers so existing tests pass unmodified.

## Per-kind defaults

- **`failure-lesson`**: K=3, superseded by `implement`, any-shared-tag overlap (unchanged from PR #75).
- **`implement`**: K=5, superseded by `implement`, **Jaccard ≥ 0.5** — barely-overlapping later successes don't supersede topically-distinct earlier ones.
- **`pushback`**: K=∞, superseded by `pushback`, any-shared-tag — preserved indefinitely by default; pushback lessons aren't superseded by a single newer pushback.

## Env knobs

- `VP_DEV_FAILURE_LESSON_EXPIRE_K` (default 3, unchanged).
- `VP_DEV_SUCCESS_LESSON_EXPIRE_K` (default 5).
- `VP_DEV_PUSHBACK_LESSON_EXPIRE_K` (default Infinity / disabled). Accepts a positive integer to enable, or `off`/`disabled`/`infinity` to disable explicitly. Garbage falls back to default.

## Wiring

- `runIssueCore` now calls `expireSentinels(agentId, resolveExpiryPolicies())` after every successful implement run, replacing the failure-lesson-only call. Logged kinds and counts are surfaced in the `specialization.expired` log line.
- The legacy entry points (`decideExpiry`, `expireFailureLessonsInContent`, `expireFailureLessons`, `resolveExpireK`) are preserved as wrappers — they delegate to the generalized API with the failure-lesson policy.

## Test plan

- [x] `npm run build` clean (tsc).
- [x] `npm test` — 100 tests pass (15 pre-existing tests untouched, 15 new tests for the generalized API including Jaccard overlap, infinity-K preservation, env-driven policies, idempotence, and combined cross-kind boundaries).
- [x] Verified backward compat: `decideExpiry(headers, k)` / `expireFailureLessonsInContent(content, k)` produce identical results for the existing fixtures.

## Out of scope (per the issue)

- Re-summarization of dropped lesson content.
- LLM-driven semantic dedup (heuristic stays).
- Cross-agent lesson de-duplication (covered by #33 / #81).

— Rogue Component Trust Isolation (agent-6100)
