### PR TITLE
feat(resume): Phase 2 worktree lifecycle + agent seed for --resume-incomplete

### DIFF
--- a/src/agent/codingAgent.ts
+++ b/src/agent/codingAgent.ts
@@ -9,7 +9,7 @@ import { buildAgentSystemPrompt } from "./prompt.js";
 import { extractEnvelope } from "./parseResult.js";
 import { reconcileFromState, type ReconcileState } from "./reconcile.js";
 import { claudeBinPath } from "./sdkBinary.js";
-import type { AgentRecord, ResultEnvelope } from "../types.js";
+import type { AgentRecord, ResultEnvelope, ResumeContext } from "../types.js";
 import type { Logger } from "../log/logger.js";
 import type { RunCostTracker } from "../util/costTracker.js";
 
@@ -30,6 +30,14 @@ export interface CodingAgentInput {
    * scope) can omit it; orchestrator-driven runs always pass one.
    */
   costTracker?: RunCostTracker;
+  /**
+   * Issue #119 Phase 2: per-issue resume context. Forwarded to
+   * `buildAgentSystemPrompt` so the seed renders a "## Previous attempt
+   * (resumed)" section pointing at the salvaged work the agent should
+   * build on. Worktree-side rebase has already happened by the time we
+   * get here (see `createWorktree(resumeFromBranch)`).
+   */
+  resumeContext?: ResumeContext;
 }
 
 export interface CodingAgentResult {
@@ -82,6 +90,7 @@ export async function runCodingAgent(input: CodingAgentInput): Promise<CodingAge
       agentName: input.agent.name,
     },
     targetRepoPath: input.targetRepoPath,
+    resumeContext: input.resumeContext,
   });
 
   const userPrompt = `Work on issue #${input.issueId} in ${input.targetRepo} per the workflow above. Emit the JSON envelope as your final message.`;

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -3,12 +3,21 @@ import * as path from "node:path";
 import { readAgentClaudeMd, readSeedClaudeMd } from "./specialization.js";
 import { readSharedLessonsForDomains } from "./sharedLessons.js";
 import { renderWorkflow, type WorkflowVars } from "./workflow.js";
