### PR TITLE
feat(status): --watch flag for periodic status re-render

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,6 +48,7 @@ import {
 } from "./git/worktree.js";
 import { findOpenVpDevPrs } from "./git/openPrs.js";
 import { formatStatusJson, formatStatusText } from "./state/statusFormatter.js";
+import { resolveRenderMode, watchStatus } from "./util/statusWatcher.js";
 import {
   DEFAULT_INCOMPLETE_RETENTION_DAYS,
   filterByRetention,
@@ -165,6 +166,21 @@ export function buildCli(): Command {
     .description("Print summary of a run + per-agent state + per-issue detail. With no args: shows the active run if one exists. Pass <runId> to inspect a specific past run, or --latest for the most recent run on disk.")
     .option("--latest", "Inspect the most recent run-<ts>.json on disk regardless of completion")
     .option("--json", "Print machine-readable JSON")
+    .option(
+      "--watch",
+      "Re-render the status block on an interval until the run reaches a terminal state or SIGINT (#124). TTY: clear-and-home + redraw; non-TTY: separator + append; --json: NDJSON one object per tick.",
+    )
+    .option(
+      "--interval <seconds>",
+      "Refresh interval for --watch in seconds (default 10)",
+      parsePositive,
+      10,
+    )
+    .option(
+      "--max-iterations <n>",
+      "Escape hatch for --watch: stop after N ticks even if the run hasn't completed",
+      parsePositive,
+    )
     .action(async (runIdArg, opts) => {
       await cmdStatus(runIdArg, opts);
     });
@@ -1027,6 +1043,9 @@ async function runResume(opts: RunOpts): Promise<void> {
 interface StatusOpts {
   latest?: boolean;
   json?: boolean;
+  watch?: boolean;
+  interval?: number;
+  maxIterations?: number;
 }
 
 async function cmdStatus(runIdArg?: string, opts: StatusOpts = {}): Promise<void> {
@@ -1049,6 +1068,20 @@ async function cmdStatus(runIdArg?: string, opts: StatusOpts = {}): Promise<void
     return;
   }
 
+  // Resolve names from registry once (best-effort — keep status read-only).
+  // For --watch we reuse this map across ticks; agent registry edits during
+  // a run are vanishingly rare and the cost of re-reading every tick isn't
+  // worth the freshness gain.
+  const reg = await loadRegistry();
+  const agentNames = new Map<string, string | undefined>(
+    reg.agents.map((a) => [a.agentId, a.name]),
+  );
+
+  if (opts.watch) {
+    await runStatusWatch(runId, opts, agentNames);
+    return;
+  }
+
   let state;
   try {
     state = await loadRunState(runId);
@@ -1057,17 +1090,53 @@ async function cmdStatus(runIdArg?: string, opts: StatusOpts = {}): Promise<void
     process.exit(2);
   }
 
-  // Resolve names from registry (best-effort — keep status read-only).
-  const reg = await loadRegistry();
-  const agentNames = new Map<string, string | undefined>(
-    reg.agents.map((a) => [a.agentId, a.name]),
-  );
-
   if (opts.json) {
     process.stdout.write(JSON.stringify(formatStatusJson(state, { agentNames }), null, 2) + "\n");
     return;
   }
   process.stdout.write(formatStatusText(state, { agentNames }));
+}
+
+async function runStatusWatch(
+  runId: string,
+  opts: StatusOpts,
+  agentNames: Map<string, string | undefined>,
+): Promise<void> {
+  const intervalSec = opts.interval ?? 10;
+  const intervalMs = intervalSec * 1000;
+  const isTty = Boolean(process.stdout.isTTY);
+  const mode = resolveRenderMode({ json: Boolean(opts.json), isTty });
+
+  const ac = new AbortController();
+  const onSigint = () => ac.abort();
+  process.on("SIGINT", onSigint);
+
+  try {
+    const result = await watchStatus({
+      tickFn: async () => {
+        const state = await loadRunState(runId);
+        const output = opts.json
+          ? JSON.stringify(formatStatusJson(state, { agentNames }))
+          : formatStatusText(state, { agentNames });
+        return { done: isRunComplete(state), output };
+      },
+      intervalMs,
+      mode,
+      maxIterations: opts.maxIterations,
+      signal: ac.signal,
+    });
+    // Surface a one-line trailer to stderr in text modes so the operator
+    // can tell why the loop stopped (run-complete vs ctrl-c vs cap). JSON
+    // mode stays pure NDJSON for downstream parsers.
+    if (mode !== "json") {
+      process.stderr.write(`\n[watch] exited (${result.reason}) after ${result.iterations} tick(s)\n`);
+    }
+  } catch (err) {
+    process.stderr.write(`ERROR: watch failed for ${runId}: ${(err as Error).message}\n`);
+    process.exit(2);
+  } finally {
+    process.off("SIGINT", onSigint);
+  }
 }
 
 interface AgentsSpecialtiesOpts {

--- a/src/util/statusWatcher.test.ts
+++ b/src/util/statusWatcher.test.ts
@@ -1,0 +1,215 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Writable } from "node:stream";
+import { resolveRenderMode, watchStatus, type WatcherTick } from "./statusWatcher.js";
+
+class CollectStream extends Writable {
+  chunks: string[] = [];
+  override _write(chunk: Buffer | string, _enc: BufferEncoding, cb: (err?: Error | null) => void): void {
+    this.chunks.push(typeof chunk === "string" ? chunk : chunk.toString("utf-8"));
+    cb();
+  }
+  get text(): string {
+    return this.chunks.join("");
+  }
+}
+
+function ticker(plan: WatcherTick[]): () => Promise<WatcherTick> {
+  let i = 0;
+  return async () => {
+    const t = plan[Math.min(i, plan.length - 1)];
+    i += 1;
+    return t;
+  };
+}
+
+const noopSleep = async (): Promise<void> => {};
+
+test("watchStatus: stream-text mode appends separator each tick and exits on done", async () => {
+  const out = new CollectStream();
+  const fixedNow = () => new Date("2026-05-05T13:00:00Z");
+  const result = await watchStatus({
+    tickFn: ticker([
+      { done: false, output: "snapshot A\n" },
+      { done: false, output: "snapshot B\n" },
+      { done: true, output: "snapshot C\n" },
+    ]),
+    intervalMs: 10,
+    mode: "stream-text",
+    out,
+    sleep: noopSleep,
+    now: fixedNow,
+  });
+
+  assert.equal(result.iterations, 3);
+  assert.equal(result.reason, "complete");
+  // All three snapshots present in chronological order
+  const idxA = out.text.indexOf("snapshot A");
+  const idxB = out.text.indexOf("snapshot B");
+  const idxC = out.text.indexOf("snapshot C");
+  assert.ok(idxA >= 0 && idxB > idxA && idxC > idxB, "snapshots ordered chronologically");
+  // Separator format: "--- tick N <iso> ---"
+  assert.match(out.text, /--- tick 1 2026-05-05T13:00:00\.000Z ---/);
+  assert.match(out.text, /--- tick 3 2026-05-05T13:00:00\.000Z ---/);
+  // Stream-text never emits clear-and-home
+  assert.equal(out.text.includes("\x1b[2J"), false);
+});
+
+test("watchStatus: tty-text mode emits clear-and-home each tick, no separator", async () => {
+  const out = new CollectStream();
+  const result = await watchStatus({
+    tickFn: ticker([
+      { done: false, output: "snap1\n" },
+      { done: true, output: "snap2\n" },
+    ]),
+    intervalMs: 10,
+    mode: "tty-text",
+    out,
+    sleep: noopSleep,
+  });
+
+  assert.equal(result.iterations, 2);
+  // Two clear-and-home sequences (one per tick)
+  const clears = (out.text.match(/\x1b\[2J\x1b\[H/g) ?? []).length;
+  assert.equal(clears, 2);
+  // No "--- tick" separators in TTY mode
+  assert.equal(out.text.includes("--- tick"), false);
+});
+
+test("watchStatus: json mode emits NDJSON, one object per line, no clear/separator", async () => {
+  const out = new CollectStream();
+  const result = await watchStatus({
+    tickFn: ticker([
+      { done: false, output: '{"tick":1}' },
+      { done: false, output: '{"tick":2}' },
+      { done: true, output: '{"tick":3}' },
+    ]),
+    intervalMs: 10,
+    mode: "json",
+    out,
+    sleep: noopSleep,
+  });
+
+  assert.equal(result.iterations, 3);
+  // Each line is parseable JSON; exactly 3 lines
+  const lines = out.text.split("\n").filter((l) => l.length > 0);
+  assert.equal(lines.length, 3);
+  for (const line of lines) {
+    assert.doesNotThrow(() => JSON.parse(line));
+  }
+  assert.deepEqual(JSON.parse(lines[0]), { tick: 1 });
+  assert.deepEqual(JSON.parse(lines[2]), { tick: 3 });
+  // No clear-and-home, no separator
+  assert.equal(out.text.includes("\x1b[2J"), false);
+  assert.equal(out.text.includes("--- tick"), false);
+});
+
+test("watchStatus: max-iterations halts before run completes", async () => {
+  const out = new CollectStream();
+  const result = await watchStatus({
+    tickFn: ticker([
+      { done: false, output: "x\n" },
+      { done: false, output: "x\n" },
+      { done: false, output: "x\n" },
+      { done: false, output: "x\n" },
+    ]),
+    intervalMs: 10,
+    mode: "tty-text",
+    maxIterations: 2,
+    out,
+    sleep: noopSleep,
+  });
+
+  assert.equal(result.reason, "max-iterations");
+  assert.equal(result.iterations, 2);
+});
+
+test("watchStatus: aborted signal exits after current tick renders", async () => {
+  const out = new CollectStream();
+  const ac = new AbortController();
+  // Sleep cancels on abort
+  const cancelableSleep = (ms: number, signal?: AbortSignal) =>
+    new Promise<void>((resolve) => {
+      const t = setTimeout(resolve, ms);
+      signal?.addEventListener("abort", () => {
+        clearTimeout(t);
+        resolve();
+      }, { once: true });
+    });
+
+  const tickFn = async (): Promise<WatcherTick> => {
+    // Trip the signal during the first tick — subsequent sleep should
+    // resolve immediately and the loop should exit "aborted" before
+    // a second render.
+    if (!ac.signal.aborted) ac.abort();
+    return { done: false, output: "x\n" };
+  };
+
+  const result = await watchStatus({
+    tickFn,
+    intervalMs: 1,
+    mode: "tty-text",
+    signal: ac.signal,
+    out,
+    sleep: cancelableSleep,
+  });
+
+  assert.equal(result.reason, "aborted");
+  assert.equal(result.iterations, 1);
+});
+
+test("watchStatus: aborted before first tick renders nothing", async () => {
+  const out = new CollectStream();
+  const ac = new AbortController();
+  ac.abort();
+
+  const result = await watchStatus({
+    tickFn: async () => ({ done: false, output: "should not render\n" }),
+    intervalMs: 10,
+    mode: "tty-text",
+    signal: ac.signal,
+    out,
+    sleep: noopSleep,
+  });
+
+  assert.equal(result.reason, "aborted");
+  assert.equal(result.iterations, 0);
+  assert.equal(out.text, "");
+});
+
+test("watchStatus: stream-text leading separator has no preceding blank line", async () => {
+  const out = new CollectStream();
+  const result = await watchStatus({
+    tickFn: ticker([{ done: true, output: "x\n" }]),
+    intervalMs: 10,
+    mode: "stream-text",
+    out,
+    sleep: noopSleep,
+    now: () => new Date("2026-05-05T13:00:00Z"),
+  });
+
+  assert.equal(result.reason, "complete");
+  assert.ok(out.text.startsWith("--- tick 1"), "first separator on first byte");
+});
+
+test("watchStatus: tick output without trailing newline still renders cleanly", async () => {
+  const out = new CollectStream();
+  await watchStatus({
+    tickFn: ticker([{ done: true, output: "no-trailing-newline" }]),
+    intervalMs: 10,
+    mode: "tty-text",
+    out,
+    sleep: noopSleep,
+  });
+  assert.ok(out.text.endsWith("no-trailing-newline\n"));
+});
+
+test("resolveRenderMode: json wins over isTty", () => {
+  assert.equal(resolveRenderMode({ json: true, isTty: true }), "json");
+  assert.equal(resolveRenderMode({ json: true, isTty: false }), "json");
+});
+
+test("resolveRenderMode: text branches on isTty", () => {
+  assert.equal(resolveRenderMode({ json: false, isTty: true }), "tty-text");
+  assert.equal(resolveRenderMode({ json: false, isTty: false }), "stream-text");
+});

--- a/src/util/statusWatcher.ts
+++ b/src/util/statusWatcher.ts
@@ -1,0 +1,108 @@
+/**
+ * Generic poll-loop helper for `vp-dev status --watch` (#124). Stays
+ * decoupled from disk I/O and run-state types: callers pass a `tickFn`
+ * that returns the rendered output + a terminal flag, and `watchStatus`
+ * handles cadence, render mode (TTY clear-and-home vs non-TTY accumulate
+ * vs NDJSON), exit conditions, and SIGINT.
+ */
+
+export interface WatcherTick {
+  /** Run reached a terminal state — loop exits after rendering this tick. */
+  done: boolean;
+  /** Pre-formatted output for this tick. JSON mode expects a single line. */
+  output: string;
+}
+
+export type WatcherRenderMode = "tty-text" | "stream-text" | "json";
+
+export interface WatchStatusOptions {
+  tickFn: () => Promise<WatcherTick>;
+  intervalMs: number;
+  mode: WatcherRenderMode;
+  /** Hard escape-hatch — exit after N ticks even if not done. */
+  maxIterations?: number;
+  /** SIGINT / external abort. Loop exits after current tick renders. */
+  signal?: AbortSignal;
+  /** Where to write rendered output. Defaults to process.stdout. */
+  out?: NodeJS.WritableStream;
+  /** Test seam for cancellable sleep. */
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+  /** Test seam for timestamp on stream-text separator. */
+  now?: () => Date;
+}
+
+export type WatchExitReason = "complete" | "max-iterations" | "aborted";
+
+export interface WatchStatusResult {
+  iterations: number;
+  reason: WatchExitReason;
+}
+
+const ANSI_CLEAR_AND_HOME = "\x1b[2J\x1b[H";
+
+export async function watchStatus(opts: WatchStatusOptions): Promise<WatchStatusResult> {
+  const out = opts.out ?? process.stdout;
+  const sleep = opts.sleep ?? defaultSleep;
+  const now = opts.now ?? (() => new Date());
+
+  let iterations = 0;
+  while (true) {
+    if (opts.signal?.aborted) return { iterations, reason: "aborted" };
+
+    iterations += 1;
+    const tick = await opts.tickFn();
+
+    if (opts.mode === "json") {
+      out.write(stripTrailingNewlines(tick.output) + "\n");
+    } else if (opts.mode === "tty-text") {
+      out.write(ANSI_CLEAR_AND_HOME);
+      out.write(ensureTrailingNewline(tick.output));
+    } else {
+      // stream-text: keep history as a chronological log
+      const ts = now().toISOString();
+      const sep = iterations === 1
+        ? `--- tick ${iterations} ${ts} ---\n`
+        : `\n--- tick ${iterations} ${ts} ---\n`;
+      out.write(sep);
+      out.write(ensureTrailingNewline(tick.output));
+    }
+
+    if (tick.done) return { iterations, reason: "complete" };
+    if (opts.maxIterations !== undefined && iterations >= opts.maxIterations) {
+      return { iterations, reason: "max-iterations" };
+    }
+
+    await sleep(opts.intervalMs, opts.signal);
+    if (opts.signal?.aborted) return { iterations, reason: "aborted" };
+  }
+}
+
+function ensureTrailingNewline(s: string): string {
+  return s.endsWith("\n") ? s : s + "\n";
+}
+
+function stripTrailingNewlines(s: string): string {
+  return s.replace(/\n+$/, "");
+}
+
+function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) return resolve();
+    const t = setTimeout(resolve, ms);
+    if (!signal) return;
+    const onAbort = () => {
+      clearTimeout(t);
+      resolve();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Map text-mode + isTTY to the concrete render mode. JSON mode ignores
+ * TTY-ness — NDJSON is meant to be machine-piped.
+ */
+export function resolveRenderMode(opts: { json: boolean; isTty: boolean }): WatcherRenderMode {
+  if (opts.json) return "json";
+  return opts.isTty ? "tty-text" : "stream-text";
+}


### PR DESCRIPTION
Closes #124.

Adds `vp-dev status --watch` so operators can keep a live structural view of an in-flight run without re-typing `vp-dev status --latest` every 30s. Implements scope **A** of #124; scope **B** (`vp-dev run --progress` orchestrator-tick auto-emit) remains an optional follow-up — file separately if useful.

## Surfaces

- `vp-dev status --watch` — active run, refresh every 10s.
- `vp-dev status <runId> --watch --interval 5` — specific run, 5s.
- `vp-dev status --latest --watch` — most recent run on disk.
- `vp-dev status --watch --json` — NDJSON, one object per tick (machine-readable progress stream).
- `vp-dev status --watch --max-iterations N` — escape hatch.

## Render modes

- **TTY + text**: ANSI `\x1b[2J\x1b[H` clear-and-home + redraw each tick.
- **Non-TTY + text**: `--- tick N <iso> ---` separator + append; piping into a file gives a chronological progress log.
- **JSON (any)**: NDJSON, one object per line, no separator/clear (downstream parsers stay clean).

A single-line trailer goes to **stderr** in text modes after the loop exits (`[watch] exited (complete|aborted|max-iterations) after N tick(s)`); JSON mode stays pure NDJSON.

## Exit conditions

- `isRunComplete(state)` returns true → exit `complete`.
- SIGINT → `AbortController` aborts after the current tick renders → exit `aborted`.
- `--max-iterations N` reached → exit `max-iterations`.

## Files

- `src/util/statusWatcher.ts` (new, 110 lines) — pure poll-loop helper. `tickFn`-shaped seam keeps it disk-free; `sleep` and `now` are injectable for tests.
- `src/util/statusWatcher.test.ts` (new, 11 tests) — covers all three render modes, exit-on-complete, exit-on-max-iterations, abort-during-tick, abort-before-first-tick, leading-separator shape, missing-trailing-newline normalization, `resolveRenderMode` JSON-vs-TTY precedence.
- `src/cli.ts` — registers `--watch` / `--interval` / `--max-iterations` on the `status` command and routes through a new `runStatusWatch()` helper.

## Smoke tests

Verified end-to-end against a synthetic run:
- Stream-text mode (3 ticks, --max-iterations 3): separators between ticks, trailer printed.
- JSON mode against a `done` run: exits immediately on tick 1 with one NDJSON line, no trailer (clean for parsers).

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run build` clean.
- [x] `npm test` — 232 tests pass (221 prior + 11 new).
- [x] `vp-dev status --watch` against no active run → "No active run." (no loop).
- [x] `vp-dev status <id> --watch --max-iterations 3` against in-flight run → 3 ticks + trailer.
- [x] `vp-dev status <id> --watch --json` against done run → 1 NDJSON line, exits clean.