### PR TITLE
Add `vp-dev lessons trim <domain>` for LLM-driven pool reduction

### DIFF
--- a/src/agent/trimPool.ts
+++ b/src/agent/trimPool.ts
@@ -1,0 +1,426 @@
+// LLM-driven trim of a shared-lesson pool that has hit `MAX_POOL_LINES`.
+//
+// Flow (`vp-dev lessons trim <domain>`):
+//   1. Parse the pool file into header + indexed entries.
+//   2. Send the entries to a sonnet model with a "rank by lasting signal"
+//      prompt; receive `{verdicts: [{entryIndex, verdict, rationale}, ...]}`.
+//   3. Surface the proposal to the human (interactive y/N or `--yes`); on
+//      accept, rewrite the pool keeping `keep` entries (and `maybe` unless
+//      `--drop-maybes`).
+//
+// The trim model NEVER mutates entry text — it only proposes verdicts.
+// Per-entry length caps are enforced at promotion time
+// (`validateEntry` in `promotionMarkers.ts`) and trim cannot expand
+// entries because it doesn't rewrite them.
+//
+// Boundary preservation: trim is an explicit, human-driven CLI operation.
+// `acceptCandidate()`'s 200-line cap rejection still fires — trim is a
+// separate user-driven escape hatch, not an automatic one.
+
+import { promises as fs } from "node:fs";
+import { z } from "zod";
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { claudeBinPath } from "./sdkBinary.js";
+import { parseJsonEnvelope } from "../util/parseJsonEnvelope.js";
+import { withFileLock } from "../state/locks.js";
+import { MAX_POOL_LINES, sharedLessonsPath } from "./sharedLessons.js";
+import {
+  MAX_ENTRY_CHARS,
+  MAX_ENTRY_LINES,
+  isValidDomain,
+} from "../util/promotionMarkers.js";
+import type { Logger } from "../log/logger.js";
+
+const TRIM_MODEL = "claude-sonnet-4-6";
+
+// Matches the entry sentinel emitted by `formatEntryBlock` in
+// `sharedLessons.ts`. Domain-source-issueId-ts triple uniquely keys an entry
+// across re-parses (used for drift-tolerant apply).
+const ENTRY_MARKER_RE =
+  /^<!--\s*entry source:(\S+)\s+issue:#(\d+)\s+ts:(\S+)\s*-->\s*$/;
+
+export interface PoolEntry {
+  /** 0-based index within `PoolFile.entries`, in pool order. */
+  index: number;
+  source: string;
+  issueId: number;
+  ts: string;
+  /** Body lines joined with `\n`, with any trailing newline(s) stripped. */
+  body: string;
+  startLine: number;
+  endLine: number;
+}
+
+export interface PoolFile {
+  domain: string;
+  /** Everything before the first entry marker, verbatim. */
+  header: string;
+  entries: PoolEntry[];
+  totalLines: number;
+}
+
+export type TrimVerdictKind = "keep" | "maybe" | "drop";
+
+export interface TrimVerdict {
+  entryIndex: number;
+  verdict: TrimVerdictKind;
+  rationale: string;
+}
+
+export interface TrimProposal {
+  domain: string;
+  filePath: string;
+  totalEntries: number;
+  totalLines: number;
+  /** One verdict per entry (missing model verdicts default to `keep`). */
+  verdicts: TrimVerdict[];
+}
+
+const TrimPayloadSchema = z.object({
+  verdicts: z
+    .array(
+      z.object({
+        entryIndex: z.number().int().nonnegative(),
+        verdict: z.enum(["keep", "maybe", "drop"]),
+        rationale: z.string().min(1).max(500),
+      }),
+    )
+    .min(1),
+});
+
+/**
+ * Parse a pool file's content into header + entries. Any line matching
+ * the entry sentinel begins a new entry; the body runs from the line
+ * after the sentinel up to (exclusive) the next sentinel or EOF.
+ */
+export function parsePool(domain: string, content: string): PoolFile {
+  if (!isValidDomain(domain)) {
+    throw new Error(
+      `Invalid domain '${domain}': expected lowercase dash-separated tag.`,
+    );
+  }
+  const lines = content.split("\n");
+  const starts: { line: number; source: string; issueId: number; ts: string }[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(ENTRY_MARKER_RE);
+    if (m) starts.push({ line: i, source: m[1], issueId: Number(m[2]), ts: m[3] });
+  }
+  const headerEnd = starts.length > 0 ? starts[0].line : lines.length;
+  const header = lines.slice(0, headerEnd).join("\n");
+  const entries: PoolEntry[] = [];
+  for (let k = 0; k < starts.length; k++) {
+    const cur = starts[k];
+    const next = k + 1 < starts.length ? starts[k + 1].line : lines.length;
+    // Strip trailing newlines: the last entry's slice may include the file's
+    // trailing empty-string element (from `split("\n")` on a `\n`-terminated
+    // file), giving the last entry a phantom trailing `\n` that middle
+    // entries don't have. Stripping makes body semantics symmetric.
+    const body = lines.slice(cur.line + 1, next).join("\n").replace(/\n+$/, "");
+    entries.push({
+      index: k,
+      source: cur.source,
+      issueId: cur.issueId,
+      ts: cur.ts,
+      body,
+      startLine: cur.line,
+      endLine: next - 1,
+    });
+  }
+  return { domain, header, entries, totalLines: lines.length };
+}
+
+/**
+ * Re-emit a pool given a (possibly trimmed) entry list. Header is
+ * normalized to end with `\n\n`; entries are stacked back-to-back to
+ * match the format produced by `appendLessonToPool`.
+ */
+export function emitPool(file: PoolFile, kept: PoolEntry[]): string {
+  const headerNorm = file.header.replace(/\n*$/, "") + "\n\n";
+  const blocks = kept
+    .map(
+      (e) =>
+        `<!-- entry source:${e.source} issue:#${e.issueId} ts:${e.ts} -->\n${e.body.replace(/\n*$/, "")}\n`,
+    )
+    .join("");
+  return headerNorm + blocks;
+}
+
+/**
+ * Compute the kept-entry subset implied by a verdict list. By default,
+ * `keep` and `maybe` are kept; `dropMaybes:true` drops `maybe` too.
+ * Entries with no matching verdict are kept (conservative default).
+ */
+export function selectKeptEntries(
+  file: PoolFile,
+  verdicts: TrimVerdict[],
+  opts?: { dropMaybes?: boolean },
+): PoolEntry[] {
+  const dropMaybes = !!opts?.dropMaybes;
+  const drop = new Set<number>();
+  for (const v of verdicts) {
+    if (v.verdict === "drop") drop.add(v.entryIndex);
+    else if (v.verdict === "maybe" && dropMaybes) drop.add(v.entryIndex);
+  }
+  return file.entries.filter((e) => !drop.has(e.index));
+}
+
+export function buildTrimSystemPrompt(): string {
+  return `You are a curation agent for cross-agent shared-lesson pools. A domain pool has hit its line cap (target: under ${MAX_POOL_LINES} lines). Your job is to rank each entry by lasting signal value so the human reviewer can drop low-value entries.
+
+For each entry, choose exactly one verdict:
+- "keep" — high-signal, broadly applicable to sibling agents, durable observation.
+- "maybe" — narrow scope, partially obsolete, or duplicative of another entry but not strictly redundant.
+- "drop" — superseded by a newer entry, redundant, or a one-off implementation detail with no transfer value.
+
+Tie-breaking: when content overlaps, prefer the newer entry (later \`ts:\` timestamp) and mark the older one "drop" or "maybe".
+
+Each entry is at most ${MAX_ENTRY_LINES} non-empty lines / ${MAX_ENTRY_CHARS} chars by promotion-time validation. Do NOT propose rewrites — verdicts only.
+
+Drop enough entries to bring the kept set below ${MAX_POOL_LINES} non-empty lines. If the pool is already comfortably below the cap, returning all "keep" is acceptable.
+
+Output a single JSON object, no fences, no prose:
+  {"verdicts": [{"entryIndex": <0-based>, "verdict": "keep"|"maybe"|"drop", "rationale": "<one short sentence>"}]}
+
+Include exactly one verdict per entry. The schema is mandatory.`;
+}
+
+export function buildTrimUserPrompt(file: PoolFile): string {
+  const lines: string[] = [];
+  lines.push(`Domain: ${file.domain}`);
+  lines.push(`Total entries: ${file.entries.length}`);
+  lines.push(`Total lines: ${file.totalLines} (cap ${MAX_POOL_LINES})`);
+  lines.push("");
+  lines.push("Entries (in pool order; ts:<timestamp> indicates promotion time):");
+  for (const e of file.entries) {
+    lines.push("");
+    lines.push(
+      `### entry ${e.index}  source=${e.source}  issue=#${e.issueId}  ts=${e.ts}`,
+    );
+    lines.push(e.body.replace(/\n+$/, ""));
+  }
+  lines.push("");
+  lines.push("Emit verdicts JSON now.");
+  return lines.join("\n");
+}
+
+export interface ProposeTrimResult {
+  proposal: TrimProposal;
+  file: PoolFile;
+}
+
+export interface ProposeTrimInput {
+  domain: string;
+  logger?: Logger;
+}
+
+export async function proposeTrim(
+  input: ProposeTrimInput,
+): Promise<ProposeTrimResult> {
+  const filePath = sharedLessonsPath("target", input.domain);
+  const content = await fs.readFile(filePath, "utf-8");
+  const file = parsePool(input.domain, content);
+  if (file.entries.length === 0) {
+    return {
+      file,
+      proposal: {
+        domain: input.domain,
+        filePath,
+        totalEntries: 0,
+        totalLines: file.totalLines,
+        verdicts: [],
+      },
+    };
+  }
+  const rawVerdicts = await runTrimQuery({
+    domain: input.domain,
+    systemPrompt: buildTrimSystemPrompt(),
+    userPrompt: buildTrimUserPrompt(file),
+    logger: input.logger,
+  });
+  const verdicts = reconcileVerdicts(file, rawVerdicts);
+  return {
+    file,
+    proposal: {
+      domain: input.domain,
+      filePath,
+      totalEntries: file.entries.length,
+      totalLines: file.totalLines,
+      verdicts,
+    },
+  };
+}
+
+/**
+ * Defensive normalization: drop verdicts pointing at out-of-range or
+ * duplicate `entryIndex`, then default any uncovered entry to `keep`.
+ * Sorted by entryIndex for stable rendering.
+ */
+export function reconcileVerdicts(
+  file: PoolFile,
+  raw: TrimVerdict[],
+): TrimVerdict[] {
+  const seen = new Set<number>();
+  const sane: TrimVerdict[] = [];
+  for (const v of raw) {
+    if (v.entryIndex < 0 || v.entryIndex >= file.entries.length) continue;
+    if (seen.has(v.entryIndex)) continue;
+    seen.add(v.entryIndex);
+    sane.push(v);
+  }
+  for (const e of file.entries) {
+    if (!seen.has(e.index)) {
+      sane.push({
+        entryIndex: e.index,
+        verdict: "keep",
+        rationale: "no verdict from model — defaulting to keep",
+      });
+    }
+  }
+  sane.sort((a, b) => a.entryIndex - b.entryIndex);
+  return sane;
+}
+
+interface RunTrimQueryArgs {
+  domain: string;
+  systemPrompt: string;
+  userPrompt: string;
+  logger?: Logger;
+}
+
+async function runTrimQuery(args: RunTrimQueryArgs): Promise<TrimVerdict[]> {
+  let raw = "";
+  const stream = query({
+    prompt: args.userPrompt,
+    options: {
+      model: TRIM_MODEL,
+      systemPrompt: args.systemPrompt,
+      tools: [],
+      permissionMode: "default",
+      env: process.env,
+      maxTurns: 1,
+      settingSources: [],
+      persistSession: false,
+      pathToClaudeCodeExecutable: claudeBinPath(),
+    },
+  });
+  for await (const msg of stream) {
+    if (msg.type === "result") {
+      if (msg.subtype === "success") raw = msg.result;
+      else throw new Error(`trim model failed: ${msg.subtype}`);
+    }
+  }
+  const extracted = parseJsonEnvelope(raw, TrimPayloadSchema);
+  if (!extracted.ok) {
+    args.logger?.warn("trim.malformed_payload", {
+      domain: args.domain,
+      error: extracted.error ?? "no envelope",
+      raw: raw.slice(0, 4000),
+    });
+    throw new Error(
+      `trim model output not valid: ${extracted.error ?? "no envelope"}`,
+    );
+  }
+  return extracted.value!.verdicts;
+}
+
+export interface ApplyTrimInput {
+  proposal: TrimProposal;
+  /** The PoolFile parsed at propose-time; used as the source-of-truth for
+   * which entryIndex maps to which (source, issueId, ts) key. */
+  file: PoolFile;
+  /** Default false: keep `maybe` entries. */
+  dropMaybes?: boolean;
+}
+
+export type ApplyTrimResult =
+  | {
+      kind: "applied";
+      filePath: string;
+      totalLines: number;
+      kept: number;
+      dropped: number;
+    }
+  | {
+      kind: "still-over-cap";
+      filePath: string;
+      totalLines: number;
+    };
+
+/**
+ * Apply the proposal to the pool file under the per-file lock used by
+ * `appendLessonToPool`. Re-reads + re-parses the file under the lock so
+ * a concurrent append is reconciled: the drop-set is keyed by
+ * `(source, issueId, ts)`, so any entry appended between propose and
+ * apply is preserved (treated as keep).
+ *
+ * Refuses to write if the trimmed pool would still exceed
+ * {@link MAX_POOL_LINES} — surfaced back to the CLI to ask the human to
+ * trim manually.
+ */
+export async function applyTrimProposal(
+  input: ApplyTrimInput,
+): Promise<ApplyTrimResult> {
+  const filePath = input.proposal.filePath;
+  return withFileLock(filePath, async () => {
+    const fresh = await fs.readFile(filePath, "utf-8");
+    const file = parsePool(input.proposal.domain, fresh);
+    const dropKeys = new Set<string>();
+    for (const v of input.proposal.verdicts) {
+      const isDrop =
+        v.verdict === "drop" || (v.verdict === "maybe" && input.dropMaybes);
+      if (!isDrop) continue;
+      const e = input.file.entries.find((x) => x.index === v.entryIndex);
+      if (e) dropKeys.add(entryKey(e));
+    }
+    const kept = file.entries.filter((e) => !dropKeys.has(entryKey(e)));
+    const next = emitPool(file, kept);
+    const nextLines = next.split("\n").length;
+    if (nextLines > MAX_POOL_LINES) {
+      return { kind: "still-over-cap", totalLines: nextLines, filePath };
+    }
+    const tmp = `${filePath}.tmp.${process.pid}`;
+    await fs.writeFile(tmp, next);
+    await fs.rename(tmp, filePath);
+    return {
+      kind: "applied",
+      filePath,
+      totalLines: nextLines,
+      kept: kept.length,
+      dropped: file.entries.length - kept.length,
+    };
+  });
+}
+
+function entryKey(e: PoolEntry): string {
+  return `${e.source}|${e.issueId}|${e.ts}`;
+}
+
+export function formatTrimProposal(
+  file: PoolFile,
+  proposal: TrimProposal,
+  opts?: { dropMaybes?: boolean },
+): string {
+  const dropMaybes = !!opts?.dropMaybes;
+  const kept = selectKeptEntries(file, proposal.verdicts, { dropMaybes });
+  const dropped = file.entries.length - kept.length;
+  const projectedLines = emitPool(file, kept).split("\n").length;
+  const out: string[] = [];
+  out.push(
+    `Trim proposal for '${proposal.domain}': ${proposal.totalEntries} entries, ${proposal.totalLines}/${MAX_POOL_LINES} lines.`,
+  );
+  out.push("");
+  for (const v of proposal.verdicts) {
+    const e = file.entries[v.entryIndex];
+    if (!e) continue;
+    const tag = v.verdict.toUpperCase().padEnd(5);
+    out.push(
+      `  [${tag}] entry ${v.entryIndex}  ${e.source} #${e.issueId} ${e.ts}`,
+    );
+    out.push(`         ${v.rationale}`);
+  }
+  out.push("");
+  out.push(
+    `Outcome (dropMaybes=${dropMaybes}): keep ${kept.length} / drop ${dropped} → projected ${projectedLines}/${MAX_POOL_LINES} lines.`,
+  );
+  return out.join("\n");
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -80,8 +80,18 @@ import {
 import {
   listSharedLessonDomains,
   MAX_POOL_LINES,
+  sharedLessonsPath,
   type LessonTier,
 } from "./agent/sharedLessons.js";
+import {
+  applyTrimProposal,
+  formatTrimProposal,
+  proposeTrim,
+  type ApplyTrimResult,
+  type PoolFile,
+  type TrimProposal,
+} from "./agent/trimPool.js";
+import { isValidDomain } from "./util/promotionMarkers.js";
 import {
   loadAllOutcomes,
   pollOutcomes,
@@ -253,6 +263,17 @@ export function buildCli(): Command {
         .option("--global", "Append accepted entries to the global pool (~/.vaultpilot/shared-lessons/) instead of the per-target pool")
         .action(async (opts) => {
           await cmdLessonsReview(opts);
+        }),
+    )
+    .addCommand(
+      new Command("trim")
+        .description("LLM-driven proposal to drop low-signal entries from a shared-lesson pool that hit the line cap")
+        .argument("<domain>", "Pool domain to trim (e.g. 'solana'). Must match an existing pool file under agents/.shared/lessons/.")
+        .option("--json", "Print the ranked proposal as JSON and exit (no mutation)")
+        .option("--yes", "Auto-accept the LLM's proposal (required for non-TTY environments)")
+        .option("--drop-maybes", "Treat 'maybe' verdicts as drops too (default: keep them)")
+        .action(async (domain, opts) => {
+          await cmdLessonsTrim(domain, opts);
         }),
     );
   program.addCommand(lessonsCmd);
@@ -1711,6 +1732,100 @@ async function cmdCleanupIncompleteBranches(
   );
   process.stdout.write(
     "  git push origin --delete <branch>   (per branch; review before running)\n",
+  );
+}
+
+interface LessonsTrimOpts {
+  json?: boolean;
+  yes?: boolean;
+  dropMaybes?: boolean;
+}
+
+async function cmdLessonsTrim(domain: string, opts: LessonsTrimOpts): Promise<void> {
+  if (!isValidDomain(domain)) {
+    process.stderr.write(
+      `ERROR: invalid domain '${domain}': expected lowercase dash-separated tag (e.g. 'solana', 'eip-712').\n`,
+    );
+    process.exit(2);
+  }
+  const filePath = sharedLessonsPath("target", domain);
+  try {
+    await fs.access(filePath);
+  } catch {
+    process.stderr.write(
+      `ERROR: no shared-lesson pool found for domain '${domain}' at ${filePath}.\n`,
+    );
+    process.exit(2);
+  }
+
+  process.stderr.write(`Generating trim proposal for '${domain}'...\n`);
+  const runId = `trim-${new Date().toISOString().replace(/[:.]/g, "-")}-${domain}`;
+  const logger = new Logger({ runId, verbose: false });
+  await logger.open();
+  let result: { proposal: TrimProposal; file: PoolFile };
+  try {
+    result = await proposeTrim({ domain, logger });
+  } catch (err) {
+    process.stderr.write(`ERROR: trim proposal failed: ${(err as Error).message}\n`);
+    await logger.close();
+    process.exit(2);
+  } finally {
+    await logger.close();
+  }
+
+  const { proposal, file } = result;
+  const dropMaybes = !!opts.dropMaybes;
+
+  if (opts.json) {
+    process.stdout.write(
+      JSON.stringify({ proposal, dropMaybes }, null, 2) + "\n",
+    );
+    return;
+  }
+
+  if (proposal.totalEntries === 0) {
+    process.stdout.write(`Pool for '${domain}' has no entries — nothing to trim.\n`);
+    return;
+  }
+
+  process.stdout.write(formatTrimProposal(file, proposal, { dropMaybes }) + "\n\n");
+
+  if (!opts.yes) {
+    if (!process.stdin.isTTY) {
+      process.stderr.write(
+        "ERROR: stdin is not a TTY and --yes was not passed. Re-run with --yes to auto-accept, or pipe to a TTY.\n",
+      );
+      process.exit(2);
+    }
+    const { createInterface } = await import("node:readline/promises");
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    let answer: string;
+    try {
+      answer = (await rl.question("Apply this trim? [y/N] ")).trim().toLowerCase();
+    } finally {
+      rl.close();
+    }
+    if (answer !== "y" && answer !== "yes") {
+      process.stdout.write("Aborted — no mutation.\n");
+      return;
+    }
+  } else {
+    process.stdout.write("Auto-confirmed (--yes).\n");
+  }
+
+  const applied: ApplyTrimResult = await applyTrimProposal({
+    proposal,
+    file,
+    dropMaybes,
+  });
+  if (applied.kind === "still-over-cap") {
+    process.stderr.write(
+      `REFUSED: trimmed pool would still be ${applied.totalLines}/${MAX_POOL_LINES} lines. The model didn't drop enough — re-run \`vp-dev lessons trim ${domain}\` (optionally with --drop-maybes) or edit ${applied.filePath} by hand.\n`,
+    );
+    process.exit(2);
+  }
+  process.stdout.write(
+    `Trimmed '${domain}': kept ${applied.kept}, dropped ${applied.dropped}, ${applied.totalLines}/${MAX_POOL_LINES} lines. (${applied.filePath})\n`,
   );
 }
 

--- a/src/util/trimPool.test.ts
+++ b/src/util/trimPool.test.ts
@@ -1,0 +1,402 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import {
+  applyTrimProposal,
+  buildTrimUserPrompt,
+  emitPool,
+  formatTrimProposal,
+  parsePool,
+  reconcileVerdicts,
+  selectKeptEntries,
+  type PoolEntry,
+  type PoolFile,
+  type TrimProposal,
+  type TrimVerdict,
+} from "../agent/trimPool.js";
+import { MAX_POOL_LINES } from "../agent/sharedLessons.js";
+
+function makePoolContent(domain: string, entries: { source: string; issueId: number; ts: string; body: string }[]): string {
+  const header =
+    `# Shared lessons: ${domain}\n` +
+    `\n` +
+    `Curated cross-agent lessons for the \`${domain}\` domain.\n` +
+    `\n` +
+    `\n`;
+  const blocks = entries
+    .map(
+      (e) =>
+        `<!-- entry source:${e.source} issue:#${e.issueId} ts:${e.ts} -->\n${e.body}\n`,
+    )
+    .join("");
+  return header + blocks;
+}
+
+test("parsePool: extracts header + entries; empty pool yields zero entries", () => {
+  const content = makePoolContent("solana", []);
+  const file = parsePool("solana", content);
+  assert.equal(file.domain, "solana");
+  assert.equal(file.entries.length, 0);
+  assert.match(file.header, /# Shared lessons: solana/);
+});
+
+test("parsePool: parses single entry with multi-line body", () => {
+  const content = makePoolContent("solana", [
+    {
+      source: "agent-90e4",
+      issueId: 42,
+      ts: "2026-04-29T12:00:00.000Z",
+      body: "Solana RPC X behaves like Y.\nConfirm with `getRecentBlockhash`.",
+    },
+  ]);
+  const file = parsePool("solana", content);
+  assert.equal(file.entries.length, 1);
+  const e = file.entries[0];
+  assert.equal(e.index, 0);
+  assert.equal(e.source, "agent-90e4");
+  assert.equal(e.issueId, 42);
+  assert.equal(e.ts, "2026-04-29T12:00:00.000Z");
+  assert.match(e.body, /Solana RPC X behaves like Y/);
+  assert.match(e.body, /getRecentBlockhash/);
+});
+
+test("parsePool: parses multiple entries in pool order", () => {
+  const content = makePoolContent("eip-712", [
+    {
+      source: "agent-1111",
+      issueId: 1,
+      ts: "2026-01-01T00:00:00.000Z",
+      body: "Entry one body.",
+    },
+    {
+      source: "agent-2222",
+      issueId: 2,
+      ts: "2026-02-02T00:00:00.000Z",
+      body: "Entry two body line A.\nEntry two body line B.",
+    },
+    {
+      source: "agent-3333",
+      issueId: 3,
+      ts: "2026-03-03T00:00:00.000Z",
+      body: "Entry three body.",
+    },
+  ]);
+  const file = parsePool("eip-712", content);
+  assert.equal(file.entries.length, 3);
+  assert.equal(file.entries[0].issueId, 1);
+  assert.equal(file.entries[1].issueId, 2);
+  assert.equal(file.entries[2].issueId, 3);
+  assert.match(file.entries[1].body, /Entry two body line A/);
+  assert.match(file.entries[1].body, /Entry two body line B/);
+});
+
+test("parsePool: rejects invalid domain", () => {
+  assert.throws(() => parsePool("Bad-Domain", "ignored"));
+  assert.throws(() => parsePool("", "ignored"));
+});
+
+test("emitPool roundtrips an unchanged pool", () => {
+  const content = makePoolContent("solana", [
+    {
+      source: "agent-aaaa",
+      issueId: 10,
+      ts: "2026-04-01T00:00:00.000Z",
+      body: "Body one.",
+    },
+    {
+      source: "agent-bbbb",
+      issueId: 20,
+      ts: "2026-04-02T00:00:00.000Z",
+      body: "Body two\nwith two lines.",
+    },
+  ]);
+  const file = parsePool("solana", content);
+  const reEmitted = emitPool(file, file.entries);
+  // The re-emitted file must parse back to the same entry set verbatim.
+  const round = parsePool("solana", reEmitted);
+  assert.equal(round.entries.length, 2);
+  assert.equal(round.entries[0].source, "agent-aaaa");
+  assert.equal(round.entries[0].body, "Body one.");
+  assert.equal(round.entries[1].source, "agent-bbbb");
+  assert.equal(round.entries[1].body, "Body two\nwith two lines.");
+});
+
+test("selectKeptEntries: drop verdicts always drop; maybe kept by default", () => {
+  const file: PoolFile = {
+    domain: "solana",
+    header: "",
+    entries: [
+      mkEntry(0, "a", 1, "t1", "body0"),
+      mkEntry(1, "b", 2, "t2", "body1"),
+      mkEntry(2, "c", 3, "t3", "body2"),
+    ],
+    totalLines: 0,
+  };
+  const verdicts: TrimVerdict[] = [
+    { entryIndex: 0, verdict: "keep", rationale: "" },
+    { entryIndex: 1, verdict: "maybe", rationale: "" },
+    { entryIndex: 2, verdict: "drop", rationale: "" },
+  ];
+  const keptDefault = selectKeptEntries(file, verdicts);
+  assert.deepEqual(keptDefault.map((e) => e.index), [0, 1]);
+
+  const keptDropMaybes = selectKeptEntries(file, verdicts, { dropMaybes: true });
+  assert.deepEqual(keptDropMaybes.map((e) => e.index), [0]);
+});
+
+test("reconcileVerdicts: missing verdict defaults to keep; out-of-range ignored", () => {
+  const file: PoolFile = {
+    domain: "solana",
+    header: "",
+    entries: [
+      mkEntry(0, "a", 1, "t", "b"),
+      mkEntry(1, "b", 2, "t", "b"),
+      mkEntry(2, "c", 3, "t", "b"),
+    ],
+    totalLines: 0,
+  };
+  const raw: TrimVerdict[] = [
+    { entryIndex: 0, verdict: "drop", rationale: "x" },
+    { entryIndex: 99, verdict: "drop", rationale: "out of range" },
+    { entryIndex: 2, verdict: "drop", rationale: "x" },
+    // entry 1 deliberately omitted
+  ];
+  const sane = reconcileVerdicts(file, raw);
+  assert.equal(sane.length, 3);
+  assert.equal(sane[0].entryIndex, 0);
+  assert.equal(sane[0].verdict, "drop");
+  assert.equal(sane[1].entryIndex, 1);
+  assert.equal(sane[1].verdict, "keep");
+  assert.match(sane[1].rationale, /defaulting to keep/);
+  assert.equal(sane[2].entryIndex, 2);
+  assert.equal(sane[2].verdict, "drop");
+});
+
+test("reconcileVerdicts: dedups duplicate verdicts on the same entryIndex", () => {
+  const file: PoolFile = {
+    domain: "solana",
+    header: "",
+    entries: [mkEntry(0, "a", 1, "t", "b")],
+    totalLines: 0,
+  };
+  const raw: TrimVerdict[] = [
+    { entryIndex: 0, verdict: "keep", rationale: "first" },
+    { entryIndex: 0, verdict: "drop", rationale: "second (dropped)" },
+  ];
+  const sane = reconcileVerdicts(file, raw);
+  assert.equal(sane.length, 1);
+  assert.equal(sane[0].verdict, "keep");
+  assert.equal(sane[0].rationale, "first");
+});
+
+test("buildTrimUserPrompt: includes per-entry index, source, issueId, ts", () => {
+  const file = parsePool(
+    "solana",
+    makePoolContent("solana", [
+      { source: "agent-aa", issueId: 5, ts: "2026-01-01T00:00:00.000Z", body: "X" },
+      { source: "agent-bb", issueId: 6, ts: "2026-02-01T00:00:00.000Z", body: "Y" },
+    ]),
+  );
+  const prompt = buildTrimUserPrompt(file);
+  assert.match(prompt, /entry 0/);
+  assert.match(prompt, /agent-aa/);
+  assert.match(prompt, /issue=#5/);
+  assert.match(prompt, /ts=2026-01-01T00:00:00.000Z/);
+  assert.match(prompt, /entry 1/);
+  assert.match(prompt, /agent-bb/);
+  assert.match(prompt, /Emit verdicts JSON now\./);
+});
+
+test("formatTrimProposal: surfaces verdict tags and projected line count", () => {
+  const file = parsePool(
+    "solana",
+    makePoolContent("solana", [
+      { source: "a", issueId: 1, ts: "2026-01-01T00:00:00.000Z", body: "alpha" },
+      { source: "b", issueId: 2, ts: "2026-02-01T00:00:00.000Z", body: "beta" },
+    ]),
+  );
+  const proposal: TrimProposal = {
+    domain: "solana",
+    filePath: "/tmp/solana.md",
+    totalEntries: 2,
+    totalLines: file.totalLines,
+    verdicts: [
+      { entryIndex: 0, verdict: "drop", rationale: "stale" },
+      { entryIndex: 1, verdict: "keep", rationale: "useful" },
+    ],
+  };
+  const text = formatTrimProposal(file, proposal);
+  assert.match(text, /\[DROP \] entry 0/);
+  assert.match(text, /\[KEEP \] entry 1/);
+  assert.match(text, /stale/);
+  assert.match(text, /useful/);
+  assert.match(text, /keep 1 \/ drop 1/);
+  assert.match(text, new RegExp(`/${MAX_POOL_LINES} lines`));
+});
+
+test("applyTrimProposal: rewrites pool dropping the targeted entries", async () => {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vp-trim-pool-"));
+  // applyTrimProposal goes through sharedLessonsPath(domain), which is
+  // pinned to AGENTS_ROOT/.shared/lessons/. To exercise the function
+  // end-to-end without coupling to that root, redirect via the proposal's
+  // explicit filePath.
+  const filePath = path.join(tmpRoot, "test-domain.md");
+  const content = makePoolContent("solana", [
+    { source: "agent-a", issueId: 1, ts: "2026-01-01T00:00:00.000Z", body: "alpha line one\nalpha line two" },
+    { source: "agent-b", issueId: 2, ts: "2026-02-01T00:00:00.000Z", body: "beta only line" },
+    { source: "agent-c", issueId: 3, ts: "2026-03-01T00:00:00.000Z", body: "gamma line" },
+  ]);
+  await fs.writeFile(filePath, content);
+  const file = parsePool("solana", content);
+  const proposal: TrimProposal = {
+    domain: "solana",
+    filePath,
+    totalEntries: 3,
+    totalLines: file.totalLines,
+    verdicts: [
+      { entryIndex: 0, verdict: "drop", rationale: "stale" },
+      { entryIndex: 1, verdict: "keep", rationale: "useful" },
+      { entryIndex: 2, verdict: "maybe", rationale: "narrow" },
+    ],
+  };
+
+  // Default: keep maybes.
+  const result = await applyTrimProposal({ proposal, file });
+  assert.equal(result.kind, "applied");
+  if (result.kind !== "applied") return;
+  assert.equal(result.kept, 2);
+  assert.equal(result.dropped, 1);
+  const after = await fs.readFile(filePath, "utf-8");
+  const reparsed = parsePool("solana", after);
+  assert.deepEqual(
+    reparsed.entries.map((e) => e.source),
+    ["agent-b", "agent-c"],
+  );
+  assert.equal(reparsed.entries[0].body, "beta only line");
+  assert.equal(reparsed.entries[1].body, "gamma line");
+
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+test("applyTrimProposal: dropMaybes also removes 'maybe' entries", async () => {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vp-trim-pool-"));
+  const filePath = path.join(tmpRoot, "test-domain.md");
+  const content = makePoolContent("eip-712", [
+    { source: "agent-a", issueId: 1, ts: "2026-01-01T00:00:00.000Z", body: "alpha" },
+    { source: "agent-b", issueId: 2, ts: "2026-02-01T00:00:00.000Z", body: "beta" },
+    { source: "agent-c", issueId: 3, ts: "2026-03-01T00:00:00.000Z", body: "gamma" },
+  ]);
+  await fs.writeFile(filePath, content);
+  const file = parsePool("eip-712", content);
+  const proposal: TrimProposal = {
+    domain: "eip-712",
+    filePath,
+    totalEntries: 3,
+    totalLines: file.totalLines,
+    verdicts: [
+      { entryIndex: 0, verdict: "keep", rationale: "" },
+      { entryIndex: 1, verdict: "maybe", rationale: "" },
+      { entryIndex: 2, verdict: "drop", rationale: "" },
+    ],
+  };
+
+  const result = await applyTrimProposal({ proposal, file, dropMaybes: true });
+  assert.equal(result.kind, "applied");
+  if (result.kind !== "applied") return;
+  assert.equal(result.kept, 1);
+  assert.equal(result.dropped, 2);
+  const after = await fs.readFile(filePath, "utf-8");
+  const reparsed = parsePool("eip-712", after);
+  assert.deepEqual(reparsed.entries.map((e) => e.source), ["agent-a"]);
+
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+test("applyTrimProposal: refuses to write if result still exceeds line cap", async () => {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vp-trim-pool-"));
+  const filePath = path.join(tmpRoot, "test-domain.md");
+  // Build a pool that overflows MAX_POOL_LINES even with a single entry.
+  const giantBody = Array.from({ length: MAX_POOL_LINES + 50 }, (_, i) => `line ${i}`).join("\n");
+  const content = makePoolContent("solana", [
+    { source: "agent-a", issueId: 1, ts: "2026-01-01T00:00:00.000Z", body: giantBody },
+  ]);
+  await fs.writeFile(filePath, content);
+  const file = parsePool("solana", content);
+  const proposal: TrimProposal = {
+    domain: "solana",
+    filePath,
+    totalEntries: 1,
+    totalLines: file.totalLines,
+    verdicts: [{ entryIndex: 0, verdict: "keep", rationale: "" }],
+  };
+  const result = await applyTrimProposal({ proposal, file });
+  assert.equal(result.kind, "still-over-cap");
+  // File must NOT have been mutated.
+  const after = await fs.readFile(filePath, "utf-8");
+  assert.equal(after, content);
+
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+test("applyTrimProposal: drift-tolerant — entry appended after propose is preserved", async () => {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vp-trim-pool-"));
+  const filePath = path.join(tmpRoot, "test-domain.md");
+  const initialEntries = [
+    { source: "agent-a", issueId: 1, ts: "2026-01-01T00:00:00.000Z", body: "alpha" },
+    { source: "agent-b", issueId: 2, ts: "2026-02-01T00:00:00.000Z", body: "beta" },
+  ];
+  await fs.writeFile(filePath, makePoolContent("solana", initialEntries));
+  const file = parsePool("solana", await fs.readFile(filePath, "utf-8"));
+
+  // Simulate a concurrent append between propose and apply.
+  const driftedEntries = [
+    ...initialEntries,
+    { source: "agent-c", issueId: 3, ts: "2026-03-01T00:00:00.000Z", body: "gamma (appended after propose)" },
+  ];
+  await fs.writeFile(filePath, makePoolContent("solana", driftedEntries));
+
+  // Proposal still references the propose-time entry indices (0, 1) only.
+  const proposal: TrimProposal = {
+    domain: "solana",
+    filePath,
+    totalEntries: 2,
+    totalLines: file.totalLines,
+    verdicts: [
+      { entryIndex: 0, verdict: "drop", rationale: "stale" },
+      { entryIndex: 1, verdict: "keep", rationale: "useful" },
+    ],
+  };
+
+  const result = await applyTrimProposal({ proposal, file });
+  assert.equal(result.kind, "applied");
+  if (result.kind !== "applied") return;
+  // agent-a dropped, agent-b kept, agent-c (drifted-in) preserved.
+  const after = await fs.readFile(filePath, "utf-8");
+  const reparsed = parsePool("solana", after);
+  assert.deepEqual(
+    reparsed.entries.map((e) => e.source),
+    ["agent-b", "agent-c"],
+  );
+
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+function mkEntry(
+  index: number,
+  source: string,
+  issueId: number,
+  ts: string,
+  body: string,
+): PoolEntry {
+  return {
+    index,
+    source,
+    issueId,
+    ts,
+    body,
+    startLine: 0,
+    endLine: 0,
+  };
+}


### PR DESCRIPTION
Closes #102.

## Summary

Adds `vp-dev lessons trim <domain>` — a sonnet-driven curation step the human can invoke when a shared-lesson pool hits the 200-line cap, so reviewers aren't kicked out of `vp-dev lessons review` to manually edit the pool file mid-review.

The flow:

1. Read `agents/.shared/lessons/<domain>.md` and parse it into header + indexed entries.
2. Send the entries to a sonnet model with a "rank by lasting signal" prompt; receive `{verdicts: [{entryIndex, verdict, rationale}]}`.
3. Surface the proposal to the human (interactive `[y/N]` or `--yes`); on accept, rewrite the pool keeping `keep` entries (and `maybe` unless `--drop-maybes`).
4. `--json` prints the ranked proposal without writing.

## Behaviour bounds preserved

- The trim model only emits verdicts; it never rewrites entry text. The per-entry length caps from `validateEntry` (≤ 40 non-empty lines, ≤ 1500 chars) are enforced at promotion time and cannot be expanded by trim.
- Apply runs under the same per-file lock as `appendLessonToPool`, re-reads the pool inside the lock, and matches kept entries by `(source, issueId, ts)` so a concurrent append between propose and apply is preserved (treated as keep).
- Apply refuses to write if the trimmed pool would still exceed `MAX_POOL_LINES` — falls back to a clear error message asking the human to re-run with `--drop-maybes` or hand-edit.
- The 200-line cap rejection in `acceptCandidate()` continues to fire — trim is a separate user-driven escape hatch, not an automatic one.

## Files (3, matches the issue scope)

- `src/agent/trimPool.ts` — new helper: parse, emit, propose (LLM), apply (under lock).
- `src/cli.ts` — register `vp-dev lessons trim <domain>`; flags: `--json`, `--yes`, `--drop-maybes`.
- `src/util/trimPool.test.ts` — 14 tests covering parse roundtrip, verdict reconciliation, default vs `dropMaybes`, line-cap refusal, drift-tolerant apply.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run build` clean.
- [x] `npm test` — 99/99 tests pass (14 new).
- [x] Manual smoke: `vp-dev lessons trim --help`, `vp-dev lessons trim doesnotexist` (clean error), `vp-dev lessons trim BadDomain` (invalid-domain error).

— Advisory Scope Boundary (agent-916a)