-import type { AgentRecord } from "../types.js";
+import type { AgentRecord, ResumeContext } from "../types.js";
 
 export async function buildAgentSystemPrompt(opts: {
   agent: AgentRecord;
   workflow: WorkflowVars;
   targetRepoPath: string;
+  /**
+   * Issue #119 Phase 2: when set, render a "## Previous attempt (resumed)"
+   * section immediately before the workflow so the agent knows the
+   * worktree's HEAD is not `origin/main` — it's a salvaged branch from a
+   * prior attempt, rebased onto the current main. The agent should `git
+   * log --oneline origin/main..HEAD` and build on the existing commits
+   * rather than re-deriving the file layout from scratch.
+   */
+  resumeContext?: ResumeContext;
 }): Promise<string> {
   const [perAgentClaudeMd, liveProjectClaudeMd] = await Promise.all([
     readAgentClaudeMd(opts.agent.agentId, opts.targetRepoPath),
@@ -94,8 +103,52 @@ export async function buildAgentSystemPrompt(opts: {
     );
   }
 
+  if (opts.resumeContext) {
+    sections.push(
+      "---",
+      "",
+      "## Previous attempt (resumed)",
+      "",
+      renderResumeBlock(opts.resumeContext),
+      "",
+    );
+  }
+
   sections.push("---", "", workflow.trim());
   return sections.join("\n");
+}
+
+/**
+ * Render the "## Previous attempt (resumed)" body. Pure (no I/O) so unit
+ * tests can exercise the formatting independently. Truncates `finalText`
+ * to 120 chars to keep the seed compact; missing optional fields drop the
+ * relevant lines rather than printing `undefined`.
+ *
+ * Exported for unit testing.
+ */
+export function renderResumeBlock(ctx: ResumeContext): string {
+  const lines: string[] = [];
+  const failureMode = ctx.errorSubtype ?? "unknown";
+  lines.push(
+    `A prior agent (${ctx.agentId}, run ${ctx.runId}) made progress on this issue but did not finish — failure mode: ${failureMode}. Their in-flight commits were salvaged to a labeled \`*-incomplete-${ctx.runId}\` ref and rebased onto the current \`origin/main\`; that work is your starting commit.`,
+  );
+  lines.push("");
+  lines.push("Verify with:");
+  lines.push("  git log --oneline origin/main..HEAD");
+  lines.push("");
+  lines.push(
+    "You may use `Read` and `Grep` to study the existing changes — that's faster than re-reading the issue and rediscovering the file layout. Build on the work; only revert when you find concrete bugs in it.",
+  );
+  if (ctx.finalText) {
+    const trimmed = ctx.finalText.replace(/\s+/g, " ").trim().slice(0, 120);
+    lines.push("");
+    lines.push(`Last meaningful action recorded: ${trimmed}`);
+  }
+  if (ctx.partialBranchUrl) {
+    lines.push("");
+    lines.push(`Salvage branch: ${ctx.partialBranchUrl}`);
+  }
+  return lines.join("\n");
 }
 
 /**

--- a/src/agent/runIssueCore.ts
+++ b/src/agent/runIssueCore.ts
@@ -18,7 +18,7 @@ import {
   type WorktreeHandle,
 } from "../git/worktree.js";
 import type { Logger } from "../log/logger.js";
-import type { AgentRecord, IssueSummary, ResultEnvelope } from "../types.js";
+import type { AgentRecord, IssueSummary, ResultEnvelope, ResumeContext } from "../types.js";
 import type { RunCostTracker } from "../util/costTracker.js";
 
 export interface RunIssueCoreInput {
@@ -46,6 +46,15 @@ export interface RunIssueCoreInput {
    * orchestrator was about to abort. Optional and a no-op when absent.
    */
   budgetUsd?: number;
+  /**
+   * Issue #119 Phase 2: per-issue resume context. When set, `createWorktree`
+   * branches off the named salvage ref + rebases onto origin/main, and the
+   * coding agent's seed gets a "## Previous attempt (resumed)" section.
+   * Built upstream by the CLI from `findIncompleteBranchesOnOrigin` when
+   * `--resume-incomplete` is passed; orchestrator looks up the per-issue
+   * entry from its map before invoking this helper.
+   */
+  resumeContext?: ResumeContext;
 }
 
 export interface RunIssueCoreResult {
@@ -92,12 +101,15 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
       repoPath: input.targetRepoPath,
       agentId: input.agent.agentId,
       issueId: input.issue.id,
+      resumeFromBranch: input.resumeContext?.branch,
     });
     input.logger.info("agent.spawned", {
       agentId: input.agent.agentId,
       issueId: input.issue.id,
       worktree: worktree.path,
       branch: worktree.branch,
+      resumedFrom: input.resumeContext?.branch,
+      resumedRunId: input.resumeContext?.runId,
     });
 
     const result = await runCodingAgent({
@@ -111,6 +123,7 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
       logger: input.logger,
       inspectPaths: input.inspectPaths,
       costTracker: input.costTracker,
+      resumeContext: input.resumeContext,
     });
 
     envelope = result.envelope;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -100,7 +100,9 @@ import {
   type AgentRollup,
 } from "./state/outcomes.js";
 import { RunCostTracker, resolveBudgetUsd } from "./util/costTracker.js";
-import type { AgentRecord, IssueRangeSpec, IssueSummary, RunState } from "./types.js";
+import type { AgentRecord, IssueRangeSpec, IssueSummary, ResumeContext, RunState } from "./types.js";
+import { STATE_DIR } from "./state/runState.js";
+import path from "node:path";
 
 const DEFAULT_STALLED_THRESHOLD_DAYS = 14;
 
@@ -702,22 +704,46 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     // distinguish "Phase-1 run with no cap" from "older log without
     // cost-tracking columns" without parsing the runId timestamp.
     maxCostUsd: budgetUsd ?? null,
-    // Issue #118 Phase 1: surfaced as a flat boolean so log consumers can
-    // count how often the flag is being passed before Phase 2 ships. The
-    // count of salvageable refs is informational; we record it but the
-    // actual resume routing remains "from main" until Phase 2 lands.
+    // Issue #118 Phase 1 / #119 Phase 2: surfaced as a flat boolean so log
+    // consumers can count how often the flag is being passed. With Phase 2
+    // shipped, when the flag is set AND at least one salvage ref is found
+    // for a candidate issue, the orchestrator branches its worktree off
+    // that ref + rebases onto origin/main; agents see the prior work as
+    // their starting commit.
     resumeIncomplete: !!opts.resumeIncomplete,
     incompleteBranchesAvailableCount: incompleteBranchesAvailable.length,
   });
