### PR TITLE
agent: closing-sequence discipline in workflow prompt (#115)

### DIFF
--- a/src/agent/workflow.ts
+++ b/src/agent/workflow.ts
@@ -67,6 +67,28 @@ Emit the JSON envelope with decision="pushback" and the comment URL.
      gh pr create --repo ${v.targetRepo} --base main --head ${v.branchName} --title <short title> --body-file <tmp>
 7. Format the returned PR URL as a Markdown hyperlink in your reasoning.
 
+## Step 3.5 — Closing-sequence discipline (read before you start editing)
+
+The closing ceremony — build → test → stage → commit → push → write PR body → \`gh pr create\` → envelope — costs **~8 turns minimum** as separate Bash invocations. Reserve at least that much budget; agents that ignore this consistently run out of turns *after* the work is substantively done, leaving an unmerged branch and burning the run's cost.
+
+**No verification ceremony after \`git push\`.** Once the push succeeds, the very next tool call MUST be \`gh pr create\`. Do NOT:
+- run \`git status\` / \`git log\` to "check the push landed" — exit code 0 from \`git push\` is the confirmation,
+- query \`gh pr list\` for an existing PR on the branch — the orchestrator pre-flight (per PR #74) already guaranteed the branch is fresh,
+- diff against \`origin/main\` to check whether commits already landed,
+- re-read source files or the issue body to "double-check the change."
+
+These post-push checks are the verification-ceremony anti-pattern — they cost 4–6 turns each at exactly the moment you have the fewest left.
+
+**Test-debug loop has a hard exit ramp.** If \`npm test\` fails and you have **fewer than 8 turns remaining**, STOP iterating on the test. Instead:
+1. Stage your in-progress files (\`git add <explicit paths>\`).
+2. Commit with a message of the form \`WIP: <one-line summary> — failing: <test name>\` (still ending with the \`Co-Authored-By\` trailer).
+3. Push the branch.
+4. Skip \`gh pr create\` and go straight to the envelope with \`decision: "error"\`, putting the failing-test name and last error line into \`reason\`.
+
+The orchestrator's recovery pass (PR [#92](https://github.com/szhygulin/vaultpilot-development-agents/pull/92)) salvages the partial branch — a known-incomplete attempt with a clean \`error\` envelope is strictly better than running out of turns mid-debug with no envelope at all.
+
+**Investigative-coding signal.** If you find yourself re-reading the same source file twice during the closing third of your turns, that's a tell that the change map wasn't complete before you started editing. Stop reading; make the smallest additional edit that compiles + passes tests; ship. Save the "I should have planned more" insight for a memory tag, not for more reads on this run.
+
 ## Step 4 — Emit the JSON envelope as your FINAL message
 
 Wrap it in a fenced \`\`\`json block. Schema:


### PR DESCRIPTION
Closes #115

## Summary

Adds a `Step 3.5 — Closing-sequence discipline` section to the coding-agent workflow prompt (`src/agent/workflow.ts`). Targets the three concrete patterns from `run-2026-05-05T11-30-15-426Z` that burned 50-turn budgets *after* the substantive work was done:

1. **Verification ceremony after `git push`** (Pattern 1, agent-08c4 / Khwarizmi on #86) — explicit prohibition of post-push `git status`/`git log`/`gh pr list`/diff checks. The very next tool call after a successful push must be `gh pr create`.
2. **Test-debug loop with no exit ramp** (Pattern 2, agent-92ff / Alonzo on #99) — when `npm test` fails with **<8 turns remaining**, the prompt now mandates: stage in-flight files → commit `WIP: … — failing: <test>` → push → emit `decision: "error"` with the failing-test name in `reason`. The salvage path in PR [#92](https://github.com/szhygulin/vaultpilot-development-agents/pull/92) (broadened by `shouldPushPartial`) catches it.
3. **Investigative re-reading** (Pattern 3, agent-e287 / Floyd on #84) — adds a "stop reading; make the smallest closing edit that compiles" tell, so the agent recognizes the symptom mid-run.

Also documents the closing-sequence budget (~8 turns minimum: build → test → stage → commit → push → write PR body → `gh pr create` → envelope) up front so agents reserve it before starting.

## Why a prompt-only change

The acceptance criteria for #115 are:
- "the workflow prompt explicitly forbids the verification-ceremony pattern",
- "the workflow prompt explicitly handles the test-debug loop case (escalate to `decision: error` with <N turns left rather than iterating)".

Both land in the streamed system prompt. The orchestrator-side recovery already exists (`shouldPushPartial` in `src/agent/shouldPushPartial.ts`, salvaging `error_max_turns` / `error_during_execution` / `error_max_budget_usd` / catch-all). The gap was the agent-side knowledge that escalating to `error` *while turns remain* is preferable to running out mid-debug — which now lives in the prompt.

Suggested-direction A (cheaper closing-sequence combo commands at the dry-run gate) is **deliberately deferred** — it touches the gate's compound-command regex which the project rules call out as load-bearing security (incident `a3cd8dc`). That belongs in its own PR with explicit scope sign-off, not bundled here.

## What's not in scope

- Cost-ceiling work (#98 / PR [#106](https://github.com/szhygulin/vaultpilot-development-agents/pull/106)) — orthogonal; the prompt fixes apply at any cap.
- Auto-resume from partial branches — separate feature.
- Surfacing turns-remaining to the agent (suggested-direction C) — defer until A + B prove insufficient.

## Test plan

- [x] `npm run build` passes (tsc clean).
- [x] `npm test` passes (192/192 tests, no regressions in `sharedLessons.test.ts` / `shouldPushPartial.test.ts`).
- [ ] Future run hitting the 50-turn cap surfaces a closing-ceremony failure mode that the prompt now explicitly addresses — empirical validation.

— Floyd (agent-e287)
