### PR TITLE
feat(cleanup): vp-dev cleanup incomplete-branches subcommand

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,6 +39,14 @@ import {
   resolveTargetRepoPath,
 } from "./git/worktree.js";
 import { findOpenVpDevPrs } from "./git/openPrs.js";
+import {
+  DEFAULT_INCOMPLETE_RETENTION_DAYS,
+  filterByRetention,
+  listIncompleteBranches,
+  pruneIncompleteBranches,
+  resolveRetentionDays,
+  type IncompleteBranchInfo,
+} from "./git/incompleteBranches.js";
 import { agentClaudeMdPath, forkClaudeMd } from "./agent/specialization.js";
 import { promises as fs } from "node:fs";
 import { runIssueCore } from "./agent/runIssueCore.js";
@@ -238,6 +246,43 @@ export function buildCli(): Command {
         }),
     );
   program.addCommand(lessonsCmd);
+
+  const cleanupCmd = new Command("cleanup")
+    .description(
+      "Local cleanup operations beyond the per-run sweep (e.g. accumulated -incomplete-<runId> salvage refs)",
+    )
+    .addCommand(
+      new Command("incomplete-branches")
+        .description(
+          "Surface vp-dev/<agent>/issue-<N>-incomplete-<runId> refs older than the retention threshold. Default: list only.",
+        )
+        .option(
+          "--target-repo <owner/repo>",
+          "Target GitHub repo, used to derive the conventional clone path",
+        )
+        .option(
+          "--target-repo-path <path>",
+          "Local clone path of the target repo (default: $HOME/dev/<repo-name>)",
+        )
+        .option(
+          "--retention-days <n>",
+          `Surface refs older than this many days (default: ${DEFAULT_INCOMPLETE_RETENTION_DAYS}, env: INCOMPLETE_BRANCH_RETENTION_DAYS)`,
+          parsePositive,
+        )
+        .option(
+          "--apply",
+          "Actually delete surfaced refs locally (default: list only, never delete)",
+        )
+        .option(
+          "--dry-run",
+          "Force list-only mode (overrides --apply for explicit safety)",
+        )
+        .option("--json", "Print machine-readable JSON")
+        .action(async (opts) => {
+          await cmdCleanupIncompleteBranches(opts);
+        }),
+    );
+  program.addCommand(cleanupCmd);
 
   return program;
 }
