### PR TITLE
feat(resume): Phase 1 detection + signal for salvageable partial branches

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,6 +49,7 @@ import { findOpenVpDevPrs } from "./git/openPrs.js";
 import {
   DEFAULT_INCOMPLETE_RETENTION_DAYS,
   filterByRetention,
+  findIncompleteBranchesOnOrigin,
   listIncompleteBranches,
   pruneIncompleteBranches,
   resolveRetentionDays,
@@ -146,6 +147,10 @@ export function buildCli(): Command {
     .option(
       "--prefer-agent <agentId>",
       "Force-pick the named agent for this run. Bumps its score by +1.0 in pickAgents() and the dispatcher's deterministic fallback so it leads regardless of natural Jaccard fit. Validated against the registry before the gate; archived agents are rejected.",
+    )
+    .option(
+      "--resume-incomplete",
+      "Phase 1 (#118): record the intent to resume from a salvageable `*-incomplete-<runId>` branch on origin. Phase 1 only logs the intent + carries it through --plan/--confirm; the actual worktree-from-partial-branch behavior is Phase 2's territory (still routes from main today).",
     )
     .action(async (opts) => {
       await cmdRun(opts);
@@ -338,6 +343,7 @@ interface RunOpts {
   includeNonReady?: boolean;
   maxCostUsd?: string;
   preferAgent?: string;
+  resumeIncomplete?: boolean;
 }
 
 async function cmdRun(opts: RunOpts): Promise<void> {
@@ -391,6 +397,10 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     // matches "no ceiling" semantics.
     opts.maxCostUsd = p.maxCostUsd;
     opts.preferAgent = p.preferAgentId;
+    // #118 Phase 1: carry the resume intent across --plan → --confirm.
+    // Phase 1 has no behavior coupling beyond the run-start log line, but
+    // the flag must persist so Phase 2 can light up cleanly.
+    opts.resumeIncomplete = p.resumeIncomplete;
   }
 
   if (opts.agents === undefined || !opts.targetRepo) {
@@ -565,6 +575,22 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     process.exit(2);
   }
 
+  // Issue #118 Phase 1: enumerate salvageable `*-incomplete-<runId>` refs
+  // on `origin` for the candidate dispatch issues so the preview can
+  // surface them under the existing skip blocks. The lookup is purely
+  // informational — failures degrade to "no salvage refs visible" rather
+  // than blocking the run. Always runs regardless of --resume-incomplete
+  // because the section's purpose is to show the user that partial state
+  // exists *before* they decide whether to pass the flag.
+  // No logger here — the triage logger is already closed and the run-id
+  // logger is not yet open. The helper is best-effort: an `ls-remote`
+  // failure simply yields an empty section.
+  const incompleteOrigin = await findIncompleteBranchesOnOrigin({
+    repoPath,
+    issueIds: dispatchIssues.map((i) => i.id),
+  });
+  const incompleteBranchesAvailable = [...incompleteOrigin.values()].flat();
+
   const registry = await loadRegistry();
   const preview = await buildSetupPreview({
     targetRepo: opts.targetRepo,
@@ -583,6 +609,7 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     budgetExceededSkipped,
     budgetUsd,
     preferAgentId: opts.preferAgent,
+    incompleteBranchesAvailable,
   });
 
   if (opts.plan) {
@@ -605,6 +632,8 @@ async function cmdRun(opts: RunOpts): Promise<void> {
         includeNonReady: !!opts.includeNonReady,
         verbose: !!opts.verbose,
         maxCostUsd: opts.maxCostUsd,
+        // #118 Phase 1: carry the resume intent across --plan → --confirm.
+        resumeIncomplete: opts.resumeIncomplete,
       },
     });
     process.stdout.write("Plan saved. No agents launched.\n");
@@ -673,7 +702,23 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     // distinguish "Phase-1 run with no cap" from "older log without
     // cost-tracking columns" without parsing the runId timestamp.
     maxCostUsd: budgetUsd ?? null,
+    // Issue #118 Phase 1: surfaced as a flat boolean so log consumers can
+    // count how often the flag is being passed before Phase 2 ships. The
+    // count of salvageable refs is informational; we record it but the
+    // actual resume routing remains "from main" until Phase 2 lands.
+    resumeIncomplete: !!opts.resumeIncomplete,
+    incompleteBranchesAvailableCount: incompleteBranchesAvailable.length,
   });
+  if (opts.resumeIncomplete) {
+    process.stdout.write(
+      "[--resume-incomplete recorded; Phase 2 wiring not yet shipped — this run still routes from main]\n",
+    );
+    logger.info("run.resume_incomplete_recorded", {
+      runId,
+      phase: 1,
+      incompleteBranchesAvailableCount: incompleteBranchesAvailable.length,
+    });
+  }
 
   try {
     await pruneWorktrees(repoPath);

--- a/src/git/incompleteBranches.test.ts
+++ b/src/git/incompleteBranches.test.ts
@@ -7,6 +7,7 @@ import {
   filterByRetention,
   lookupRunStateRef,
   parseIncompleteRefs,
+  parseLsRemoteIncompleteRefs,
   resolveRetentionDays,
   DEFAULT_INCOMPLETE_RETENTION_DAYS,
 } from "./incompleteBranches.js";
@@ -197,6 +198,59 @@ test("lookupRunStateRef: malformed JSON treated as 'missing' (no throw)", async 
   } finally {
     await fs.rm(dir, { recursive: true, force: true });
   }
+});
+
+// ---- parseLsRemoteIncompleteRefs (issue #118 Phase 1) -------------------
+
+test("parseLsRemoteIncompleteRefs: extracts (issue, agent, runId) from ls-remote --heads output", () => {
+  // Real `git ls-remote --heads origin <pattern>` output: `<sha>\trefs/heads/<branch>`
+  const lines = [
+    "deadbeef0000000000000000000000000000beef\trefs/heads/vp-dev/agent-75a0/issue-88-incomplete-run-2026-05-01T12-00-00-000Z",
+    "cafebabe0000000000000000000000000000cafe\trefs/heads/vp-dev/agent-ef41/issue-1234-incomplete-run-2026-05-02T08-30-00-000Z",
+  ];
+  const out = parseLsRemoteIncompleteRefs(lines);
+  assert.equal(out.length, 2);
+  assert.deepEqual(out[0], {
+    issueId: 88,
+    agentId: "agent-75a0",
+    branchName: "vp-dev/agent-75a0/issue-88-incomplete-run-2026-05-01T12-00-00-000Z",
+    runId: "run-2026-05-01T12-00-00-000Z",
+  });
+  assert.equal(out[1].issueId, 1234);
+  assert.equal(out[1].agentId, "agent-ef41");
+});
+
+test("parseLsRemoteIncompleteRefs: drops non-matching refs (regular vp-dev branches, malformed lines)", () => {
+  // The ls-remote glob may also surface uninteresting refs if a future
+  // caller widens the pattern; the parser must drop them silently rather
+  // than throwing.
+  const lines = [
+    "sha1\trefs/heads/vp-dev/agent-aa00/issue-1", // regular vp-dev branch — no -incomplete- suffix
+    "sha2\trefs/heads/main",
+    "no-tab-line", // entire line missing the SHA\tref shape
+    "", // blank line (often present at the trailing newline of stdout)
+    "sha3\trefs/heads/vp-dev/agent-AB/issue-1-incomplete-run-x", // uppercase agent id rejected
+    "sha4\trefs/heads/vp-dev/agent-bb11/issue-42-incomplete-run-OK", // valid
+  ];
+  const out = parseLsRemoteIncompleteRefs(lines);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].issueId, 42);
+  assert.equal(out[0].runId, "run-OK");
+});
+
+test("parseLsRemoteIncompleteRefs: tolerates refs not prefixed with `refs/heads/` (defensive)", () => {
+  // Some git invocations / future format flags may emit short refs.
+  // Parser strips the prefix when present but also accepts unprefixed.
+  const lines = [
+    "sha1\tvp-dev/agent-bb11/issue-7-incomplete-run-Z",
+  ];
+  const out = parseLsRemoteIncompleteRefs(lines);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].branchName, "vp-dev/agent-bb11/issue-7-incomplete-run-Z");
+});
+
+test("parseLsRemoteIncompleteRefs: empty input yields empty output", () => {
+  assert.deepEqual(parseLsRemoteIncompleteRefs([]), []);
 });
 
 test("lookupRunStateRef: matches across multiple issues in the state file", async () => {

--- a/src/git/incompleteBranches.ts
+++ b/src/git/incompleteBranches.ts
@@ -72,6 +72,19 @@ export interface IncompleteBranchInfo {
   runStateRef: RunStateRef;
 }
 
+/**
+ * Origin-side counterpart to `IncompleteBranchInfo`. Lighter shape because
+ * `git ls-remote` does not surface committer-date metadata — Phase 1 only
+ * needs the (issueId, branchName, runId, agentId) tuple to render the
+ * "salvage available" section in the setup preview (issue #118).
+ */
+export interface OriginIncompleteBranch {
+  issueId: number;
+  agentId: string;
+  branchName: string;
+  runId: string;
+}
+
 /** Raw output of a single `git for-each-ref` line, pre-parse. */
 export interface RawIncompleteRef {
   branch: string;
@@ -258,6 +271,88 @@ export async function pruneIncompleteBranches(opts: {
     }
   }
   return { deleted, failed };
+}
+
+/**
+ * Pure parser — extract `OriginIncompleteBranch` records from raw
+ * `git ls-remote --heads origin <pattern>` output lines. Each line is
+ * `<sha>\t<refspec>` with the refspec carrying a `refs/heads/` prefix; we
+ * strip that and apply the same `INCOMPLETE_BRANCH_RE` shape match used by
+ * the local-branch parser. Lines that don't match are dropped silently.
+ *
+ * Unit-tested in `incompleteBranches.test.ts` so the regex / strip stays
+ * stable independent of git plumbing or future ls-remote format tweaks.
+ */
+export function parseLsRemoteIncompleteRefs(lines: string[]): OriginIncompleteBranch[] {
+  const out: OriginIncompleteBranch[] = [];
+  for (const raw of lines) {
+    if (!raw) continue;
+    const tab = raw.indexOf("\t");
+    if (tab < 0) continue;
+    let ref = raw.slice(tab + 1).trim();
+    if (ref.startsWith("refs/heads/")) ref = ref.slice("refs/heads/".length);
+    const m = INCOMPLETE_BRANCH_RE.exec(ref);
+    if (!m) continue;
+    const [, agentId, issueIdStr, runId] = m;
+    out.push({
+      issueId: parseInt(issueIdStr, 10),
+      agentId,
+      branchName: ref,
+      runId,
+    });
+  }
+  return out;
+}
+
+/**
+ * Enumerate the labeled-incomplete refs (matching the same shape used by
+ * `INCOMPLETE_BRANCH_PATTERN` above) on `origin` for a given set of issue
+ * ids. Single `git ls-remote` over that glob, then in-memory regex parse +
+ * filter. No mutation, no fetch — refs are read directly from the remote
+ * without updating local tracking.
+ *
+ * Returned as `Map<issueId, OriginIncompleteBranch[]>` so the setup
+ * preview can render a per-issue salvage-available section
+ * (issue #118 Phase 1). The list is empty for issues with no salvage
+ * refs; we never return a key for an issue not in the input filter.
+ *
+ * Failure mode: any `git ls-remote` failure returns an empty map and
+ * emits a `setup.incomplete_origin_list_failed` warning. This matches
+ * the `findOpenVpDevPrs` failure pattern — the surface is informational
+ * only, so a transient network blip should not block the run.
+ */
+export async function findIncompleteBranchesOnOrigin(opts: {
+  repoPath: string;
+  issueIds: number[];
+  logger?: Logger;
+}): Promise<Map<number, OriginIncompleteBranch[]>> {
+  const allowed = new Set(opts.issueIds);
+  if (allowed.size === 0) return new Map();
+  let stdout = "";
+  try {
+    const result = await execFile(
+      "git",
+      ["ls-remote", "--heads", "origin", `refs/heads/${INCOMPLETE_BRANCH_PATTERN}`],
+      { cwd: opts.repoPath, maxBuffer: 50 * 1024 * 1024 },
+    );
+    stdout = result.stdout;
+  } catch (err) {
+    opts.logger?.warn("setup.incomplete_origin_list_failed", {
+      err:
+        (err as { stderr?: string; message?: string }).stderr ??
+        (err as Error).message,
+    });
+    return new Map();
+  }
+  const parsed = parseLsRemoteIncompleteRefs(stdout.split("\n"));
+  const map = new Map<number, OriginIncompleteBranch[]>();
+  for (const p of parsed) {
+    if (!allowed.has(p.issueId)) continue;
+    const list = map.get(p.issueId) ?? [];
+    list.push(p);
+    map.set(p.issueId, list);
+  }
+  return map;
 }
 
 /**

--- a/src/orchestrator/failurePostMortem.test.ts
+++ b/src/orchestrator/failurePostMortem.test.ts
@@ -161,6 +161,21 @@ test("detectPendingPostMortem: 'fix landed' resolution keyword (multi-word) is r
   assert.equal(result.pending, false);
 });
 
+test("detectPendingPostMortem: 'resume' keyword (issue #118) lifts the gate", () => {
+  // Phase 1 of #118 added `resume` as a generic unblock signal so a human
+  // who intends to re-attempt with --resume-incomplete on the next run can
+  // flip triage back to ready without having to remember the older
+  // `retry`/`unblock` vocabulary.
+  const result = detectPendingPostMortem([
+    comment(
+      "## vp-dev failure post-mortem (run-A, agent-1)\n\nfailed",
+      "2026-05-05T10:00:00Z",
+    ),
+    comment("resume on next dispatch — partial branch looks salvageable", "2026-05-05T11:00:00Z", "alice"),
+  ]);
+  assert.equal(result.pending, false);
+});
+
 test("detectPendingPostMortem: an ambient unrelated comment does NOT lift the gate", () => {
   // A human comment that does NOT contain a resolution keyword leaves the
   // gate in place. Only explicit signals lift it.

--- a/src/orchestrator/failurePostMortem.ts
+++ b/src/orchestrator/failurePostMortem.ts
@@ -26,6 +26,12 @@ export const POST_MORTEM_SENTINEL = /^## vp-dev failure post-mortem\b/im;
  * later comment's body. Word-boundary anchored so "fix landed" inside an
  * unrelated sentence ("hope a fix landed somewhere") still resolves —
  * intentional: a human writing such a sentence is signaling progress.
+ *
+ * `resume` was added under issue #118 Phase 1. It signals "I want vp-dev
+ * to re-attempt this issue, possibly with --resume-incomplete on the next
+ * run". Phase 1 only makes the keyword recognized as a generic unblock
+ * signal so triage marks the issue ready; Phase 2 (separate issue) is
+ * responsible for auto-flipping `--resume-incomplete: true` based on it.
  */
 export const RESOLUTION_KEYWORDS = [
   "retry",
@@ -33,6 +39,7 @@ export const RESOLUTION_KEYWORDS = [
   "scope changed",
   "unblock",
   "proceed",
+  "resume",
 ] as const;
 
 export interface FailurePostMortemInput {

--- a/src/orchestrator/setup.ts
+++ b/src/orchestrator/setup.ts
@@ -36,6 +36,19 @@ export interface OpenPrSkipped {
   prUrl: string;
 }
 
+// Phase 1 of resume-from-incomplete (#118). One entry per
+// `vp-dev/agent-*/issue-N-incomplete-<runId>` ref discovered on `origin`
+// for a candidate dispatch issue. Surfaced in the setup preview so the
+// human sees salvage state exists before y/N. Phase 1 is informational
+// only — `--resume-incomplete` records the flag but does not change
+// worktree shape; Phase 2 wires the rebase-on-main + threading.
+export interface IncompleteBranchAvailable {
+  issueId: number;
+  agentId: string;
+  branchName: string;
+  runId: string;
+}
+
 export interface SetupPreview {
   targetRepo: string;
   targetRepoPath: string;
@@ -87,6 +100,16 @@ export interface SetupPreview {
    * active at plan time.
    */
   preferAgentId?: string;
+  /**
+   * Issue #118 Phase 1: salvageable `*-incomplete-<runId>` branches
+   * discovered on `origin` for the candidate dispatch issues. Always
+   * populated when the helper succeeds, regardless of whether
+   * `--resume-incomplete` was passed — the section is informational so
+   * the user can see partial state exists before approving y/N. The
+   * field is bound into the previewHash so a `--plan` token whose set of
+   * salvage refs drifted between plan and confirm forces a fresh plan.
+   */
+  incompleteBranchesAvailable: IncompleteBranchAvailable[];
 }
 
 export interface BuildPreviewInput {
@@ -112,6 +135,12 @@ export interface BuildPreviewInput {
    *  `--plan` token is bound to the override that was active at plan
    *  time. */
   preferAgentId?: string;
+  /** Issue #118 Phase 1: caller-provided list of salvageable
+   *  `*-incomplete-<runId>` branches on `origin` for the candidate
+   *  dispatch issues. Optional — callers that don't have a target-repo
+   *  clone (or are running in a test harness) pass `[]` / omit; the
+   *  preview renders no section in that case. */
+  incompleteBranchesAvailable?: IncompleteBranchAvailable[];
 }
 
 export async function buildSetupPreview(input: BuildPreviewInput): Promise<SetupPreview> {
@@ -153,6 +182,7 @@ export async function buildSetupPreview(input: BuildPreviewInput): Promise<Setup
     budgetExceededSkipped: input.budgetExceededSkipped ?? [],
     budgetUsd: input.budgetUsd,
     preferAgentId: input.preferAgentId,
+    incompleteBranchesAvailable: input.incompleteBranchesAvailable ?? [],
   };
 }
 
@@ -276,6 +306,25 @@ export function formatSetupPreview(p: SetupPreview): string {
     }
     lines.push(
       `  Override: raise --max-cost-usd, or split the issue per CLAUDE.md "Pre-dispatch scope-fit check" rule.`,
+    );
+    lines.push("");
+  }
+
+  // Issue #118 Phase 1: surface salvageable `-incomplete-<runId>` refs on
+  // origin so the user can see partial work exists for a candidate issue.
+  // Phase 1 is informational only — the section explains that the actual
+  // resume behavior (rebase-on-main, conflict surfacing, threading) is
+  // Phase 2 territory. The `--resume-incomplete` flag is recorded for
+  // future use but does not change worktree shape today.
+  if (p.incompleteBranchesAvailable.length > 0) {
+    lines.push(
+      `${p.incompleteBranchesAvailable.length} partial branch(es) available on origin (Phase 1 detection — Phase 2 will wire actual resume):`,
+    );
+    for (const b of p.incompleteBranchesAvailable) {
+      lines.push(`  #${b.issueId}  ${b.branchName}  (${b.runId}, ${b.agentId})`);
+    }
+    lines.push(
+      "  Pass --resume-incomplete to record the intent (Phase 1 logs + carries into --plan/--confirm; no behavior change yet).",
     );
     lines.push("");
   }

--- a/src/state/runConfirm.ts
+++ b/src/state/runConfirm.ts
@@ -39,6 +39,14 @@ export interface RunConfirmParams {
   // already binds the rationale-line annotation, so dropping or changing
   // the field invalidates the token.
   preferAgentId?: string;
+  // Issue #118 Phase 1: persisted intent flag for resuming from a
+  // salvageable `*-incomplete-<runId>` branch. Phase 1 only records and
+  // logs; Phase 2 (separate issue) is responsible for the actual
+  // worktree-creation lifecycle change. Carrying the flag through
+  // `--plan` → `--confirm` is necessary even before Phase 2 ships so
+  // that the two-step approval flow surfaces the same intent at confirm
+  // time as at plan time.
+  resumeIncomplete?: boolean;
 }
 
 export interface RunConfirmToken {


### PR DESCRIPTION
Closes #118

## Summary

Phase 1 of the resume-from-incomplete design: ships the *detection + signal* layer without any worktree-creation lifecycle change. Phase 2 (separate issue) will wire the actual rebase-on-main resume behavior on top.

- **`src/git/incompleteBranches.ts`** — adds `findIncompleteBranchesOnOrigin()` (single `git ls-remote --heads origin <pattern>`, no fetch, no mutation) and a pure `parseLsRemoteIncompleteRefs()` parser. Returns `Map<issueId, OriginIncompleteBranch[]>`.
- **`src/orchestrator/setup.ts`** — adds `incompleteBranchesAvailable` to `SetupPreview` + `BuildPreviewInput`. `formatSetupPreview` renders a new section under the existing skip blocks ("N partial branch(es) available on origin (Phase 1 detection — Phase 2 will wire actual resume)"). The field is bound into the previewHash so a `--plan` token whose set of salvage refs drifted between plan and confirm forces a fresh plan.
- **`src/orchestrator/failurePostMortem.ts`** — adds `resume` to `RESOLUTION_KEYWORDS`. A human comment containing `resume` after a failure post-mortem flips triage back to `ready: true`. Phase 2 will own the auto-flip-to-`--resume-incomplete: true` behavior.
- **`src/state/runConfirm.ts`** — adds `resumeIncomplete?: boolean` to `RunConfirmParams` so `--plan` → `--confirm` carries the intent.
- **`src/cli.ts`** — registers `--resume-incomplete` on `vp-dev run`. Wires `findIncompleteBranchesOnOrigin` into `cmdRun` to populate the preview (always — informational regardless of flag). Logs `[--resume-incomplete recorded; Phase 2 wiring not yet shipped]` at run-start when the flag is set; routing remains "from main".

## Acceptance

- `git ls-remote` finds an `-incomplete-*` ref → `vp-dev run --plan` lists the partial branch in the gate text. ✓ (covered by `parseLsRemoteIncompleteRefs` unit tests; integration is the cli wiring.)
- `--resume-incomplete` parses; running with it logs the Phase-2-not-shipped notice and still routes from main. ✓
- A human comment containing `resume` flips triage to `ready: true`. ✓ (`detectPendingPostMortem: 'resume' keyword (issue #118) lifts the gate` test added.)
- No worktree shape change — fresh dispatch always branches from main. ✓ (no edits to `createWorktree` or `runIssueCore`.)

## Out of scope (Phase 2)

- `createWorktree(resumeFromBranch?)` with rebase-on-main + conflict surfacing.
- Threading resume context through orchestrator → coding agent.
- Rendering "Previous attempt (resumed)" in the agent's seed.
- Auto-flipping `--resume-incomplete: true` on `resume` keyword comment.

## Implementation notes

- The `findIncompleteBranchesOnOrigin` failure path mirrors `findOpenVpDevPrs`: any `git ls-remote` failure returns an empty map and emits a single warning. Surface is informational only — a transient network blip should not block the run.
- Avoided putting `*/` inside JSDoc (an early version of the helper docstring referenced the literal glob `vp-dev/agent-*/issue-*-incomplete-*` and the `*/` prematurely closed the doc block). The corrected docstring points at the existing `INCOMPLETE_BRANCH_PATTERN` const for the full shape.

## Test plan

- [x] `npm run build` passes (`tsc` clean).
- [x] `npm test` passes (197/197 tests; 5 new — 4 for `parseLsRemoteIncompleteRefs`, 1 for `resume` keyword).
- [ ] Operator runs `vp-dev run --plan ...` against a target repo with at least one `*-incomplete-<runId>` ref on origin and confirms the new "N partial branch(es) available on origin" section renders.
- [ ] Operator runs `vp-dev run --resume-incomplete ...` and confirms the run-start stdout line + `run.resume_incomplete_recorded` log entry, with no other behavior change.

— Floyd (agent-e287)
