### PR TITLE
feat(lessons): cross-target-repo shared-lessons tier (#101)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "typecheck": "tsc --noEmit",
-    "test": "tsc && node --test dist/src/util/*.test.js dist/src/git/*.test.js dist/src/orchestrator/*.test.js",
+    "test": "tsc && node --test dist/src/util/*.test.js dist/src/git/*.test.js dist/src/orchestrator/*.test.js dist/src/agent/*.test.js",
     "vp-dev": "node dist/bin/vp-dev.js"
   },
   "dependencies": {

--- a/src/agent/promotion.ts
+++ b/src/agent/promotion.ts
@@ -9,6 +9,7 @@ import { promises as fs } from "node:fs";
 import {
   appendLessonToPool,
   type AppendLessonOutcome,
+  type LessonTier,
 } from "./sharedLessons.js";
 import { agentClaudeMdPath } from "./specialization.js";
 import { withFileLock } from "../state/locks.js";
@@ -78,11 +79,20 @@ export interface AcceptResult {
  */
 export async function acceptCandidate(input: {
   pending: PendingCandidate;
+  /**
+   * Destination tier for the accepted entry. "target" appends to
+   * `agents/.shared/lessons/<domain>.md`; "global" appends to the
+   * cross-target-repo pool under `~/.vaultpilot/shared-lessons/<domain>.md`.
+   * The source-CLAUDE.md sentinel rewrite is the same for both — only the
+   * write target differs (#101).
+   */
+  tier: LessonTier;
   ts?: string;
   issueId?: number;
 }): Promise<AcceptResult> {
   const ts = input.ts ?? new Date().toISOString();
   const appendOutcome = await appendLessonToPool({
+    tier: input.tier,
     domain: input.pending.candidate.domain,
     body: input.pending.candidate.body,
     sourceAgentId: input.pending.agentId,

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -27,12 +27,20 @@ export async function buildAgentSystemPrompt(opts: {
     issueId: opts.workflow.issueId,
   });
 
-  // Cross-agent shared lessons (#33). Pulled from `agents/.shared/lessons/`,
-  // matched against the agent's current tag fingerprint. Each pool file is
-  // capped at MAX_POOL_LINES so multi-tag agents stay bounded. Maintained by
-  // the orchestrator via `vp-dev lessons review`; never written by the
-  // coding agent — see the workflow guard in `workflow.ts`.
-  const sharedLessons = await readSharedLessonsForDomains(opts.agent.tags);
+  // Cross-agent shared lessons. Pulled per-tier and matched against the
+  // agent's current tag fingerprint. Each pool file is capped at
+  // MAX_POOL_LINES so multi-tag agents stay bounded. Maintained by the
+  // orchestrator via `vp-dev lessons review` (target tier, #33) and
+  // `vp-dev lessons review --global` (cross-target-repo tier, #101); never
+  // written by the coding agent — see the workflow guard in `workflow.ts`.
+  //
+  // Read order is global-first so per-target-repo lessons appear closer to
+  // the workflow and dominate when a domain has content in both tiers
+  // (later sections in the prompt are read more recently in context).
+  const [globalLessons, targetLessons] = await Promise.all([
+    readSharedLessonsForDomains("global", opts.agent.tags),
+    readSharedLessonsForDomains("target", opts.agent.tags),
+  ]);
 
   const sections: string[] = [
     "# Project rules (live target-repo CLAUDE.md — current as of this dispatch)",
@@ -47,19 +55,30 @@ export async function buildAgentSystemPrompt(opts: {
     "",
   ];
 
-  if (sharedLessons.length > 0) {
-    for (const pool of sharedLessons) {
-      sections.push(
-        "---",
-        "",
-        `## Shared lessons (${pool.domain})`,
-        "",
-        "Cross-agent observations curated by the orchestrator. Read-only — do NOT modify or copy back into your own CLAUDE.md.",
-        "",
-        pool.content.trim(),
-        "",
-      );
-    }
+  for (const pool of globalLessons) {
+    sections.push(
+      "---",
+      "",
+      `## Shared lessons (${pool.domain}, global)`,
+      "",
+      "Cross-target-repo observations curated by the orchestrator. Read-only — do NOT modify or copy back into your own CLAUDE.md.",
+      "",
+      pool.content.trim(),
+      "",
+    );
+  }
+
+  for (const pool of targetLessons) {
+    sections.push(
+      "---",
+      "",
+      `## Shared lessons (${pool.domain})`,
+      "",
+      "Cross-agent observations curated by the orchestrator (per-target-repo pool). Read-only — do NOT modify or copy back into your own CLAUDE.md.",
+      "",
+      pool.content.trim(),
+      "",
+    );
   }
 
   if (plan) {

--- a/src/agent/sharedLessons.test.ts
+++ b/src/agent/sharedLessons.test.ts
@@ -1,0 +1,168 @@
+// File-system tests for the two-tier shared-lessons pool (#101). Uses
+// process.env overrides + a tmp `XDG_CONFIG_HOME` so the global tier
+// resolves under a sandbox dir rather than the user's real home.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  appendLessonToPool,
+  listSharedLessonDomains,
+  readSharedLessonsForDomains,
+  sharedLessonsDir,
+  sharedLessonsPath,
+} from "./sharedLessons.js";
+
+async function withSandbox(fn: (sandbox: string) => Promise<void>): Promise<void> {
+  const sandbox = await fs.mkdtemp(path.join(os.tmpdir(), "vp-shared-lessons-"));
+  const prevXdg = process.env.XDG_CONFIG_HOME;
+  process.env.XDG_CONFIG_HOME = sandbox;
+  try {
+    await fn(sandbox);
+  } finally {
+    if (prevXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = prevXdg;
+    await fs.rm(sandbox, { recursive: true, force: true });
+  }
+}
+
+test("sharedLessonsDir: global tier honours XDG_CONFIG_HOME", async () => {
+  await withSandbox(async (sandbox) => {
+    const dir = sharedLessonsDir("global");
+    assert.equal(dir, path.join(sandbox, "vaultpilot", "shared-lessons"));
+  });
+});
+
+test("sharedLessonsDir: target tier is independent of XDG", async () => {
+  await withSandbox(async () => {
+    const dir = sharedLessonsDir("target");
+    assert.ok(
+      dir.endsWith(path.join("agents", ".shared", "lessons")),
+      `target tier should sit under agents/.shared/lessons, got ${dir}`,
+    );
+  });
+});
+
+test("sharedLessonsPath: rejects invalid domain shape", () => {
+  assert.throws(() => sharedLessonsPath("global", "Solana"));
+  assert.throws(() => sharedLessonsPath("global", ""));
+  assert.throws(() => sharedLessonsPath("target", "foo_bar"));
+});
+
+test("appendLessonToPool: writes to global tier when tier='global'", async () => {
+  await withSandbox(async (sandbox) => {
+    const outcome = await appendLessonToPool({
+      tier: "global",
+      domain: "solana",
+      body: "ERC observation: descriptive lesson body about Solana.",
+      sourceAgentId: "agent-test",
+      issueId: 101,
+      ts: "2026-05-05T00:00:00.000Z",
+    });
+    assert.equal(outcome.kind, "appended");
+    if (outcome.kind === "appended") {
+      assert.equal(outcome.tier, "global");
+      assert.ok(
+        outcome.filePath.startsWith(path.join(sandbox, "vaultpilot", "shared-lessons")),
+        `expected global path under sandbox, got ${outcome.filePath}`,
+      );
+      const content = await fs.readFile(outcome.filePath, "utf-8");
+      assert.match(content, /Shared lessons: solana \(global\)/);
+      assert.match(content, /descriptive lesson body about Solana/);
+    }
+  });
+});
+
+test("appendLessonToPool: rejects validation failure (empty body) without writing", async () => {
+  await withSandbox(async () => {
+    const outcome = await appendLessonToPool({
+      tier: "global",
+      domain: "solana",
+      body: "   \n  \n",
+      sourceAgentId: "agent-test",
+      issueId: 101,
+    });
+    assert.equal(outcome.kind, "rejected-validation");
+  });
+});
+
+test("readSharedLessonsForDomains: tier isolation — global write is invisible to target read", async () => {
+  await withSandbox(async () => {
+    await appendLessonToPool({
+      tier: "global",
+      domain: "eip-712",
+      body: "Typed-data digest must be recomputed locally before signing.",
+      sourceAgentId: "agent-test",
+      issueId: 101,
+      ts: "2026-05-05T00:00:00.000Z",
+    });
+    const globalRead = await readSharedLessonsForDomains("global", ["eip-712"]);
+    assert.equal(globalRead.length, 1);
+    assert.equal(globalRead[0].tier, "global");
+    assert.equal(globalRead[0].domain, "eip-712");
+
+    // Target tier path lives under cwd/agents/.shared/lessons — it has no
+    // `eip-712.md` file in the worktree's gitignored agents/ dir for this
+    // test. Either the file is missing entirely (ENOENT) or it exists from
+    // some prior fixture but doesn't carry the body we just wrote globally.
+    const targetRead = await readSharedLessonsForDomains("target", ["eip-712"]);
+    for (const pool of targetRead) {
+      assert.doesNotMatch(
+        pool.content,
+        /Typed-data digest must be recomputed locally before signing/,
+        "global-tier append should not leak into target-tier reads",
+      );
+    }
+  });
+});
+
+test("listSharedLessonDomains: returns ENOENT-empty list when global dir does not exist", async () => {
+  await withSandbox(async () => {
+    // Sandbox is fresh; no shared-lessons dir created. Should be silent [].
+    const pools = await listSharedLessonDomains("global");
+    assert.deepEqual(pools, []);
+  });
+});
+
+test("listSharedLessonDomains: surfaces written global-tier pools with tier label", async () => {
+  await withSandbox(async () => {
+    await appendLessonToPool({
+      tier: "global",
+      domain: "aave",
+      body: "Aave v3 caps borrow at debt ceiling — check before tx prep.",
+      sourceAgentId: "agent-test",
+      issueId: 101,
+      ts: "2026-05-05T00:00:00.000Z",
+    });
+    const pools = await listSharedLessonDomains("global");
+    assert.equal(pools.length, 1);
+    assert.equal(pools[0].tier, "global");
+    assert.equal(pools[0].domain, "aave");
+    assert.ok(pools[0].totalLines > 1);
+  });
+});
+
+test("readSharedLessonsForDomains: filters invalid domains and dedups", async () => {
+  await withSandbox(async () => {
+    await appendLessonToPool({
+      tier: "global",
+      domain: "solana",
+      body: "Sample portable lesson about Solana.",
+      sourceAgentId: "agent-test",
+      issueId: 101,
+      ts: "2026-05-05T00:00:00.000Z",
+    });
+    // Pass invalid domain + duplicate; expect a single entry back.
+    const out = await readSharedLessonsForDomains("global", [
+      "Solana",
+      "solana",
+      "solana",
+      "",
+      "foo_bar",
+    ]);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].domain, "solana");
+  });
+});

--- a/src/agent/sharedLessons.ts
+++ b/src/agent/sharedLessons.ts
@@ -2,17 +2,26 @@
 // via curated promotion (`vp-dev lessons review`). See feature plan in
 // `feature-plans/issue-33-shared-lessons-pool.md`.
 //
-// Layout: `agents/.shared/lessons/<domain>.md`. Domain == any tag the
-// agent fingerprint exposes (lowercase, dash-separated, e.g. `solana`,
-// `eip-712`). The directory lives under the same `agents/` tree that is
-// already gitignored, so pool files never leak into the target repo.
+// Two tiers (#101):
+//   - "target": `agents/.shared/lessons/<domain>.md` — local to the per-target
+//     working tree. Same gitignored `agents/` root as per-agent CLAUDE.md, so
+//     pool files never leak into the target repo.
+//   - "global": `$XDG_CONFIG_HOME/vaultpilot/shared-lessons/<domain>.md`
+//     (fallback `~/.vaultpilot/shared-lessons/`) — survives across target
+//     repos. Domain knowledge that's portable (Solana RPC quirks, ERC-4626
+//     semantics, ethers v5/v6 drift) belongs here; rules unique to one
+//     target repo's runtime stay on the target tier.
+//
+// Domain == any tag the agent fingerprint exposes (lowercase, dash-separated,
+// e.g. `solana`, `eip-712`).
 //
 // Boundary preservation: appendLessonToPool is invoked exclusively by the
 // orchestrator-side review CLI. The coding-agent workflow (`renderWorkflow`
 // in `workflow.ts`) carries an explicit "never write to agents/.shared/"
-// guard, and the agent's worktree CWD is outside this path anyway.
+// guard, and the agent's worktree CWD is outside both tier paths anyway.
 
 import { promises as fs } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { ensureDir, withFileLock } from "../state/locks.js";
 import { AGENTS_ROOT } from "./specialization.js";
@@ -22,7 +31,23 @@ import {
   type ValidationResult,
 } from "../util/promotionMarkers.js";
 
-export const SHARED_LESSONS_DIR = path.join(AGENTS_ROOT, ".shared", "lessons");
+export type LessonTier = "target" | "global";
+
+const PER_TARGET_DIR = path.join(AGENTS_ROOT, ".shared", "lessons");
+
+/**
+ * Resolve the directory backing a tier. Lazy on `XDG_CONFIG_HOME` /
+ * `os.homedir()` so test harnesses can override `process.env.HOME` /
+ * `XDG_CONFIG_HOME` without monkey-patching the module.
+ */
+export function sharedLessonsDir(tier: LessonTier): string {
+  if (tier === "target") return PER_TARGET_DIR;
+  const xdg = process.env.XDG_CONFIG_HOME;
+  if (xdg && xdg.length > 0) {
+    return path.join(xdg, "vaultpilot", "shared-lessons");
+  }
+  return path.join(os.homedir(), ".vaultpilot", "shared-lessons");
+}
 
 /**
  * Pool-file size cap. Once exceeded, append refuses with a "trim first"
@@ -31,24 +56,26 @@ export const SHARED_LESSONS_DIR = path.join(AGENTS_ROOT, ".shared", "lessons");
  */
 export const MAX_POOL_LINES = 200;
 
-export function sharedLessonsPath(domain: string): string {
+export function sharedLessonsPath(tier: LessonTier, domain: string): string {
   if (!isValidDomain(domain)) {
     throw new Error(`Invalid domain '${domain}': expected lowercase dash-separated tag.`);
   }
-  return path.join(SHARED_LESSONS_DIR, `${domain}.md`);
+  return path.join(sharedLessonsDir(tier), `${domain}.md`);
 }
 
 export interface PoolSummary {
+  tier: LessonTier;
   domain: string;
   filePath: string;
   totalLines: number;
   bytes: number;
 }
 
-export async function listSharedLessonDomains(): Promise<PoolSummary[]> {
+export async function listSharedLessonDomains(tier: LessonTier): Promise<PoolSummary[]> {
+  const dir = sharedLessonsDir(tier);
   let entries: string[];
   try {
-    entries = await fs.readdir(SHARED_LESSONS_DIR);
+    entries = await fs.readdir(dir);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
     throw err;
@@ -58,10 +85,11 @@ export async function listSharedLessonDomains(): Promise<PoolSummary[]> {
     if (!e.endsWith(".md")) continue;
     const domain = e.slice(0, -3);
     if (!isValidDomain(domain)) continue;
-    const filePath = path.join(SHARED_LESSONS_DIR, e);
+    const filePath = path.join(dir, e);
     try {
       const content = await fs.readFile(filePath, "utf-8");
       out.push({
+        tier,
         domain,
         filePath,
         totalLines: content.split("\n").length,
@@ -75,6 +103,7 @@ export async function listSharedLessonDomains(): Promise<PoolSummary[]> {
 }
 
 export interface DomainContent {
+  tier: LessonTier;
   domain: string;
   content: string;
 }
@@ -86,6 +115,7 @@ export interface DomainContent {
  * deterministic.
  */
 export async function readSharedLessonsForDomains(
+  tier: LessonTier,
   domains: string[],
 ): Promise<DomainContent[]> {
   const out: DomainContent[] = [];
@@ -94,9 +124,9 @@ export async function readSharedLessonsForDomains(
     if (!isValidDomain(domain) || seen.has(domain)) continue;
     seen.add(domain);
     try {
-      const content = await fs.readFile(sharedLessonsPath(domain), "utf-8");
+      const content = await fs.readFile(sharedLessonsPath(tier, domain), "utf-8");
       if (content.trim().length > 0) {
-        out.push({ domain, content });
+        out.push({ tier, domain, content });
       }
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
@@ -106,6 +136,7 @@ export async function readSharedLessonsForDomains(
 }
 
 export interface AppendLessonInput {
+  tier: LessonTier;
   domain: string;
   body: string;
   sourceAgentId: string;
@@ -114,8 +145,8 @@ export interface AppendLessonInput {
 }
 
 export type AppendLessonOutcome =
-  | { kind: "appended"; totalLines: number; filePath: string }
-  | { kind: "rejected-pool-full"; totalLines: number; filePath: string }
+  | { kind: "appended"; tier: LessonTier; totalLines: number; filePath: string }
+  | { kind: "rejected-pool-full"; tier: LessonTier; totalLines: number; filePath: string }
   | { kind: "rejected-validation"; validation: ValidationResult };
 
 export async function appendLessonToPool(
@@ -126,9 +157,10 @@ export async function appendLessonToPool(
     return { kind: "rejected-validation", validation };
   }
   const ts = input.ts ?? new Date().toISOString();
-  const filePath = sharedLessonsPath(input.domain);
+  const dir = sharedLessonsDir(input.tier);
+  const filePath = sharedLessonsPath(input.tier, input.domain);
   return withFileLock(filePath, async () => {
-    await ensureDir(SHARED_LESSONS_DIR);
+    await ensureDir(dir);
     let current = "";
     try {
       current = await fs.readFile(filePath, "utf-8");
@@ -136,7 +168,7 @@ export async function appendLessonToPool(
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
     }
     if (current.length === 0) {
-      current = poolHeader(input.domain);
+      current = poolHeader(input.tier, input.domain);
     }
     const entry = formatEntryBlock({
       sourceAgentId: input.sourceAgentId,
@@ -147,23 +179,27 @@ export async function appendLessonToPool(
     const next = current.endsWith("\n") ? current + entry : current + "\n" + entry;
     const totalLines = next.split("\n").length;
     if (totalLines > MAX_POOL_LINES) {
-      return { kind: "rejected-pool-full", totalLines, filePath };
+      return { kind: "rejected-pool-full", tier: input.tier, totalLines, filePath };
     }
     const tmp = `${filePath}.tmp.${process.pid}`;
     await fs.writeFile(tmp, next);
     await fs.rename(tmp, filePath);
-    return { kind: "appended", totalLines, filePath };
+    return { kind: "appended", tier: input.tier, totalLines, filePath };
   });
 }
 
-function poolHeader(domain: string): string {
+function poolHeader(tier: LessonTier, domain: string): string {
+  const tierBlurb =
+    tier === "global"
+      ? "Portable across target repos — promoted via `vp-dev lessons review --global`."
+      : "Local to this target repo's working tree — promoted via `vp-dev lessons review`.";
   return [
-    `# Shared lessons: ${domain}`,
+    `# Shared lessons: ${domain} (${tier})`,
     "",
     `Curated cross-agent lessons for the \`${domain}\` domain. Read-only at`,
-    "agent runtime; entries promoted via `vp-dev lessons review` after the",
-    "human reviewer accepts a `<!-- promote-candidate -->` block from a",
-    "sibling agent's CLAUDE.md.",
+    "agent runtime; entries promoted after the human reviewer accepts a",
+    "`<!-- promote-candidate -->` block from a sibling agent's CLAUDE.md.",
+    tierBlurb,
     "",
     "",
   ].join("\n");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -65,6 +65,7 @@ import {
 import {
   listSharedLessonDomains,
   MAX_POOL_LINES,
+  type LessonTier,
 } from "./agent/sharedLessons.js";
 import {
   loadAllOutcomes,
@@ -222,17 +223,19 @@ export function buildCli(): Command {
     .description("Cross-agent shared lessons pool: list pool files + review promote-candidate blocks queued by the summarizer")
     .addCommand(
       new Command("list")
-        .description("List all shared-lesson pool files (agents/.shared/lessons/) with size + line count")
+        .description("List shared-lesson pool files (agents/.shared/lessons/ by default; --global for ~/.vaultpilot/shared-lessons/) with size + line count")
         .option("--json", "Print machine-readable JSON")
+        .option("--global", "Inspect the cross-target-repo global pool (~/.vaultpilot/shared-lessons/) instead of the per-target pool")
         .action(async (opts) => {
           await cmdLessonsList(opts);
         }),
     )
     .addCommand(
       new Command("review")
-        .description("Walk every agent's CLAUDE.md for `<!-- promote-candidate:<domain> -->` blocks and accept/reject each interactively")
+        .description("Walk every agent's CLAUDE.md for `<!-- promote-candidate:<domain> -->` blocks and accept/reject each interactively. --global routes accepted entries to the cross-target-repo pool.")
         .option("--json", "Print machine-readable JSON listing of pending candidates and exit (no mutation)")
         .option("--yes", "Auto-accept every candidate that passes validation (non-interactive use only)")
+        .option("--global", "Append accepted entries to the global pool (~/.vaultpilot/shared-lessons/) instead of the per-target pool")
         .action(async (opts) => {
           await cmdLessonsReview(opts);
         }),
@@ -1279,20 +1282,26 @@ async function cmdAgentsStats(opts: AgentsStatsOpts): Promise<void> {
 
 interface LessonsListOpts {
   json?: boolean;
+  global?: boolean;
 }
 
 async function cmdLessonsList(opts: LessonsListOpts): Promise<void> {
-  const pools = await listSharedLessonDomains();
+  const tier: LessonTier = opts.global ? "global" : "target";
+  const pools = await listSharedLessonDomains(tier);
   if (opts.json) {
-    process.stdout.write(JSON.stringify({ pools, maxPoolLines: MAX_POOL_LINES }, null, 2) + "\n");
-    return;
-  }
-  if (pools.length === 0) {
     process.stdout.write(
-      "No shared-lesson pools yet. Run `vp-dev lessons review` after a summarizer pass tags a promote-candidate.\n",
+      JSON.stringify({ tier, pools, maxPoolLines: MAX_POOL_LINES }, null, 2) + "\n",
     );
     return;
   }
+  if (pools.length === 0) {
+    const reviewHint = opts.global ? "vp-dev lessons review --global" : "vp-dev lessons review";
+    process.stdout.write(
+      `No ${tier} shared-lesson pools yet. Run \`${reviewHint}\` after a summarizer pass tags a promote-candidate.\n`,
+    );
+    return;
+  }
+  process.stdout.write(`tier: ${tier}\n`);
   const headers = ["domain", "lines", "bytes", "path"];
   const rows = pools.map((p) => [
     p.domain,
@@ -1306,9 +1315,11 @@ async function cmdLessonsList(opts: LessonsListOpts): Promise<void> {
 interface LessonsReviewOpts {
   json?: boolean;
   yes?: boolean;
+  global?: boolean;
 }
 
 async function cmdLessonsReview(opts: LessonsReviewOpts): Promise<void> {
+  const tier: LessonTier = opts.global ? "global" : "target";
   const reg = await loadRegistry();
   // Don't filter archived agents — the candidate may have been tagged before
   // a split, and we still want to surface it. The boundary that matters is
@@ -1319,6 +1330,7 @@ async function cmdLessonsReview(opts: LessonsReviewOpts): Promise<void> {
     process.stdout.write(
       JSON.stringify(
         {
+          tier,
           pending: pending.map((p) => ({
             agentId: p.agentId,
             agentName: p.agentName,
@@ -1341,10 +1353,13 @@ async function cmdLessonsReview(opts: LessonsReviewOpts): Promise<void> {
     return;
   }
 
-  process.stdout.write(`${pending.length} promote-candidate block(s) pending review.\n\n`);
+  const tierLabel = tier === "global" ? "global (~/.vaultpilot/shared-lessons/)" : "per-target (agents/.shared/lessons/)";
+  process.stdout.write(
+    `${pending.length} promote-candidate block(s) pending review. Accepting writes to: ${tierLabel}\n\n`,
+  );
 
   if (opts.yes) {
-    await runAutoAcceptLoop(pending);
+    await runAutoAcceptLoop(pending, tier);
     return;
   }
 
@@ -1355,10 +1370,10 @@ async function cmdLessonsReview(opts: LessonsReviewOpts): Promise<void> {
     process.exit(2);
   }
 
-  await runInteractiveReview(pending);
+  await runInteractiveReview(pending, tier);
 }
 
-async function runAutoAcceptLoop(pending: PendingCandidate[]): Promise<void> {
+async function runAutoAcceptLoop(pending: PendingCandidate[], tier: LessonTier): Promise<void> {
   let acceptedCount = 0;
   let rejectedCount = 0;
   let skippedCount = 0;
@@ -1370,15 +1385,15 @@ async function runAutoAcceptLoop(pending: PendingCandidate[]): Promise<void> {
       rejectedCount += 1;
       continue;
     }
-    const result = await acceptCandidate({ pending: p });
+    const result = await acceptCandidate({ pending: p, tier });
     if (result.appendOutcome.kind === "appended") {
       process.stdout.write(
-        `accepted ${p.agentId} -> ${p.candidate.domain} (${result.appendOutcome.totalLines}/${MAX_POOL_LINES} lines)\n`,
+        `accepted [${tier}] ${p.agentId} -> ${p.candidate.domain} (${result.appendOutcome.totalLines}/${MAX_POOL_LINES} lines)\n`,
       );
       acceptedCount += 1;
     } else if (result.appendOutcome.kind === "rejected-pool-full") {
       process.stdout.write(
-        `skipped (pool full) ${p.agentId} -> ${p.candidate.domain}: ${result.appendOutcome.totalLines}/${MAX_POOL_LINES} lines. Trim the pool by hand and re-run review.\n`,
+        `skipped (pool full) [${tier}] ${p.agentId} -> ${p.candidate.domain}: ${result.appendOutcome.totalLines}/${MAX_POOL_LINES} lines. Trim the pool by hand and re-run review.\n`,
       );
       skippedCount += 1;
     } else {
@@ -1393,7 +1408,7 @@ async function runAutoAcceptLoop(pending: PendingCandidate[]): Promise<void> {
   );
 }
 
-async function runInteractiveReview(pending: PendingCandidate[]): Promise<void> {
+async function runInteractiveReview(pending: PendingCandidate[], tier: LessonTier): Promise<void> {
   const { createInterface } = await import("node:readline/promises");
   const rl = createInterface({ input: process.stdin, output: process.stdout });
   let acceptedCount = 0;
@@ -1426,10 +1441,10 @@ async function runInteractiveReview(pending: PendingCandidate[]): Promise<void> 
           skippedCount += 1;
           continue;
         }
-        const result = await acceptCandidate({ pending: p });
+        const result = await acceptCandidate({ pending: p, tier });
         if (result.appendOutcome.kind === "appended") {
           process.stdout.write(
-            `Accepted: appended to ${result.appendOutcome.filePath} (${result.appendOutcome.totalLines}/${MAX_POOL_LINES} lines).\n`,
+            `Accepted [${tier}]: appended to ${result.appendOutcome.filePath} (${result.appendOutcome.totalLines}/${MAX_POOL_LINES} lines).\n`,
           );
           acceptedCount += 1;
         } else if (result.appendOutcome.kind === "rejected-pool-full") {


### PR DESCRIPTION
Closes #101.

Adds a cross-target-repo "global" tier to the shared-lessons pool so portable domain knowledge (Solana RPC quirks, ERC-4626 semantics, ethers v5/v6 drift) survives moves between target repos. The per-target tier from PR #81 is unchanged; promotion to either tier stays human-gated.

## Summary

- New `LessonTier = "target" | "global"` in `src/agent/sharedLessons.ts`. Global tier lives at `$XDG_CONFIG_HOME/vaultpilot/shared-lessons/<domain>.md` (fallback `~/.vaultpilot/shared-lessons/`); target tier unchanged at `agents/.shared/lessons/`.
- `vp-dev lessons review --global` and `vp-dev lessons list --global` route to the global tier. Default stays per-target — same human gate, same per-entry length cap, same `MAX_POOL_LINES` cap.
- `buildAgentSystemPrompt()` reads both tiers per-domain. Global lessons render first under heading `## Shared lessons (<domain>, global)`; per-target render second under the existing `## Shared lessons (<domain>)`. Per-target sits closer to the workflow so it dominates when both tiers carry the same domain.
- `acceptCandidate({ tier })` plumbs the choice through to `appendLessonToPool`. `rejectCandidate` is unchanged — rejection only rewrites the source-CLAUDE.md sentinel and has no destination tier (matching the simpler "review once, pick destination, done" model; if a candidate is rejected for one tier, it's rejected for both, and re-promotion requires re-opening the marker by hand).
- Coding-agent boundary preserved: `appendLessonToPool` is invoked exclusively by the orchestrator-side review CLI; the workflow guard in `workflow.ts` already forbids agent writes to `agents/.shared/`, and the global tier sits outside the worktree entirely.

## Read order

`buildAgentSystemPrompt()` now layers:

1. Live target-repo `CLAUDE.md`
2. Per-agent `CLAUDE.md` (deduped)
3. Global shared lessons (NEW, per-domain)
4. Per-target shared lessons (existing, per-domain)
5. Plan file (when present)
6. Workflow

## Out of scope (per issue)

- Auto-syncing the global tier to a remote git repo. Users who want sync can `git init` the directory themselves.
- Auto-mirroring promoted entries from per-target up to global. Promotion stays explicit via the `--global` flag.
- Domain-disambiguation between target repos using the same name. Convention: domain names should be portable (`solana`, `erc-4626`) rather than target-specific.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 94 tests pass (existing 85 + 9 new in `src/agent/sharedLessons.test.ts` covering XDG honor, tier dispatch, ENOENT-empty list, validation refusal, tier isolation between global writes and target reads, domain dedup/filter)
- [x] `node dist/bin/vp-dev.js lessons list --global --json` returns `{"tier":"global","pools":[]}` on a fresh sandbox
- [x] `--global` surfaces in `lessons list --help` and `lessons review --help`
- [ ] Manual smoke: tag a `<!-- promote-candidate:solana -->` block in an agent CLAUDE.md, run `vp-dev lessons review --global --yes`, confirm `~/.vaultpilot/shared-lessons/solana.md` gets the entry and source CLAUDE.md gets the `<!-- promoted:solana:... -->` rewrite
- [ ] Manual smoke: dispatch any agent with `solana` in tags, capture seed, confirm `## Shared lessons (solana, global)` precedes `## Shared lessons (solana)`

— Alan (agent-9a77)