@@ -1459,6 +1504,128 @@ async function runInteractiveReview(pending: PendingCandidate[]): Promise<void> 
   }
   process.stdout.write(
     `\nReview complete: accepted=${acceptedCount} rejected=${rejectedCount} skipped=${skippedCount}\n`,
+  );
+}
+
+interface CleanupIncompleteOpts {
+  targetRepo?: string;
+  targetRepoPath?: string;
+  retentionDays?: number;
+  apply?: boolean;
+  dryRun?: boolean;
+  json?: boolean;
+}
+
+async function cmdCleanupIncompleteBranches(
+  opts: CleanupIncompleteOpts,
+): Promise<void> {
+  if (!opts.targetRepo && !opts.targetRepoPath) {
+    process.stderr.write(
+      "ERROR: --target-repo or --target-repo-path is required to locate the local clone.\n",
+    );
+    process.exit(2);
+  }
+  let repoPath: string;
+  try {
+    repoPath = await resolveTargetRepoPath(
+      opts.targetRepo ?? "",
+      opts.targetRepoPath,
+    );
+  } catch (err) {
+    process.stderr.write(
+      `ERROR: could not resolve target-repo path: ${(err as Error).message}\n`,
+    );
+    process.exit(2);
+  }
+
+  const retentionDays = resolveRetentionDays({
+    flag: opts.retentionDays,
+    env: process.env,
+  });
+
+  const all = await listIncompleteBranches({ repoPath });
+  const stale = filterByRetention(all, retentionDays);
+
+  // --dry-run forces list-only even if --apply is also passed. Per #96
+  // scope: --dry-run is the explicit safety override that wins.
+  const willDelete = !!opts.apply && !opts.dryRun && stale.length > 0;
+
+  if (opts.json) {
+    const payload: Record<string, unknown> = {
+      retentionDays,
+      totalScanned: all.length,
+      surfaced: stale,
+      willDelete,
+    };
+    if (willDelete) {
+      const result = await pruneIncompleteBranches({
+        repoPath,
+        branches: stale.map((b) => b.branch),
+      });
+      payload.deleted = result.deleted;
+      payload.failed = result.failed;
+    }
+    process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
+    return;
+  }
+
+  if (stale.length === 0) {
+    process.stdout.write(
+      `No -incomplete-<runId> refs older than ${retentionDays} day(s). (Scanned ${all.length} total in ${repoPath}.)\n`,
+    );
+    return;
+  }
+
+  process.stdout.write(
+    `${stale.length} -incomplete-<runId> ref(s) older than ${retentionDays} day(s) in ${repoPath}:\n\n`,
+  );
+  printTable(
+    ["branch", "age(days)", "agent", "issue", "runState"],
+    stale.map((b: IncompleteBranchInfo) => [
+      b.branch,
+      String(b.ageDays),
+      b.agentId,
+      String(b.issueId),
+      b.runStateRef,
+    ]),
+  );
+
+  if (!willDelete) {
+    if (opts.apply && opts.dryRun) {
+      process.stdout.write(
+        "\n--dry-run wins over --apply: list-only mode. Re-run without --dry-run to delete.\n",
+      );
+    } else {
+      process.stdout.write(
+        "\nList-only (default). Re-run with --apply to delete these branches locally.\n",
+      );
+    }
+    return;
+  }
+
+  // --apply path. Local-only `git branch -D`; never touches origin.
+  const result = await pruneIncompleteBranches({
+    repoPath,
+    branches: stale.map((b) => b.branch),
+  });
+  process.stdout.write(`\nDeleted ${result.deleted.length} branch(es) locally.\n`);
+  for (const d of result.deleted) process.stdout.write(`  - ${d}\n`);
+  if (result.failed.length > 0) {
+    process.stdout.write(
+      `\nCould not delete ${result.failed.length} branch(es) (likely attached to a worktree):\n`,
+    );
+    for (const f of result.failed) {
+      process.stdout.write(`  - ${f.branch}: ${f.reason.trim()}\n`);
+    }
+    process.stdout.write(
+      "  To clean up: `git worktree remove --force <path>` first, then re-run with --apply.\n",
+    );
+  }
+  process.stdout.write(
+    "\nNote: this command is local-only. To remove the corresponding remote refs, run:\n",
+  );
+  process.stdout.write(
+    "  git push origin --delete <branch>   (per branch; review before running)\n",
   );
 }
 