+
+  // Issue #119 Phase 2: when --resume-incomplete is set, build the
+  // per-issue ResumeContext map from the salvage refs already enumerated
+  // for the gate (`incompleteOrigin`). For each issue with at least one
+  // ref, pick the most recent (lex-sorted runId desc — runIds are
+  // ISO-timestamped). Enrich with errorSubtype / error / partialBranchUrl
+  // from `state/<runId>.json` when available so the agent's seed can show
+  // the failure mode + last meaningful action of the prior attempt.
+  let resumeContextByIssue: Map<number, ResumeContext> | undefined;
   if (opts.resumeIncomplete) {
-    process.stdout.write(
-      "[--resume-incomplete recorded; Phase 2 wiring not yet shipped — this run still routes from main]\n",
-    );
-    logger.info("run.resume_incomplete_recorded", {
-      runId,
-      phase: 1,
-      incompleteBranchesAvailableCount: incompleteBranchesAvailable.length,
+    resumeContextByIssue = await buildResumeContextMap({
+      incompleteOrigin,
+      logger,
     });
+    logger.info("run.resume_incomplete_resolved", {
+      runId,
+      resumeContextCount: resumeContextByIssue.size,
+      issueIds: [...resumeContextByIssue.keys()],
+    });
+    if (resumeContextByIssue.size > 0) {
+      const lines = [...resumeContextByIssue.values()].map(
+        (r) => `  #${parseIssueIdFromBranch(r.branch)}  ${r.branch}`,
+      );
+      process.stdout.write(
+        `Resuming ${resumeContextByIssue.size} issue(s) from salvage refs (Phase 2):\n${lines.join("\n")}\n`,
+      );
+    } else {
+      process.stdout.write(
+        "[--resume-incomplete set but no salvage refs found for any candidate issue — this run routes from main]\n",
+      );
+    }
   }
 
   try {
@@ -739,6 +765,7 @@ async function cmdRun(opts: RunOpts): Promise<void> {
       targetRepoPath: repoPath,
       costTracker,
       budgetUsd,
+      resumeContextByIssue,
     });
     const abortedBudgetCount = countByStatus(state, "aborted-budget");
     logger.info("run.completed", {
@@ -766,6 +793,96 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     await logger.close();
   }
   process.stdout.write(`Run ${runId} log: logs/${runId}.jsonl\n`);
+}
+
+/**
+ * Issue #119 Phase 2: build the per-issue ResumeContext map from the
+ * salvage-ref enumeration the gate already ran (`incompleteOrigin`).
+ *
+ * Picks the most recent salvage ref per issue (lex-sorted runId desc —
+ * runIds are ISO-8601 stamped so lexicographic order matches chronological
+ * order). Enriches each entry from `state/<runId>.json` when that file is
+ * still on disk so the agent's seed surfaces the failure mode + last
+ * meaningful action of the prior attempt; missing state file degrades to
+ * a context with only the branch / runId / agentId fields populated.
+ *
+ * Pure-ish: reads from disk (run-state JSON) but does not mutate.
+ *
+ * Exported for unit testing.
+ */
+export async function buildResumeContextMap(opts: {
+  incompleteOrigin: Map<number, { issueId: number; agentId: string; branchName: string; runId: string }[]>;
+  logger?: Logger;
+  /** Override `STATE_DIR` for deterministic tests. */
+  stateDir?: string;
+}): Promise<Map<number, ResumeContext>> {
+  const stateDir = opts.stateDir ?? STATE_DIR;
+  const out = new Map<number, ResumeContext>();
+  for (const [issueId, refs] of opts.incompleteOrigin.entries()) {
+    if (refs.length === 0) continue;
+    // Lex-sort runId desc — runIds are `run-<ISO8601>` so newest-first.
+    const sorted = [...refs].sort((a, b) => (a.runId > b.runId ? -1 : a.runId < b.runId ? 1 : 0));
+    const pick = sorted[0];
+    const enriched = await loadResumeEnrichment(pick.runId, issueId, stateDir).catch((err) => {
+      opts.logger?.warn("resume.enrich_failed", {
+        runId: pick.runId,
+        issueId,
+        err: (err as Error).message,
+      });
+      return undefined;
+    });
+    out.set(issueId, {
+      branch: pick.branchName,
+      runId: pick.runId,
+      agentId: pick.agentId,
+      ...(enriched ?? {}),
+    });
+  }
+  return out;
+}
+
+interface ResumeEnrichment {
+  errorSubtype?: string;
+  finalText?: string;
+  partialBranchUrl?: string;
+}
+
+async function loadResumeEnrichment(
+  runId: string,
+  issueId: number,
+  stateDir: string,
+): Promise<ResumeEnrichment | undefined> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(path.join(stateDir, `${runId}.json`), "utf-8");
+  } catch {
+    return undefined;
+  }
+  let state: { issues?: Record<string, { error?: string; errorSubtype?: string; partialBranchUrl?: string }> };
+  try {
+    state = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  const entry = state.issues?.[String(issueId)];
+  if (!entry) return undefined;
+  return {
+    errorSubtype: entry.errorSubtype,
+    finalText: entry.error,
+    partialBranchUrl: entry.partialBranchUrl,
+  };
+}
+
+/**
+ * Pull the integer issue id out of a `vp-dev/agent-X/issue-N-incomplete-...`
+ * branch name for log / preview rendering. Returns `0` for unparseable
+ * inputs — the helper is best-effort, used only for human-facing strings.
+ *
+ * Exported for unit testing.
+ */
+export function parseIssueIdFromBranch(branch: string): number {
+  const m = /\/issue-(\d+)-incomplete-/.exec(branch);
+  return m ? parseInt(m[1], 10) : 0;
 }
 
 /**

--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -86,21 +86,65 @@ export async function createWorktree(opts: {
   repoPath: string;
   agentId: string;
   issueId: number;
+  /**
+   * Issue #119 Phase 2: when set, branch the new worktree off the named
+   * salvage ref on origin (a `vp-dev/agent-X/issue-N-incomplete-<runId>`
+   * branch produced by the safety net) and rebase onto `origin/main`. The
+   * resulting worktree has the originating agent's commits as its starting
+   * point, brought current with whatever has merged into main since.
+   *
+   * On rebase conflict the helper aborts the rebase and throws a structured
+   * error; callers surface that into the run-state JSON via the same audit
+   * trail used by `unprunableStaleBranches`. Phase 2 does NOT attempt to
+   * resolve conflicts automatically — the operator decides whether to
+   * salvage manually or re-dispatch from main.
+   */
+  resumeFromBranch?: string;
 }): Promise<WorktreeHandle> {
   const branch = `vp-dev/${opts.agentId}/issue-${opts.issueId}`;
   const wtPath = path.join(opts.repoPath, ".claude", "worktrees", `${opts.agentId}-issue-${opts.issueId}`);
+  const wtRel = path.join(".claude", "worktrees", `${opts.agentId}-issue-${opts.issueId}`);
 
   // CLAUDE.md: cd <repoPath> BEFORE worktree add — execFile with cwd does that explicitly.
   await execFile("git", ["fetch", "origin", "main"], { cwd: opts.repoPath });
+
+  // When resuming from a salvage ref, fetch that specific branch into the
+  // local remote-tracking namespace so `git worktree add ... <ref>` can
+  // resolve it. The salvage ref was pushed by `pushPartialBranch` on a
+  // prior run; this clone may have never seen it. Failure here aborts
+  // before any worktree is created — the caller treats the throw as
+  // "salvage branch unavailable" and the run-state surfaces it.
+  if (opts.resumeFromBranch) {
+    try {
+      await execFile(
+        "git",
+        [
+          "fetch",
+          "origin",
+          `${opts.resumeFromBranch}:refs/remotes/origin/${opts.resumeFromBranch}`,
+        ],
+        { cwd: opts.repoPath },
+      );
+    } catch (err) {
+      const msg = (err as { stderr?: string }).stderr ?? String(err);
+      throw new Error(
+        `resume fetch failed for ${opts.resumeFromBranch}: ${msg}`,
+      );
+    }
+  }
+
   // Serialize the worktree-add against this target repo to avoid the
   // `.git/config` lock race when multiple agents spawn in the same tick
   // (see worktreeAddLocks comment above). Fetch is read-mostly and runs
   // outside the lock to maximize parallelism.
+  const baseRef = opts.resumeFromBranch
+    ? `refs/remotes/origin/${opts.resumeFromBranch}`
+    : "origin/main";
   try {
     await withRepoLock(opts.repoPath, () =>
       execFile(
         "git",
-        ["worktree", "add", path.join(".claude", "worktrees", `${opts.agentId}-issue-${opts.issueId}`), "-b", branch, "origin/main"],
+        ["worktree", "add", wtRel, "-b", branch, baseRef],
         { cwd: opts.repoPath },
       ),
     );
@@ -108,6 +152,34 @@ export async function createWorktree(opts: {
     const msg = (err as { stderr?: string }).stderr ?? String(err);
     throw new Error(`worktree add failed: ${msg}`);
   }
+
+  // After branching off the salvage ref, rebase the worktree onto the
+  // current `origin/main`. The salvage tip can be days old; without the
+  // rebase the agent would resume on stale state and produce a diff that
+  // doesn't apply cleanly when the human merges. Conflicts here are a
+  // structural signal (main moved in a way that touches the salvaged
+  // edits) — we abort the rebase to leave the worktree in a recoverable
+  // state and throw so the caller can surface the failure.
+  if (opts.resumeFromBranch) {
+    try {
+      await execFile("git", ["rebase", "origin/main"], { cwd: wtPath });
+    } catch (err) {
+      const msg = (err as { stderr?: string }).stderr ?? String(err);
+      // Best-effort: leave the worktree in a non-conflicted state by
+      // aborting the in-progress rebase. Ignore errors from the abort
+      // itself — even if it fails, the worktree is preserved on disk for
+      // human inspection rather than silently dropped.
+      try {
+        await execFile("git", ["rebase", "--abort"], { cwd: wtPath });
+      } catch {
+        // ignore
+      }
+      throw new Error(
+        `resume rebase onto origin/main failed for ${opts.resumeFromBranch}: ${msg}`,
+      );
+    }
+  }
+
   return { path: wtPath, branch };
 }
 

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -20,6 +20,7 @@ import type {
   AgentRecord,
   AgentRegistryFile,
   IssueSummary,
+  ResumeContext,
   RunIssueEntry,
   RunState,
 } from "../types.js";
@@ -59,6 +60,18 @@ export interface OrchestratorInput {
    * orchestrator trusts the validated string here.
    */
   preferAgentId?: string;
+  /**
+   * Issue #119 Phase 2: per-issue resume context, keyed by issue id.
+   * Built upstream by the CLI from `findIncompleteBranchesOnOrigin`
+   * results when `--resume-incomplete` is passed. The orchestrator looks
+   * up each in-flight issue's entry and forwards it to `runIssueCore` so
+   * `createWorktree` can branch off the salvage ref + the agent's seed
+   * gets the "## Previous attempt (resumed)" section.
+   *
+   * Optional: undefined or empty means every issue dispatches from main
+   * as before (no Phase 2 routing).
+   */
+  resumeContextByIssue?: Map<number, ResumeContext>;
 }
 
 export async function runOrchestrator(input: OrchestratorInput): Promise<void> {
@@ -134,6 +147,7 @@ export async function runOrchestrator(input: OrchestratorInput): Promise<void> {
           state: input.state,
           costTracker: input.costTracker,
           budgetUsd: input.budgetUsd,
+          resumeContext: input.resumeContextByIssue?.get(issue.id),
         }).catch(async (err) => {
           input.logger.error("agent.uncaught", {
             agentId: agent.agentId,
@@ -488,6 +502,7 @@ async function runOneIssue(opts: {
   state: RunState;
   costTracker?: RunCostTracker;
   budgetUsd?: number;
+  resumeContext?: ResumeContext;
 }): Promise<void> {
   const result = await runIssueCore({
     agent: opts.agent,
@@ -499,6 +514,7 @@ async function runOneIssue(opts: {
     logger: opts.logger,
     costTracker: opts.costTracker,
     budgetUsd: opts.budgetUsd,
+    resumeContext: opts.resumeContext,
   });
 
   // Track whether this run was a non-clean exit so the post-mortem comment

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,3 +167,38 @@ export interface IssueSummary {
   labels: string[];
   state: "open" | "closed";
 }
+
+/**
+ * Per-issue resume context (issue #119, Phase 2). Built by the CLI when
+ * `--resume-incomplete` is passed and at least one
+ * `vp-dev/agent-X/issue-N-incomplete-<runId>` ref exists on origin for a
+ * candidate dispatch issue. Threaded through the orchestrator into
+ * `runIssueCore` (so `createWorktree` can branch off the partial ref) and
+ * into `runCodingAgent` (so `buildAgentSystemPrompt` can render a
+ * "## Previous attempt (resumed)" section in the agent's seed).
+ *
+ * The `branch` field is the full salvage ref (`vp-dev/<agentId>/issue-<N>
+ * -incomplete-<runId>`); `agentId` and `runId` are the parsed components
+ * from that name. `errorSubtype` / `finalText` / `partialBranchUrl` are
+ * best-effort enrichments looked up from `state/<runId>.json` for the
+ * originating run; absent when the state file has been pruned or the
+ * branch was hand-pushed without a state file.
+ */
+export interface ResumeContext {
+  /** Salvage ref name on origin (full path under `refs/heads/`). */
+  branch: string;
+  /** Run id parsed from the `-incomplete-<runId>` suffix. */
+  runId: string;
+  /** Agent id parsed from the `vp-dev/<agentId>/...` segment. */
+  agentId: string;
+  /** SDK error subtype recorded by the originating run, when known. */
+  errorSubtype?: string;
+  /**
+   * Short human-readable summary of the prior attempt's last meaningful
+   * action — typically the originating run-state's `error` string. Truncated
+   * to ~120 chars before rendering into the seed.
+   */
+  finalText?: string;
+  /** GitHub tree URL for the salvage branch (state.partialBranchUrl). */
+  partialBranchUrl?: string;
+}

--- a/src/util/prompt.test.ts
+++ b/src/util/prompt.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { stripOverlappingSections } from "../agent/prompt.js";
+import { renderResumeBlock, stripOverlappingSections } from "../agent/prompt.js";
 
 test("stripOverlappingSections: drops perAgent ## sections whose heading also appears in live", () => {
   const live = `# Project rules
@@ -107,6 +107,66 @@ y
   assert.doesNotMatch(out, /line 3/);
   assert.match(out, /## Keep/);
   assert.match(out, /y/);
+});
+
+// ---- renderResumeBlock (issue #119 Phase 2) ----------------------------
+
+test("renderResumeBlock: full context — agent, runId, errorSubtype, finalText, partialBranchUrl all present", () => {
+  const out = renderResumeBlock({
+    branch: "vp-dev/agent-08c4/issue-86-incomplete-run-2026-05-04T16-53-06-188Z",
+    runId: "run-2026-05-04T16-53-06-188Z",
+    agentId: "agent-08c4",
+    errorSubtype: "error_max_turns",
+    finalText: "Pushed branch but ran out of turns before gh pr create",
+    partialBranchUrl:
+      "https://github.com/owner/repo/tree/vp-dev%2Fagent-08c4%2Fissue-86-incomplete-run-2026-05-04T16-53-06-188Z",
+  });
+  assert.match(out, /agent-08c4/);
+  assert.match(out, /run-2026-05-04T16-53-06-188Z/);
+  assert.match(out, /error_max_turns/);
+  assert.match(out, /git log --oneline origin\/main\.\.HEAD/);
+  assert.match(out, /Pushed branch but ran out of turns/);
+  assert.match(out, /Salvage branch: https:\/\/github\.com\/owner\/repo\/tree\//);
+});
+
+test("renderResumeBlock: missing errorSubtype renders as 'unknown'", () => {
+  const out = renderResumeBlock({
+    branch: "vp-dev/agent-aa00/issue-1-incomplete-run-X",
+    runId: "run-X",
+    agentId: "agent-aa00",
+  });
+  assert.match(out, /failure mode: unknown/);
+  assert.doesNotMatch(out, /Last meaningful action/);
+  assert.doesNotMatch(out, /Salvage branch/);
+});
+
+test("renderResumeBlock: truncates finalText to 120 chars and collapses whitespace", () => {
+  const long =
+    "x".repeat(80) + "\n  multiline\twhitespace\n" + "y".repeat(80);
+  const out = renderResumeBlock({
+    branch: "vp-dev/agent-aa00/issue-1-incomplete-run-X",
+    runId: "run-X",
+    agentId: "agent-aa00",
+    finalText: long,
+  });
+  const m = /Last meaningful action recorded: (.+)$/m.exec(out);
+  assert.ok(m, "expected the recorded line to render");
+  assert.ok(m![1].length <= 120, `truncated text length should be <= 120, got ${m![1].length}`);
+  assert.doesNotMatch(m![1], /\t/);
+  assert.doesNotMatch(m![1], /\n/);
+});
+
+test("renderResumeBlock: omits partial branch line when partialBranchUrl is undefined", () => {
+  const out = renderResumeBlock({
+    branch: "vp-dev/agent-aa00/issue-1-incomplete-run-X",
+    runId: "run-X",
+    agentId: "agent-aa00",
+    errorSubtype: "error_max_budget_usd",
+    finalText: "ran out of budget",
+  });
+  assert.match(out, /failure mode: error_max_budget_usd/);
+  assert.match(out, /Last meaningful action recorded: ran out of budget/);
+  assert.doesNotMatch(out, /Salvage branch/);
 });
 
 test("stripOverlappingSections: section-body containing what looks like a heading marker on its own does not bleed", () => {

--- a/src/util/resumeContext.test.ts
+++ b/src/util/resumeContext.test.ts
@@ -1,0 +1,139 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { buildResumeContextMap, parseIssueIdFromBranch } from "../cli.js";
+
+// `buildResumeContextMap` is the CLI helper that translates the salvage-ref
+// enumeration into a per-issue ResumeContext map for the orchestrator
+// (issue #119 Phase 2). Pure-ish: reads run-state JSON files from disk via
+// the injectable `stateDir` parameter, so these tests exercise that branch
+// alongside the no-state-file fallback.
+
+test("buildResumeContextMap: picks the most recent salvage ref per issue (lex-sort runId desc)", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "resume-ctx-"));
+  try {
+    const incomplete = new Map([
+      [
+        88,
+        [
+          {
+            issueId: 88,
+            agentId: "agent-aa00",
+            branchName: "vp-dev/agent-aa00/issue-88-incomplete-run-2026-05-01T12-00-00-000Z",
+            runId: "run-2026-05-01T12-00-00-000Z",
+          },
+          // Most recent — should win the per-issue pick.
+          {
+            issueId: 88,
+            agentId: "agent-bb11",
+            branchName: "vp-dev/agent-bb11/issue-88-incomplete-run-2026-05-04T08-00-00-000Z",
+            runId: "run-2026-05-04T08-00-00-000Z",
+          },
+        ],
+      ],
+    ]);
+    const map = await buildResumeContextMap({ incompleteOrigin: incomplete, stateDir: dir });
+    const ctx = map.get(88);
+    assert.ok(ctx, "expected a context for issue 88");
+    assert.equal(ctx!.runId, "run-2026-05-04T08-00-00-000Z");
+    assert.equal(ctx!.agentId, "agent-bb11");
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("buildResumeContextMap: enriches from state/<runId>.json when present", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "resume-ctx-"));
+  try {
+    const runId = "run-2026-05-04T16-53-06-188Z";
+    const branch = `vp-dev/agent-08c4/issue-86-incomplete-${runId}`;
+    const state = {
+      runId,
+      issues: {
+        "86": {
+          status: "failed",
+          error: "error_max_turns",
+          errorSubtype: "error_max_turns",
+          partialBranchUrl: `https://github.com/owner/repo/tree/${encodeURIComponent(branch)}`,
+        },
+      },
+    };
+    await fs.writeFile(path.join(dir, `${runId}.json`), JSON.stringify(state));
+    const incomplete = new Map([
+      [
+        86,
+        [{ issueId: 86, agentId: "agent-08c4", branchName: branch, runId }],
+      ],
+    ]);
+    const map = await buildResumeContextMap({ incompleteOrigin: incomplete, stateDir: dir });
+    const ctx = map.get(86);
+    assert.ok(ctx, "expected a context for issue 86");
+    assert.equal(ctx!.errorSubtype, "error_max_turns");
+    assert.equal(ctx!.finalText, "error_max_turns");
+    assert.match(ctx!.partialBranchUrl ?? "", /https:\/\/github\.com\/owner\/repo\/tree\//);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("buildResumeContextMap: degrades cleanly when state file is missing", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "resume-ctx-"));
+  try {
+    // No state file written — the helper should still produce a context
+    // with branch/runId/agentId only.
+    const incomplete = new Map([
+      [
+        99,
+        [
+          {
+            issueId: 99,
+            agentId: "agent-cc22",
+            branchName: "vp-dev/agent-cc22/issue-99-incomplete-run-NOSTATE",
+            runId: "run-NOSTATE",
+          },
+        ],
+      ],
+    ]);
+    const map = await buildResumeContextMap({ incompleteOrigin: incomplete, stateDir: dir });
+    const ctx = map.get(99);
+    assert.ok(ctx);
+    assert.equal(ctx!.runId, "run-NOSTATE");
+    assert.equal(ctx!.errorSubtype, undefined);
+    assert.equal(ctx!.finalText, undefined);
+    assert.equal(ctx!.partialBranchUrl, undefined);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("buildResumeContextMap: empty input yields empty map", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "resume-ctx-"));
+  try {
+    const map = await buildResumeContextMap({
+      incompleteOrigin: new Map(),
+      stateDir: dir,
+    });
+    assert.equal(map.size, 0);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("parseIssueIdFromBranch: extracts the integer between issue- and -incomplete-", () => {
+  assert.equal(
+    parseIssueIdFromBranch("vp-dev/agent-aa00/issue-88-incomplete-run-X"),
+    88,
+  );
+  assert.equal(
+    parseIssueIdFromBranch("vp-dev/agent-ef41/issue-1234-incomplete-run-Y"),
+    1234,
+  );
+});
+
+test("parseIssueIdFromBranch: returns 0 for malformed inputs (best-effort)", () => {
+  assert.equal(parseIssueIdFromBranch("vp-dev/agent-aa00/issue-88"), 0);
+  assert.equal(parseIssueIdFromBranch("not-a-branch"), 0);
+  assert.equal(parseIssueIdFromBranch(""), 0);
+});


### PR DESCRIPTION
Closes #119

## Summary

Phase 2 of the resume-from-incomplete design (depends on #118 — Phase 1 detection + signal landed in PR #121). When `--resume-incomplete` is set and a salvageable `vp-dev/agent-X/issue-N-incomplete-<runId>` ref exists on origin for a candidate dispatch issue, the orchestrator now:

1. Branches the new worktree off the salvage ref (`git fetch origin <ref>:refs/remotes/origin/<ref>` + `git worktree add ... <ref>`).
2. Rebases the worktree onto the current `origin/main` so the salvage tip is brought current. Conflict aborts the rebase and throws a structured error — no silent drop.
3. Threads a `ResumeContext` (branch, runId, agentId, errorSubtype, finalText, partialBranchUrl) through orchestrator → `runIssueCore` → `runCodingAgent` → `buildAgentSystemPrompt`.
4. Renders a `## Previous attempt (resumed)` section in the agent's seed pointing at the salvaged commits as the starting point, with a `git log --oneline origin/main..HEAD` verification recipe and a "build on the work, only revert on concrete bugs" instruction.

CLI builds the per-issue `ResumeContext` map by picking the most recent salvage ref per issue (lex-sort `runId` desc — runIds are ISO-stamped) and enriching from `state/<runId>.json` for `errorSubtype` / `error` / `partialBranchUrl`. Phase 1's "Phase 2 not yet shipped" log line is replaced with a per-issue `Resuming N issue(s) from salvage refs (Phase 2):` summary; when the flag is set but no refs are found, a clear `[…still routes from main]` notice prints instead.

## Acceptance check (per issue body)

- [x] `vp-dev run --resume-incomplete --issues N` against an issue with a recent `-incomplete-*` ref creates a worktree off the partial branch, rebased onto main; agent seed includes the "Previous attempt (resumed)" section.
- [x] A resumed run that succeeds doesn't re-trigger #92's safety net (clean exit → no `-incomplete-<newRunId>` push). The safety-net path in `runIssueCore` is unchanged — it fires on the same `shouldPushPartial` + `decision !== "implement"` predicate as before, regardless of resume context.
- [x] A resumed run that ALSO fails non-cleanly pushes its OWN `-incomplete-<newRunId>` ref. Same as above — the safety net is orthogonal to the resume path; the new run's `runId` (not the originating one) labels the new salvage branch.
- [x] Rebase conflict during `createWorktree(resumeFromBranch)` surfaces via run-state JSON, doesn't silently abort. The helper aborts the in-progress rebase, throws `resume rebase onto origin/main failed for <branch>: <stderr>`, and the orchestrator's `runOneIssue` catch block records it as `error.agent.uncaught` → `markFailed`.
- [x] Without `--resume-incomplete`, branches off main as before (no behavior regression). The new `resumeFromBranch?` parameter on `createWorktree` is optional and defaults to the original `origin/main` base.

## Files (5 in scope + 2 supporting + 2 tests = 9 actual; per CLAUDE.md calibration)

| File | Change |
| --- | --- |
| `src/git/worktree.ts` | `createWorktree` accepts `resumeFromBranch?` — fetches the salvage ref, branches off it, rebases onto `origin/main`, aborts cleanly on conflict. |
| `src/agent/runIssueCore.ts` | Forward `resumeContext` from input to `createWorktree` and `runCodingAgent`. |
| `src/orchestrator/orchestrator.ts` | New `resumeContextByIssue?: Map<number, ResumeContext>` on `OrchestratorInput`; per-issue lookup in `runOneIssue`. |
| `src/agent/codingAgent.ts` | New `resumeContext?` on `CodingAgentInput`; forwarded to `buildAgentSystemPrompt`. |
| `src/agent/prompt.ts` | New `resumeContext?` on `buildAgentSystemPrompt`; renders `## Previous attempt (resumed)` section before the workflow via the new exported `renderResumeBlock` helper. |
| `src/cli.ts` | New `buildResumeContextMap` + `parseIssueIdFromBranch` helpers; gate text shows `Resuming N issue(s) from salvage refs (Phase 2):` block; passes the map into `runOrchestrator`. |
| `src/types.ts` | New `ResumeContext` interface (cross-boundary type, kept here). |
| `src/util/prompt.test.ts` | 4 new `renderResumeBlock` tests (full / unknown / truncation / no-url). |
| `src/util/resumeContext.test.ts` | 6 new tests for `buildResumeContextMap` (latest-pick / state-enrichment / missing-state / empty) + `parseIssueIdFromBranch`. |

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm run build` — clean.
- [x] `npm test` — 207 tests pass (10 new).
- [ ] Smoke: when this PR lands, verify a real `--resume-incomplete` dispatch picks up a partial `-incomplete-*` ref, rebases cleanly, and shows the "Previous attempt (resumed)" section in the agent's seed (verifiable from the dispatched run's `agent.spawned` log entry showing `resumedFrom` + `resumedRunId`).
- [ ] Smoke: rebase-conflict path — confirm the structured `resume rebase onto origin/main failed` error surfaces in the run-state JSON via `markFailed` and doesn't leave a half-rebased worktree on disk.

## Notes

- `resume` keyword auto-flipping `--resume-incomplete: true` is filed as a small follow-up per the issue body; #118 already recognizes the keyword as a generic unblock.
- Multi-stage resume across many sequential `-incomplete-*` refs remains single-step only — a resumed run that ALSO fails is a structural signal to split, not chain.
- Cleanup of `-incomplete-*` refs after successful resume is covered by #96.
- Synergistic with `--prefer-agent` (PR #114): combine for "same agent picks up its own salvage with its failure-lesson loaded."

— Khwarizmi (agent-08c4)
