### PR TITLE
feat(status): inspect any run by ID + per-issue detail + --json output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import {
   clearCurrentRunId,
   downgradeInFlightToPending,
   isRunComplete,
+  findLatestRunId,
   loadRunState,
   makeRunId,
   newRunState,
@@ -46,6 +47,7 @@ import {
   resolveTargetRepoPath,
 } from "./git/worktree.js";
 import { findOpenVpDevPrs } from "./git/openPrs.js";
+import { formatStatusJson, formatStatusText } from "./state/statusFormatter.js";
 import {
   DEFAULT_INCOMPLETE_RETENTION_DAYS,
   filterByRetention,
@@ -157,10 +159,12 @@ export function buildCli(): Command {
     });
 
   program
-    .command("status")
-    .description("Print summary of the current run + per-agent state")
-    .action(async () => {
-      await cmdStatus();
+    .command("status [runId]")
+    .description("Print summary of a run + per-agent state + per-issue detail. With no args: shows the active run if one exists. Pass <runId> to inspect a specific past run, or --latest for the most recent run on disk.")
+    .option("--latest", "Inspect the most recent run-<ts>.json on disk regardless of completion")
+    .option("--json", "Print machine-readable JSON")
+    .action(async (runIdArg, opts) => {
+      await cmdStatus(runIdArg, opts);
     });
 
   program
@@ -903,42 +907,50 @@ async function runResume(opts: RunOpts): Promise<void> {
   }
 }
 
-async function cmdStatus(): Promise<void> {
-  const runId = await readCurrentRunId();
+interface StatusOpts {
+  latest?: boolean;
+  json?: boolean;
+}
+
+async function cmdStatus(runIdArg?: string, opts: StatusOpts = {}): Promise<void> {
+  // Three resolution modes for which run to inspect:
+  //   1. Explicit `runId` arg → that run.
+  //   2. --latest → most recent run-*.json on disk regardless of completion.
+  //   3. (default) the active run referenced by `state/current-run.txt`.
+  let runId: string | undefined = runIdArg ?? undefined;
   if (!runId) {
-    process.stdout.write("No active run.\n");
+    runId = opts.latest
+      ? (await findLatestRunId()) ?? undefined
+      : (await readCurrentRunId()) ?? undefined;
+  }
+  if (!runId) {
+    if (opts.json) {
+      process.stdout.write(JSON.stringify({ runId: null, reason: opts.latest ? "no runs on disk" : "no active run" }, null, 2) + "\n");
+    } else {
+      process.stdout.write(opts.latest ? "No runs on disk.\n" : "No active run.\n");
+    }
     return;
   }
-  const state = await loadRunState(runId);
-  const total = Object.keys(state.issues).length;
-  // #86: `aborted-budget` is a distinct terminal state — surface it as its
-  // own column so post-run audits don't have to grep run-state JSON to
-  // tell "operator pulled the plug on cost" apart from "agent failed".
-  const counts: Record<string, number> = {
-    pending: 0,
-    "in-flight": 0,
-    done: 0,
-    failed: 0,
-    "aborted-budget": 0,
-  };
-  for (const e of Object.values(state.issues)) {
-    counts[e.status] = (counts[e.status] ?? 0) + 1;
+
+  let state;
+  try {
+    state = await loadRunState(runId);
+  } catch (err) {
+    process.stderr.write(`ERROR: could not load run-state for ${runId}: ${(err as Error).message}\n`);
+    process.exit(2);
   }
-  process.stdout.write(`Run ${runId} on ${state.targetRepo}\n`);
-  process.stdout.write(
-    `  total=${total} pending=${counts.pending} in-flight=${counts["in-flight"]} done=${counts.done} failed=${counts.failed} aborted-budget=${counts["aborted-budget"]}\n`,
-  );
-  process.stdout.write(`  ticks=${state.tickCount} parallelism=${state.parallelism} dryRun=${state.dryRun}\n`);
-  if (state.maxCostUsd !== undefined) {
-    process.stdout.write(`  maxCostUsd=${state.maxCostUsd}\n`);
-  }
+
   // Resolve names from registry (best-effort — keep status read-only).
   const reg = await loadRegistry();
-  const nameOf = new Map(reg.agents.map((a) => [a.agentId, a.name]));
-  for (const a of state.agents) {
-    const label = nameOf.get(a.agentId) ? `${nameOf.get(a.agentId)} (${a.agentId})` : a.agentId;
-    process.stdout.write(`  agent ${label}: ${a.status}\n`);
+  const agentNames = new Map<string, string | undefined>(
+    reg.agents.map((a) => [a.agentId, a.name]),
+  );
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(formatStatusJson(state, { agentNames }), null, 2) + "\n");
+    return;
   }
+  process.stdout.write(formatStatusText(state, { agentNames }));
 }
 
 interface AgentsSpecialtiesOpts {

--- a/src/state/runState.ts
+++ b/src/state/runState.ts
@@ -56,6 +56,28 @@ export async function clearCurrentRunId(): Promise<void> {
   await fs.rm(CURRENT_RUN_FILE, { force: true });
 }
 
+/**
+ * Return the most recent `run-<ISO>.json` runId on disk, or null if none.
+ * `state/` is gitignored and run files are named with their ISO start
+ * timestamps — lexicographic sort = chronological order. Used by
+ * `vp-dev status --latest` to inspect the most recent run regardless of
+ * whether `current-run.txt` was cleared on completion.
+ */
+export async function findLatestRunId(): Promise<string | null> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(STATE_DIR);
+  } catch {
+    return null;
+  }
+  const runFiles = entries
+    .filter((e) => e.startsWith("run-") && e.endsWith(".json"))
+    .sort();
+  if (runFiles.length === 0) return null;
+  const last = runFiles[runFiles.length - 1];
+  return last.replace(/\.json$/, "");
+}
+
 export function newRunState(opts: {
   runId: string;
   targetRepo: string;

--- a/src/state/statusFormatter.ts
+++ b/src/state/statusFormatter.ts
@@ -1,0 +1,199 @@
+import type { IssueStatus, RunIssueEntry, RunState } from "../types.js";
+
+/**
+ * Pure formatters for `vp-dev status` output. Both the text and JSON
+ * variants take a `RunState` plus an optional `agentNames` lookup (so the
+ * registry I/O stays in the CLI layer and these helpers are testable
+ * without touching disk).
+ */
+export interface StatusFormatOpts {
+  /** Map of agentId -> display name. Agents not in the map render with bare ID. */
+  agentNames?: Map<string, string | undefined>;
+}
+
+const STATUS_KEYS: IssueStatus[] = [
+  "pending",
+  "in-flight",
+  "done",
+  "failed",
+  "aborted-budget",
+];
+
+export function formatStatusText(state: RunState, opts: StatusFormatOpts = {}): string {
+  const total = Object.keys(state.issues).length;
+  const counts = countByStatus(state);
+  const nameOf = opts.agentNames ?? new Map<string, string | undefined>();
+
+  const lines: string[] = [];
+  lines.push(`Run ${state.runId} on ${state.targetRepo}`);
+  const countParts = STATUS_KEYS.map((k) => `${k}=${counts[k]}`).join(" ");
+  lines.push(`  total=${total} ${countParts}`);
+
+  const duration = formatDuration(state.startedAt, state.lastTickAt);
+  const metaParts = [
+    `ticks=${state.tickCount}`,
+    `parallelism=${state.parallelism}`,
+    `dryRun=${state.dryRun}`,
+  ];
+  if (duration) metaParts.push(`duration=${duration}`);
+  lines.push(`  ${metaParts.join(" ")}`);
+
+  if (state.maxCostUsd !== undefined) {
+    lines.push(`  maxCostUsd=${state.maxCostUsd}`);
+  }
+
+  for (const a of state.agents) {
+    const name = nameOf.get(a.agentId);
+    const label = name ? `${name} (${a.agentId})` : a.agentId;
+    lines.push(`  agent ${label}: ${a.status}`);
+  }
+
+  if (total > 0) {
+    lines.push("");
+    lines.push("  Issues:");
+    const issueIds = Object.keys(state.issues).sort((a, b) => Number(a) - Number(b));
+    for (const id of issueIds) {
+      const e = state.issues[id];
+      lines.push(...renderIssueLines(id, e, nameOf));
+    }
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+export interface StatusJson {
+  runId: string;
+  targetRepo: string;
+  startedAt?: string;
+  lastTickAt?: string;
+  durationMs?: number;
+  parallelism: number;
+  dryRun: boolean;
+  tickCount: number;
+  maxCostUsd?: number;
+  summary: { total: number } & Record<IssueStatus, number>;
+  agents: { agentId: string; agentName?: string; status: string }[];
+  issues: {
+    id: number;
+    status: IssueStatus;
+    agentId?: string;
+    agentName?: string;
+    outcome?: string;
+    prUrl?: string;
+    commentUrl?: string;
+    partialBranchUrl?: string;
+    error?: string;
+    errorSubtype?: string;
+    parseError?: string;
+  }[];
+}
+
+export function formatStatusJson(state: RunState, opts: StatusFormatOpts = {}): StatusJson {
+  const counts = countByStatus(state);
+  const nameOf = opts.agentNames ?? new Map<string, string | undefined>();
+  const total = Object.keys(state.issues).length;
+  const durationMs =
+    state.startedAt && state.lastTickAt
+      ? Date.parse(state.lastTickAt) - Date.parse(state.startedAt)
+      : undefined;
+
+  return {
+    runId: state.runId,
+    targetRepo: state.targetRepo,
+    startedAt: state.startedAt,
+    lastTickAt: state.lastTickAt,
+    durationMs:
+      typeof durationMs === "number" && Number.isFinite(durationMs) && durationMs >= 0
+        ? durationMs
+        : undefined,
+    parallelism: state.parallelism,
+    dryRun: state.dryRun,
+    tickCount: state.tickCount,
+    maxCostUsd: state.maxCostUsd,
+    summary: { total, ...counts },
+    agents: state.agents.map((a) => ({
+      agentId: a.agentId,
+      agentName: nameOf.get(a.agentId),
+      status: a.status,
+    })),
+    issues: Object.keys(state.issues)
+      .sort((a, b) => Number(a) - Number(b))
+      .map((id) => {
+        const e = state.issues[id];
+        return {
+          id: Number(id),
+          status: e.status,
+          agentId: e.agentId,
+          agentName: e.agentId ? nameOf.get(e.agentId) : undefined,
+          outcome: e.outcome,
+          prUrl: e.prUrl,
+          commentUrl: e.commentUrl,
+          partialBranchUrl: e.partialBranchUrl,
+          error: e.error,
+          errorSubtype: e.errorSubtype,
+          parseError: e.parseError,
+        };
+      }),
+  };
+}
+
+export function formatDuration(startedAt?: string, lastTickAt?: string): string | undefined {
+  if (!startedAt || !lastTickAt) return undefined;
+  const ms = Date.parse(lastTickAt) - Date.parse(startedAt);
+  if (!Number.isFinite(ms) || ms < 0) return undefined;
+  const total = Math.floor(ms / 1000);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  if (h > 0) return `${h}h${m}m${s}s`;
+  if (m > 0) return `${m}m${s}s`;
+  return `${s}s`;
+}
+
+function countByStatus(state: RunState): Record<IssueStatus, number> {
+  const counts: Record<IssueStatus, number> = {
+    pending: 0,
+    "in-flight": 0,
+    done: 0,
+    failed: 0,
+    "aborted-budget": 0,
+  };
+  for (const e of Object.values(state.issues)) {
+    counts[e.status] = (counts[e.status] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function renderIssueLines(
+  id: string,
+  e: RunIssueEntry,
+  nameOf: Map<string, string | undefined>,
+): string[] {
+  const out: string[] = [];
+  const agentLabel = e.agentId
+    ? nameOf.get(e.agentId)
+      ? `${nameOf.get(e.agentId)} (${e.agentId})`
+      : e.agentId
+    : "—";
+  const outcome = e.outcome ?? "—";
+  const detail =
+    e.prUrl ??
+    (e.error ? truncate(e.error, 80) : "") ??
+    e.commentUrl ??
+    "";
+  out.push(`    #${id.padStart(4)}  ${e.status.padEnd(15)} ${agentLabel.padEnd(30)} ${outcome.padEnd(10)} ${detail}`);
+  if (e.partialBranchUrl) {
+    out.push(`           partial: ${e.partialBranchUrl}`);
+  }
+  if (e.errorSubtype && !e.error?.includes(e.errorSubtype)) {
+    out.push(`           errorSubtype: ${e.errorSubtype}`);
+  }
+  if (e.commentUrl && e.prUrl) {
+    out.push(`           comment: ${e.commentUrl}`);
+  }
+  return out;
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 3) + "..." : s;
+}

--- a/src/util/statusFormatter.test.ts
+++ b/src/util/statusFormatter.test.ts
@@ -1,0 +1,195 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  formatDuration,
+  formatStatusJson,
+  formatStatusText,
+} from "../state/statusFormatter.js";
+import type { RunState } from "../types.js";
+
+function fixture(overrides: Partial<RunState> = {}): RunState {
+  return {
+    runId: "run-2026-05-05T13-32-46-094Z",
+    targetRepo: "szhygulin/vaultpilot-development-agents",
+    issueRange: { kind: "csv", ids: [119] },
+    parallelism: 1,
+    agents: [{ agentId: "agent-08c4", status: "idle" }],
+    issues: {},
+    tickCount: 2,
+    startedAt: "2026-05-05T13:32:46.095Z",
+    lastTickAt: "2026-05-05T13:38:55.000Z",
+    dryRun: false,
+    ...overrides,
+  } as RunState;
+}
+
+test("formatStatusText: empty issues renders aggregate header without Issues block", () => {
+  const text = formatStatusText(fixture());
+  assert.match(text, /Run run-2026-05-05/);
+  assert.match(text, /total=0 pending=0 in-flight=0 done=0 failed=0 aborted-budget=0/);
+  assert.match(text, /agent agent-08c4: idle/);
+  assert.doesNotMatch(text, /Issues:/);
+});
+
+test("formatStatusText: single done issue with PR url", () => {
+  const text = formatStatusText(
+    fixture({
+      issues: {
+        "119": {
+          status: "done",
+          agentId: "agent-08c4",
+          outcome: "implement",
+          prUrl: "https://github.com/x/y/pull/122",
+        },
+      },
+    }),
+  );
+  assert.match(text, /total=1 pending=0 in-flight=0 done=1 failed=0/);
+  assert.match(text, /Issues:/);
+  assert.match(text, /#\s*119/);
+  assert.match(text, /implement/);
+  assert.match(text, /https:\/\/github\.com\/x\/y\/pull\/122/);
+});
+
+test("formatStatusText: failed issue surfaces error + partialBranchUrl + errorSubtype", () => {
+  const text = formatStatusText(
+    fixture({
+      issues: {
+        "84": {
+          status: "failed",
+          agentId: "agent-e287",
+          outcome: "error",
+          error: "error_max_turns",
+          errorSubtype: "error_max_turns",
+          parseError: "No JSON envelope found",
+          partialBranchUrl: "https://github.com/x/y/tree/vp-dev/agent-e287/issue-84-incomplete-run-X",
+        },
+      },
+    }),
+  );
+  assert.match(text, /failed/);
+  assert.match(text, /error_max_turns/);
+  assert.match(text, /partial:/);
+  assert.match(text, /-incomplete-/);
+  // errorSubtype suppressed when already in error string
+  assert.equal((text.match(/error_max_turns/g) ?? []).length, 1);
+});
+
+test("formatStatusText: errorSubtype surfaced separately when not in error message", () => {
+  const text = formatStatusText(
+    fixture({
+      issues: {
+        "1": {
+          status: "failed",
+          error: "Unknown agent failure",
+          errorSubtype: "error_during_execution",
+        },
+      },
+    }),
+  );
+  assert.match(text, /errorSubtype: error_during_execution/);
+});
+
+test("formatStatusText: applies agent name from registry lookup", () => {
+  const text = formatStatusText(
+    fixture({
+      agents: [{ agentId: "agent-08c4", status: "idle" }],
+      issues: { "1": { status: "done", agentId: "agent-08c4", outcome: "implement" } },
+    }),
+    { agentNames: new Map([["agent-08c4", "Khwarizmi"]]) },
+  );
+  assert.match(text, /Khwarizmi \(agent-08c4\)/);
+});
+
+test("formatStatusText: maxCostUsd surfaces when set", () => {
+  const text = formatStatusText(fixture({ maxCostUsd: 5.0 } as Partial<RunState>));
+  assert.match(text, /maxCostUsd=5/);
+});
+
+test("formatStatusText: omits maxCostUsd line when undefined", () => {
+  const text = formatStatusText(fixture());
+  assert.doesNotMatch(text, /maxCostUsd/);
+});
+
+test("formatStatusJson: shape includes summary, agents, issues, durationMs", () => {
+  const json = formatStatusJson(
+    fixture({
+      issues: {
+        "119": {
+          status: "done",
+          agentId: "agent-08c4",
+          outcome: "implement",
+          prUrl: "https://github.com/x/y/pull/122",
+        },
+      },
+    }),
+    { agentNames: new Map([["agent-08c4", "Khwarizmi"]]) },
+  );
+  assert.equal(json.runId, "run-2026-05-05T13-32-46-094Z");
+  assert.equal(json.summary.total, 1);
+  assert.equal(json.summary.done, 1);
+  assert.equal(json.summary.failed, 0);
+  assert.equal(json.issues.length, 1);
+  assert.equal(json.issues[0].id, 119);
+  assert.equal(json.issues[0].agentName, "Khwarizmi");
+  assert.equal(json.issues[0].prUrl, "https://github.com/x/y/pull/122");
+  assert.ok(json.durationMs && json.durationMs > 0);
+});
+
+test("formatStatusJson: omits durationMs when timestamps missing", () => {
+  const json = formatStatusJson(
+    fixture({ startedAt: undefined, lastTickAt: undefined } as Partial<RunState>),
+  );
+  assert.equal(json.durationMs, undefined);
+});
+
+test("formatStatusJson: issues sorted numerically by id, not lexically", () => {
+  const json = formatStatusJson(
+    fixture({
+      issues: {
+        "12": { status: "done" },
+        "2": { status: "done" },
+        "100": { status: "done" },
+        "9": { status: "done" },
+      },
+    }),
+  );
+  assert.deepEqual(
+    json.issues.map((i) => i.id),
+    [2, 9, 12, 100],
+  );
+});
+
+test("formatDuration: minutes + seconds for short runs", () => {
+  assert.equal(
+    formatDuration("2026-05-05T13:00:00Z", "2026-05-05T13:06:09Z"),
+    "6m9s",
+  );
+});
+
+test("formatDuration: just seconds when under a minute", () => {
+  assert.equal(
+    formatDuration("2026-05-05T13:00:00Z", "2026-05-05T13:00:42Z"),
+    "42s",
+  );
+});
+
+test("formatDuration: hours + minutes + seconds for long runs", () => {
+  assert.equal(
+    formatDuration("2026-05-05T10:00:00Z", "2026-05-05T12:34:56Z"),
+    "2h34m56s",
+  );
+});
+
+test("formatDuration: returns undefined for missing timestamps", () => {
+  assert.equal(formatDuration(undefined, "2026-05-05T13:06:09Z"), undefined);
+  assert.equal(formatDuration("2026-05-05T13:00:00Z", undefined), undefined);
+  assert.equal(formatDuration(undefined, undefined), undefined);
+});
+
+test("formatDuration: returns undefined for negative span (clock skew)", () => {
+  assert.equal(
+    formatDuration("2026-05-05T13:06:09Z", "2026-05-05T13:00:00Z"),
+    undefined,
+  );
+});


### PR DESCRIPTION
Promote the ad-hoc python one-liners I (and any operator) reached for during prior sessions to read `state/run-*.json` into a first-class `vp-dev status` capability.

## Why

The existing `vp-dev status` was **current-run-only** (reads `state/current-run.txt`, returns "No active run" otherwise) and **aggregate-only** (per-status counts + agent statuses, no per-issue detail). Useful for "is this run still going?" but not for "what happened on run X?".

The session leading to this PR repeatedly hit that gap — every time a run landed, the operator needed to run a python one-liner against the latest `run-*.json` to see per-issue PR URLs, error subtypes, partial-branch URLs (post-PR [#92](https://github.com/szhygulin/vaultpilot-development-agents/pull/92)), and agent assignments. This PR formalizes that workflow.

## What changes

Three resolution modes for which run to inspect:

```
vp-dev status                   # active run, per current-run.txt (existing behavior)
vp-dev status <runId>           # historical inspection by ID
vp-dev status --latest          # most recent run-*.json on disk
vp-dev status --json            # machine-readable JSON shape (works with all three)
```

**Output additions** (text mode):
- Run duration (`6m9s` / `2h34m56s` / `42s` formats based on magnitude).
- Per-issue block when total > 0 — status / agent (with display name) / outcome / PR-url-or-error.
- Partial-branch URL on its own line when present (#92's `-incomplete-<runId>` salvage refs).
- `errorSubtype` surfaces separately when not already embedded in the error message (#90's cause-vs-symptom distinction stays visible).

**JSON mode** — stable shape:
```ts
{ runId, targetRepo, startedAt, lastTickAt, durationMs,
  parallelism, dryRun, tickCount, maxCostUsd,
  summary: { total, pending, "in-flight", done, failed, "aborted-budget" },
  agents: [{ agentId, agentName, status }],
  issues: [{ id, status, agentId, agentName, outcome, prUrl, commentUrl,
             partialBranchUrl, error, errorSubtype, parseError }] }
```

Issues sorted **numerically** by ID (lex sort would put `#100` before `#20`).

## Implementation

- **`src/state/statusFormatter.ts`** (new) — pure helpers `formatStatusText` and `formatStatusJson` plus `formatDuration`. No I/O; takes `RunState` + optional `agentNames` lookup so registry resolution stays in the CLI layer and the helpers are testable without touching disk.
- **`src/state/runState.ts`** — new `findLatestRunId()` helper. Walks `state/`, sorts ISO-timestamped run files lexically (= chronologically), returns the last one or `null`.
- **`src/cli.ts`** — extend the `status` subcommand: `[runId]` optional positional, `--latest` and `--json` flags. `cmdStatus` resolves the runId via the three-mode precedence (arg → `--latest` → `current-run.txt`), loads the registry once for name lookup, renders text or JSON.
- **`src/util/statusFormatter.test.ts`** (new) — 15 unit tests under the existing `dist/src/util/*.test.js` glob.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run build` clean.
- [x] `npm test` — 212 tests pass (197 baseline + 15 new). New tests cover empty state, single done with PR, failed with partial-branch + errorSubtype suppression, agent-name resolution, maxCostUsd surfacing, JSON shape, numeric issue sort, formatDuration corner cases.
- [x] Smoke-tested against this session's run states:
  - `--latest` → latest single-issue run renders with `9s` duration + Khwarizmi assignment.
  - Explicit runId on the 11-issue parallel run renders all 3 failures' `-incomplete-` partial-branch URLs intact.
  - `--json` round-trips cleanly.

## Compatibility / risk

- **No `state/` schema changes.** Pure read-side enhancement.
- **No registry mutation.** Status command stays read-only.
- **Existing behavior preserved**: `vp-dev status` with no args still reads `current-run.txt` and prints "No active run" when absent.
- **No new deps.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)