--- a/src/git/incompleteBranches.test.ts
+++ b/src/git/incompleteBranches.test.ts
@@ -1,0 +1,224 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  filterByRetention,
+  lookupRunStateRef,
+  parseIncompleteRefs,
+  resolveRetentionDays,
+  DEFAULT_INCOMPLETE_RETENTION_DAYS,
+} from "./incompleteBranches.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.UTC(2026, 4, 15, 12, 0, 0); // 2026-05-15T12:00:00Z
+
+test("parseIncompleteRefs: extracts agent/issue/runId and computes ageDays", () => {
+  // 14 days back, in unix seconds
+  const committerUnix = Math.floor((NOW - 14 * DAY_MS) / 1000);
+  const out = parseIncompleteRefs(
+    [
+      {
+        branch: "vp-dev/agent-75a0/issue-88-incomplete-run-2026-05-01T12-00-00-000Z",
+        committerUnix,
+      },
+    ],
+    NOW,
+  );
+  assert.equal(out.length, 1);
+  assert.deepEqual(out[0], {
+    branch: "vp-dev/agent-75a0/issue-88-incomplete-run-2026-05-01T12-00-00-000Z",
+    agentId: "agent-75a0",
+    issueId: 88,
+    runId: "run-2026-05-01T12-00-00-000Z",
+    committerDate: new Date(committerUnix * 1000).toISOString(),
+    ageDays: 14,
+  });
+});
+
+test("parseIncompleteRefs: drops malformed branches silently", () => {
+  // Anchored regex rejects:
+  //   - the regular vp-dev branch shape (no `-incomplete-` segment)
+  //   - human-authored branches at the same prefix (uppercase agent id)
+  //   - branches missing `issue-` prefix
+  const out = parseIncompleteRefs(
+    [
+      { branch: "vp-dev/agent-aa00/issue-1", committerUnix: 0 },
+      { branch: "vp-dev/agent-AB/issue-1-incomplete-run-x", committerUnix: 0 },
+      { branch: "vp-dev/agent-aa00/1-incomplete-run-x", committerUnix: 0 },
+      { branch: "renovate/main-incomplete-r", committerUnix: 0 },
+    ],
+    NOW,
+  );
+  assert.deepEqual(out, []);
+});
+
+test("parseIncompleteRefs: ageDays floors at zero for future-dated commits", () => {
+  // Clock skew between machines can put committerdate slightly ahead of now.
+  const committerUnix = Math.floor((NOW + 5 * 60 * 1000) / 1000);
+  const out = parseIncompleteRefs(
+    [
+      {
+        branch: "vp-dev/agent-aa00/issue-1-incomplete-run-x",
+        committerUnix,
+      },
+    ],
+    NOW,
+  );
+  assert.equal(out[0].ageDays, 0);
+});
+
+test("parseIncompleteRefs: multi-digit issue numbers and runIds with hyphens", () => {
+  const committerUnix = Math.floor(NOW / 1000) - 30 * 24 * 60 * 60;
+  const out = parseIncompleteRefs(
+    [
+      {
+        branch: "vp-dev/agent-ef41/issue-1234-incomplete-run-2026-05-01T12-00-00-000Z",
+        committerUnix,
+      },
+    ],
+    NOW,
+  );
+  assert.equal(out[0].issueId, 1234);
+  assert.equal(out[0].runId, "run-2026-05-01T12-00-00-000Z");
+  assert.equal(out[0].ageDays, 30);
+});
+
+test("filterByRetention: includes branches at exactly the threshold (>=)", () => {
+  const branches = [
+    { ageDays: 0 },
+    { ageDays: 13 },
+    { ageDays: 14 },
+    { ageDays: 100 },
+  ];
+  // Threshold-inclusive: a 14-day-old ref crosses a 14-day retention.
+  // Closes the off-by-one between "kept long enough" and "ready to surface".
+  const out = filterByRetention(branches, 14);
+  assert.deepEqual(
+    out.map((b) => b.ageDays),
+    [14, 100],
+  );
+});
+
+test("filterByRetention: retentionDays of 0 surfaces every branch", () => {
+  const branches = [{ ageDays: 0 }, { ageDays: 1 }];
+  assert.equal(filterByRetention(branches, 0).length, 2);
+});
+
+test("filterByRetention: negative retentionDays is treated as 0 (defensive)", () => {
+  const branches = [{ ageDays: 0 }, { ageDays: 5 }];
+  assert.equal(filterByRetention(branches, -7).length, 2);
+});
+
+test("resolveRetentionDays: flag wins over env over default", () => {
+  assert.equal(
+    resolveRetentionDays({ flag: 7, env: { INCOMPLETE_BRANCH_RETENTION_DAYS: "30" } }),
+    7,
+  );
+  assert.equal(
+    resolveRetentionDays({ env: { INCOMPLETE_BRANCH_RETENTION_DAYS: "30" } }),
+    30,
+  );
+  assert.equal(
+    resolveRetentionDays({ env: {} }),
+    DEFAULT_INCOMPLETE_RETENTION_DAYS,
+  );
+});
+
+test("resolveRetentionDays: rejects malformed env (NaN, zero, negative)", () => {
+  // Defensive: an operator setting `INCOMPLETE_BRANCH_RETENTION_DAYS=0`
+  // (or `-1`, or `"abc"`) shouldn't silently surface every ref. Falls back
+  // to the default rather than honoring the misconfigured value.
+  for (const bad of ["abc", "0", "-1", "", " "]) {
+    assert.equal(
+      resolveRetentionDays({ env: { INCOMPLETE_BRANCH_RETENTION_DAYS: bad } }),
+      DEFAULT_INCOMPLETE_RETENTION_DAYS,
+    );
+  }
+});
+
+test("lookupRunStateRef: 'present' when state file references the branch", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "incomplete-test-"));
+  try {
+    const runId = "run-2026-05-01T12-00-00-000Z";
+    const branch = `vp-dev/agent-75a0/issue-88-incomplete-${runId}`;
+    const state = {
+      runId,
+      issues: {
+        "88": {
+          status: "failed",
+          partialBranchUrl: `https://github.com/owner/repo/tree/${encodeURIComponent(branch)}`,
+        },
+      },
+    };
+    await fs.writeFile(path.join(dir, `${runId}.json`), JSON.stringify(state));
+    assert.equal(await lookupRunStateRef(branch, runId, dir), "present");
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("lookupRunStateRef: 'present-no-ref' when state exists but no entry references the branch", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "incomplete-test-"));
+  try {
+    const runId = "run-2026-05-01T12-00-00-000Z";
+    const branch = `vp-dev/agent-75a0/issue-88-incomplete-${runId}`;
+    const state = {
+      runId,
+      issues: {
+        "88": { status: "done" }, // no partialBranchUrl
+      },
+    };
+    await fs.writeFile(path.join(dir, `${runId}.json`), JSON.stringify(state));
+    assert.equal(await lookupRunStateRef(branch, runId, dir), "present-no-ref");
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("lookupRunStateRef: 'missing' when state file does not exist", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "incomplete-test-"));
+  try {
+    const branch = "vp-dev/agent-75a0/issue-88-incomplete-run-X";
+    assert.equal(await lookupRunStateRef(branch, "run-X", dir), "missing");
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("lookupRunStateRef: malformed JSON treated as 'missing' (no throw)", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "incomplete-test-"));
+  try {
+    const runId = "run-X";
+    await fs.writeFile(path.join(dir, `${runId}.json`), "{not json");
+    const branch = `vp-dev/agent-75a0/issue-88-incomplete-${runId}`;
+    assert.equal(await lookupRunStateRef(branch, runId, dir), "missing");
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("lookupRunStateRef: matches across multiple issues in the state file", async () => {
+  // Real state files often have several issues — confirm we scan all of
+  // them, not just the first.
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "incomplete-test-"));
+  try {
+    const runId = "run-2026-05-01T12-00-00-000Z";
+    const branch = `vp-dev/agent-75a0/issue-99-incomplete-${runId}`;
+    const state = {
+      runId,
+      issues: {
+        "88": { status: "done", prUrl: "https://github.com/o/r/pull/1" },
+        "99": {
+          status: "failed",
+          partialBranchUrl: `https://github.com/o/r/tree/${encodeURIComponent(branch)}`,
+        },
+      },
+    };
+    await fs.writeFile(path.join(dir, `${runId}.json`), JSON.stringify(state));
+    assert.equal(await lookupRunStateRef(branch, runId, dir), "present");
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});

