### PR TITLE
Extend failure-summarizer with promote-candidate marker mechanic

### DIFF
--- a/src/agent/summarizer.ts
+++ b/src/agent/summarizer.ts
@@ -249,6 +249,17 @@ Three questions to anchor the body:
 
 Style: match the dense rule-form of an existing CLAUDE.md section. Lead with the rule itself in bold. Then a **Why:** line (the failure mode this targets). Then a **How to apply:** line (when this guidance kicks in). Use **Tells:** sparingly. Markdown hyperlinks (\`[label](url)\`) over raw URLs.
 
+Cross-agent promotion (optional, gated by human review):
+- If the failure mode is STRUCTURAL — a fact about the SDK, the tooling, the protocol, or the framework that any sibling agent in the same domain would hit the same way — wrap the cross-agent useful piece inside the \`body\` between two HTML comments:
+    <!-- promote-candidate:<domain> -->
+    <descriptive observation, multiple lines OK>
+    <!-- /promote-candidate -->
+- The \`<domain>\` MUST be one of the agent's current tags listed under "Pre-run agent tags" or "Tags added this run".
+- Use SPARINGLY — most failure lessons are agent-internal artifacts (this agent's tool sequencing was inefficient, this agent burned turns on a config quirk, context-window bloat). Those stay agent-local and MUST NOT be wrapped. Only structural facts ("Anthropic SDK X has known shape Y", "ERC-4626 reverts on zero-share deposit", "Solana RPC Z drops txs above N CU") earn the wrapper.
+- The wrapped content must read as a DESCRIPTIVE OBSERVATION, not an instruction to other agents. Avoid "you must / should", "the agent must" — use indicative voice.
+- Cap the wrapped content at ~40 non-empty lines / ~1500 chars.
+- Promote-candidates are queued for human review; they do NOT auto-promote. The human reviewer rejects noise.
+
 Hard rules:
 - If the failure was genuinely uninformative (single ambiguous error string, no agent reasoning, no clear missed assumption), emit \`{"skip": true, "skipReason": "<one short sentence>"}\`. Wrong-lesson risk beats noisy-lesson risk.
 - Heading: ≤ 120 chars, no trailing colon, no markdown prefix (no leading "##"). The append step prepends "##".

--- a/src/util/promotionMarkers.test.ts
+++ b/src/util/promotionMarkers.test.ts
@@ -89,6 +89,38 @@ test("findPromoteCandidates: nested open invalidates outer; inner is matched", (
   assert.equal(found[0].domain, "inner");
 });
 
+test("findPromoteCandidates: kind-agnostic — finds markers inside outcome:failure-lesson blocks", () => {
+  // Failure-derived blocks share the same body shape as success-derived
+  // ones; the only difference is the sentinel header above the heading.
+  // This guards the contract that `vp-dev lessons review` surfaces both
+  // kinds via the same marker walk.
+  const md = [
+    "<!-- run:run-A issue:#1 outcome:implement ts:2026-05-05T00:00:00.000Z tags:solana -->",
+    "## Success-derived rule",
+    "",
+    "Body of a success rule.",
+    "<!-- promote-candidate:solana -->",
+    "Solana RPC X drops txs above N compute units.",
+    "<!-- /promote-candidate -->",
+    "",
+    "<!-- run:run-B issue:#2 outcome:failure-lesson ts:2026-05-05T00:01:00.000Z tags:eip-712 -->",
+    "## Failure-derived rule",
+    "",
+    "Body of a failure rule.",
+    "<!-- promote-candidate:eip-712 -->",
+    "EIP-712 typed-data digests do not authenticate the tree itself.",
+    "<!-- /promote-candidate -->",
+  ].join("\n");
+  const found = findPromoteCandidates(md);
+  assert.equal(found.length, 2);
+  assert.equal(found[0].domain, "solana");
+  assert.equal(found[1].domain, "eip-712");
+  assert.equal(
+    found[1].body,
+    "EIP-712 typed-data digests do not authenticate the tree itself.",
+  );
+});
+
 test("findPromoteCandidates: ignores blocks with invalid domain shape", () => {
   const md = [
     "<!-- promote-candidate:Bad-Domain -->",


### PR DESCRIPTION
Closes #103

## Summary

Extends `FAILURE_SUMMARIZER_SYSTEM_PROMPT` in `src/agent/summarizer.ts` with the cross-agent `<!-- promote-candidate:<domain> -->` mechanic that already exists on the success-summarizer prompt (shipped via PR #81). Failure-derived lessons can now opt-in to the same human-gated review path, surfacing structural warnings (SDK shape quirks, protocol invariants, framework gotchas) to sibling agents in the same domain.

## Approach

- The new prompt section mirrors the success-summarizer's wording but carries a stronger "use sparingly" bias. Most failure lessons are agent-internal artifacts (this agent's tool sequencing was inefficient, context-window bloat, idiosyncratic config) and MUST NOT be wrapped — only structural facts that any sibling agent in the same domain would hit the same way earn the wrapper.
- Per-entry length caps (~40 lines / ~1500 chars), descriptive-observation phrasing, and domain-must-be-a-tag rules are spelled out identically to the success path. Hard caps and imperative-phrasing detection are still enforced at promotion time in `acceptCandidate()` / `validateEntry()`, not at summarizer time.
- No code change in `src/agent/promotion.ts`, `src/agent/sharedLessons.ts`, or `src/cli.ts`. Confirmed by inspection that the existing review walker is kind-agnostic: `findPromoteCandidates` matches the marker pattern over the entire file content with no awareness of the surrounding `outcome:implement` vs `outcome:failure-lesson` sentinel header, and `collectPendingCandidates` calls it as-is.
- Added an explicit test (`findPromoteCandidates: kind-agnostic — finds markers inside outcome:failure-lesson blocks`) that pins this contract so a future filter regression would surface.

## Out of scope (from issue body)

- Auto-promotion of failure lessons.
- A `--failure-only` filter on `vp-dev lessons review`.
- Stripping the `**Why:** failure mode this targets` rationale from candidate bodies.

## Test plan

- [x] `npm run build` passes.
- [x] `npm run typecheck` passes.
- [x] `npm test` passes (86/86 — the new kind-agnostic test brings the count from 85 to 86).
- [ ] Next failure-summarizer run on a structural SDK / protocol failure should produce a body that includes `<!-- promote-candidate:<domain> -->` for the structural fact (judgment-call, not auto-fired).
- [ ] `vp-dev lessons review` continues to surface candidates from both implement and failure-lesson blocks identically.

— Floyd (agent-e287)