--- a/src/git/incompleteBranches.ts
+++ b/src/git/incompleteBranches.ts
@@ -1,0 +1,280 @@
+// Periodic cleanup helpers for the `<branch>-incomplete-<runId>` refs the
+// orchestrator's safety net pushes after a non-clean agent exit (today only
+// `error_max_turns`; see `pushPartialBranch` in worktree.ts and issue #88).
+//
+// Why these need their own sweep, separate from `pruneStaleAgentBranches`:
+//   - The labeled `-incomplete-<runId>` shape intentionally fails the
+//     anchored `VP_DEV_BRANCH_RE` so the existing per-run sweep does NOT
+//     auto-clean them — they're salvage state for human inspection.
+//   - That's correct on a per-run basis but accumulates forever. Over weeks
+//     of usage the ref count slows `git fetch`, noises up `gh pr list` /
+//     `git branch -r | grep vp-dev`, and dilutes the signal value of any
+//     single salvage ref.
+//
+// Default behaviour follows the global "destructive actions need user
+// confirmation" rule: list-only, never delete unless `--apply` is passed.
+// Local-only — never touches origin (the partial-push left a branch on
+// origin too; the user can `git push origin --delete <branch>` separately).
+//
+// Push-protection invariant: `git branch -D` against local refs only. No
+// `git push --delete`, no remote mutation. Issue #96.
+
+import { promisify } from "node:util";
+import { execFile as execFileCb } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { Logger } from "../log/logger.js";
+import { STATE_DIR } from "../state/runState.js";
+import type { RunState } from "../types.js";
+
+const execFile = promisify(execFileCb);
+
+// `git branch --list <pattern>` glob form. Anchored to the labeled shape
+// produced by `buildIncompleteBranchName` (worktree.ts):
+//   vp-dev/<agentId>/issue-<N>-incomplete-<safeRunId>
+// Note: this glob does not match the regular `vp-dev/agent-*/issue-<N>`
+// branches handled by `pruneStaleAgentBranches`, by design.
+const INCOMPLETE_BRANCH_PATTERN = "vp-dev/agent-*/issue-*-incomplete-*";
+
+// Regex form of the same shape. AgentId charset matches the registry
+// generator (lowercase alphanumerics). The runId capture is `.+` because
+// `safeRunId` may contain `-` from the canonical `run-<iso>` form.
+const INCOMPLETE_BRANCH_RE =
+  /^vp-dev\/(agent-[a-z0-9]+)\/issue-(\d+)-incomplete-(.+)$/;
+
+export const DEFAULT_INCOMPLETE_RETENTION_DAYS = 14;
+
+/**
+ * Diagnostic signal for whether the corresponding run-state JSON exists and
+ * still references this branch via `partialBranchUrl`. Surfaced in the CLI
+ * output so the user can spot orphan refs (state file gone) vs. healthy
+ * salvage state (state file present and refers to this URL).
+ *   - `present`: `state/<runId>.json` exists AND an issue entry's
+ *     `partialBranchUrl` references this branch.
+ *   - `present-no-ref`: state file exists but does NOT reference this
+ *     branch — possible if the safety-net pushed but the run-state write
+ *     racing partial-update lost the field, or the branch was hand-renamed.
+ *   - `missing`: `state/<runId>.json` not present (already cleaned up,
+ *     never written, or the runId in the branch name is malformed).
+ */
+export type RunStateRef = "present" | "present-no-ref" | "missing";
+
+export interface IncompleteBranchInfo {
+  branch: string;
+  agentId: string;
+  issueId: number;
+  /** runId suffix parsed from the branch name (everything after `-incomplete-`). */
+  runId: string;
+  /** ISO-8601 committer date of the branch tip. */
+  committerDate: string;
+  /** Floor((now - committerDate) / 1 day). Computed at scan time. */
+  ageDays: number;
+  runStateRef: RunStateRef;
+}
+
+/** Raw output of a single `git for-each-ref` line, pre-parse. */
+export interface RawIncompleteRef {
+  branch: string;
+  /** Unix epoch seconds (`%(committerdate:unix)`). */
+  committerUnix: number;
+}
+
+/**
+ * Pure parser — extracts `(agentId, issueId, runId, ageDays, committerDate)`
+ * from `git for-each-ref` output. Lines that don't match the labeled shape
+ * are silently dropped (defensive against future glob loosening).
+ *
+ * Unit-tested in `incompleteBranches.test.ts` so the regex / age math stays
+ * stable independent of git plumbing.
+ */
+export function parseIncompleteRefs(
+  refs: RawIncompleteRef[],
+  nowMs: number,
+): Array<Omit<IncompleteBranchInfo, "runStateRef">> {
+  const dayMs = 24 * 60 * 60 * 1000;
+  const out: Array<Omit<IncompleteBranchInfo, "runStateRef">> = [];
+  for (const r of refs) {
+    const m = INCOMPLETE_BRANCH_RE.exec(r.branch);
+    if (!m) continue;
+    const [, agentId, issueIdStr, runId] = m;
+    const committerMs = r.committerUnix * 1000;
+    const ageDays = Math.max(0, Math.floor((nowMs - committerMs) / dayMs));
+    out.push({
+      branch: r.branch,
+      agentId,
+      issueId: parseInt(issueIdStr, 10),
+      runId,
+      committerDate: new Date(committerMs).toISOString(),
+      ageDays,
+    });
+  }
+  return out;
+}
+
+/**
+ * Filter pure on `ageDays`. Branches with `ageDays >= retentionDays` cross
+ * the threshold and are returned. A retentionDays of 0 surfaces every ref;
+ * negative values are treated as 0 (defensive — the CLI rejects non-positive
+ * via `parsePositive`, but the helper accepts any caller).
+ */
+export function filterByRetention<T extends { ageDays: number }>(
+  branches: T[],
+  retentionDays: number,
+): T[] {
+  const threshold = Math.max(0, retentionDays | 0);
+  return branches.filter((b) => b.ageDays >= threshold);
+}
+
+/**
+ * Cross-reference a single incomplete branch against `state/<runId>.json`.
+ * Returns the diagnostic tag — see `RunStateRef` above. All errors map to
+ * `missing` (file unreadable / parse failure / shape mismatch); the caller
+ * never throws.
+ *
+ * Matches on the URL-encoded branch substring of `partialBranchUrl`, which
+ * is built as `https://github.com/<repo>/tree/${encodeURIComponent(branch)}`
+ * by `pushPartialBranch`. Substring match is robust against future tweaks
+ * to the URL shape (e.g. `?ref=` form) without coupling to `<repo>`.
+ */
+export async function lookupRunStateRef(
+  branch: string,
+  runId: string,
+  stateDir: string,
+): Promise<RunStateRef> {
+  const filePath = path.join(stateDir, `${runId}.json`);
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, "utf-8");
+  } catch {
+    return "missing";
+  }
+  let state: RunState;
+  try {
+    state = JSON.parse(raw) as RunState;
+  } catch {
+    return "missing";
+  }
+  if (!state || typeof state !== "object" || !state.issues) return "present-no-ref";
+  const encodedBranch = encodeURIComponent(branch);
+  for (const entry of Object.values(state.issues)) {
+    if (entry?.partialBranchUrl && entry.partialBranchUrl.includes(encodedBranch)) {
+      return "present";
+    }
+  }
+  return "present-no-ref";
+}
+
+export interface ListIncompleteBranchesOpts {
+  repoPath: string;
+  /** Override `Date.now()` for deterministic tests. */
+  nowMs?: number;
+  /** Override the default `STATE_DIR` for deterministic tests. */
+  stateDir?: string;
+  logger?: Logger;
+}
+
+/**
+ * Enumerate every local labeled-incomplete ref (vp-dev/agent-X/issue-N
+ * -incomplete-runId) with committer-date metadata, then enrich each with
+ * its `runStateRef` tag. Returns `[]` on `git for-each-ref` failure (network
+ * has nothing to do with this, but the cwd may not be a git repo) — the
+ * caller treats an empty result as "nothing to clean up".
+ */
+export async function listIncompleteBranches(
+  opts: ListIncompleteBranchesOpts,
+): Promise<IncompleteBranchInfo[]> {
+  let stdout = "";
+  try {
+    const result = await execFile(
+      "git",
+      [
+        "for-each-ref",
+        "--format=%(refname:short)\t%(committerdate:unix)",
+        `refs/heads/${INCOMPLETE_BRANCH_PATTERN}`,
+      ],
+      { cwd: opts.repoPath },
+    );
+    stdout = result.stdout;
+  } catch (err) {
+    opts.logger?.warn("cleanup.incomplete_list_failed", {
+      err: (err as Error).message,
+    });
+    return [];
+  }
+  const refs: RawIncompleteRef[] = stdout
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const tab = line.indexOf("\t");
+      if (tab < 0) return { branch: line, committerUnix: 0 };
+      const branch = line.slice(0, tab);
+      const ts = parseInt(line.slice(tab + 1), 10);
+      return { branch, committerUnix: Number.isFinite(ts) ? ts : 0 };
+    });
+  const nowMs = opts.nowMs ?? Date.now();
+  const stateDir = opts.stateDir ?? STATE_DIR;
+  const parsed = parseIncompleteRefs(refs, nowMs);
+  const out: IncompleteBranchInfo[] = [];
+  for (const p of parsed) {
+    const runStateRef = await lookupRunStateRef(p.branch, p.runId, stateDir);
+    out.push({ ...p, runStateRef });
+  }
+  return out;
+}
+
+export interface PruneIncompleteResult {
+  deleted: string[];
+  failed: Array<{ branch: string; reason: string }>;
+}
+
+/**
+ * Delete each branch with `git branch -D`. Local-only; never pushes.
+ *
+ * If a branch is still attached to a worktree, `git branch -D` rejects the
+ * delete — that surfaces as a `failed` entry with the git stderr included
+ * so the user can act (`git worktree remove --force <path>` first). Same
+ * fail-safe pattern as `pruneStaleAgentBranches`.
+ */
+export async function pruneIncompleteBranches(opts: {
+  repoPath: string;
+  branches: string[];
+  logger?: Logger;
+}): Promise<PruneIncompleteResult> {
+  const deleted: string[] = [];
+  const failed: Array<{ branch: string; reason: string }> = [];
+  for (const branch of opts.branches) {
+    try {
+      await execFile("git", ["branch", "-D", branch], { cwd: opts.repoPath });
+      deleted.push(branch);
+      opts.logger?.info("cleanup.incomplete_branch_deleted", { branch });
+    } catch (err) {
+      const reason =
+        (err as { stderr?: string }).stderr ?? (err as Error).message;
+      failed.push({ branch, reason });
+      opts.logger?.warn("cleanup.incomplete_branch_delete_failed", {
+        branch,
+        err: reason,
+      });
+    }
+  }
+  return { deleted, failed };
+}
+
+/**
+ * Resolve the retention-days threshold: explicit flag wins, env var
+ * (`INCOMPLETE_BRANCH_RETENTION_DAYS`) is the fallback, hard-coded default
+ * is `DEFAULT_INCOMPLETE_RETENTION_DAYS` (14 days). Pure, env-injected so
+ * tests don't have to mutate `process.env`.
+ */
+export function resolveRetentionDays(input: {
+  flag?: number;
+  env: NodeJS.ProcessEnv;
+}): number {
+  if (input.flag !== undefined && input.flag > 0) return input.flag;
+  const raw = input.env.INCOMPLETE_BRANCH_RETENTION_DAYS;
+  if (raw) {
+    const n = Number(raw);
+    if (Number.isInteger(n) && n > 0) return n;
+  }
+  return DEFAULT_INCOMPLETE_RETENTION_DAYS;
+}


### PR DESCRIPTION
Closes #96

## Summary

Adds `vp-dev cleanup incomplete-branches` to surface (and optionally delete) the `vp-dev/<agent>/issue-<N>-incomplete-<runId>` salvage refs the orchestrator's safety net pushes after a non-clean exit. PR #92 intentionally exempts these from `pruneStaleAgentBranches` so they survive for human inspection — but with no separate cadence they accumulate forever, slowing `git fetch` and noising up `gh pr list` over weeks of usage.

## What it does

- Lists every local ref matching `vp-dev/agent-*/issue-*-incomplete-*` whose committer date is at least `--retention-days` old.
- Each row carries: branch, age (days), agent, issue, and a `runState` tag — `present` (state file references the branch via `partialBranchUrl`), `present-no-ref` (state file exists but the URL doesn't appear), or `missing` (state file gone).
- Default is list-only. `--apply` actually deletes locally. `--dry-run` wins over `--apply` as an explicit safety override.
- Retention default `14` (constant `DEFAULT_INCOMPLETE_RETENTION_DAYS`); env override `INCOMPLETE_BRANCH_RETENTION_DAYS`.
- `--json` for machine-readable output.

## Push-protection invariant

Strictly local: `git branch -D` only. Never `git push --delete`, never any remote mutation. The user gets a hint at the end of the apply path showing the explicit per-branch `git push origin --delete <branch>` they can run if they want to clean up the remote refs too.

## Out of scope (per the issue)

- Auto-deletion on a cron / pre-run hook — too aggressive given the salvage-state intent.
- Restoring a partial branch back to a regular agent branch (auto-resume path).
- Cleaning up branches that match the regular `VP_DEV_BRANCH_RE` — already covered by `pruneStaleAgentBranches`, no behavioral change there.

## Files changed

- `src/git/incompleteBranches.ts` (new) — pure parsers (`parseIncompleteRefs`, `filterByRetention`, `resolveRetentionDays`) + I/O helpers (`listIncompleteBranches`, `lookupRunStateRef`, `pruneIncompleteBranches`).
- `src/git/incompleteBranches.test.ts` (new) — 14 tests covering regex / age math / retention threshold semantics / env override fallback / state-file cross-reference (incl. malformed JSON, multi-issue scan).
- `src/cli.ts` — wires the new `cleanup` command group + `incomplete-branches` subcommand. Existing test glob `dist/src/git/*.test.js` picks up the new tests automatically.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 99 → 113 tests pass (14 new, 99 existing)
- [x] `vp-dev cleanup incomplete-branches --help` — flags render
- [x] `vp-dev cleanup incomplete-branches --target-repo-path .` — list-only path on a clean repo prints "No -incomplete-<runId> refs..."
- [x] `vp-dev cleanup incomplete-branches --json --target-repo-path . --retention-days 1` — emits `{ retentionDays, totalScanned, surfaced, willDelete }`
- [x] `vp-dev cleanup incomplete-branches` (no args) — exits 2 with the missing-target-repo error

— Finding Triage (agent-75a0)
