### PR TITLE
fix(status): exclude run-confirm-*.json from --latest picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "typecheck": "tsc --noEmit",
-    "test": "tsc && node --test dist/src/util/*.test.js dist/src/git/*.test.js dist/src/orchestrator/*.test.js dist/src/agent/*.test.js",
+    "test": "tsc && node --test dist/src/util/*.test.js dist/src/git/*.test.js dist/src/orchestrator/*.test.js dist/src/agent/*.test.js dist/src/state/*.test.js",
     "vp-dev": "node dist/bin/vp-dev.js"
   },
   "dependencies": {

--- a/src/state/runState.test.ts
+++ b/src/state/runState.test.ts
@@ -1,0 +1,67 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { pickLatestRunIdFromEntries } from "./runState.js";
+
+test("pickLatestRunIdFromEntries: ignores run-confirm-*.json token files (#125)", () => {
+  // Repro shape: state/ contains a real run-state file plus a confirm
+  // token. Loose `startsWith("run-")` lex-sorted the token last (`'c' >
+  // '2'`) and returned `run-confirm-...`, which loadRunState parsed as
+  // valid JSON and formatStatusText then crashed on `Object.keys(state.issues)`.
+  const entries = [
+    "agents-registry.json",
+    "current-run.txt",
+    "run-2026-05-05T14-26-37-251Z.json",
+    "run-confirm-1bc06c6f01894bd6.json",
+  ];
+  assert.equal(
+    pickLatestRunIdFromEntries(entries),
+    "run-2026-05-05T14-26-37-251Z",
+  );
+});
+
+test("pickLatestRunIdFromEntries: returns null on empty directory", () => {
+  assert.equal(pickLatestRunIdFromEntries([]), null);
+});
+
+test("pickLatestRunIdFromEntries: returns null when only non-run-state files present", () => {
+  assert.equal(
+    pickLatestRunIdFromEntries([
+      "agents-registry.json",
+      "current-run.txt",
+      "run-confirm-abc.json",
+      "run-summary-xyz.json",
+    ]),
+    null,
+  );
+});
+
+test("pickLatestRunIdFromEntries: lex-sort is chronological for ISO-timestamp filenames", () => {
+  const entries = [
+    "run-2026-05-05T14-26-37-251Z.json",
+    "run-2026-05-05T14-31-12-100Z.json",
+    "run-2026-05-04T09-00-00-000Z.json",
+  ];
+  assert.equal(
+    pickLatestRunIdFromEntries(entries),
+    "run-2026-05-05T14-31-12-100Z",
+  );
+});
+
+test("pickLatestRunIdFromEntries: rejects ambiguous run-* prefixes that aren't run-state files", () => {
+  // Defense against future state-file kinds sharing the `run-` prefix:
+  // anything that doesn't look like `run-<YYYY>-<MM>-<DD>T...` is skipped.
+  for (const sneak of [
+    "run-confirm-deadbeef.json",
+    "run-summary-2026-05-05.json",
+    "run-tmp.json",
+    "run-.json",
+    "run-2026.json",
+    "run-2026-05.json",
+  ]) {
+    assert.equal(
+      pickLatestRunIdFromEntries([sneak]),
+      null,
+      `expected ${sneak} to be filtered out`,
+    );
+  }
+});

--- a/src/state/runState.ts
+++ b/src/state/runState.ts
@@ -70,12 +70,21 @@ export async function findLatestRunId(): Promise<string | null> {
   } catch {
     return null;
   }
-  const runFiles = entries
-    .filter((e) => e.startsWith("run-") && e.endsWith(".json"))
-    .sort();
+  return pickLatestRunIdFromEntries(entries);
+}
+
+// Run-state files match `run-<ISO-timestamp>.json` (per `makeRunId`'s
+// `toISOString().replace(/[:.]/g, "-")`). The anchored regex is what
+// keeps `run-confirm-<token>.json` (and any future `run-*-<x>.json`
+// kinds) out of the latest-run picker — `startsWith("run-")` was too
+// loose, lex-sorted `run-confirm-*` ahead of real runs, and crashed
+// `formatStatusText` on a confirm-token's RunConfirmToken shape (#125).
+const RUN_STATE_FILE_RE = /^run-\d{4}-\d{2}-\d{2}T.*\.json$/;
+
+export function pickLatestRunIdFromEntries(entries: string[]): string | null {
+  const runFiles = entries.filter((e) => RUN_STATE_FILE_RE.test(e)).sort();
   if (runFiles.length === 0) return null;
-  const last = runFiles[runFiles.length - 1];
-  return last.replace(/\.json$/, "");
+  return runFiles[runFiles.length - 1].replace(/\.json$/, "");
 }
 
 export function newRunState(opts: {


### PR DESCRIPTION
Closes #125.

`findLatestRunId` filtered for `startsWith("run-") && endsWith(".json")`, which catches both real run-state files (`run-<ISO>.json`) and `run-confirm-<token>.json` files (15-min TTL artifacts of `vp-dev run --plan`). Lex-sort puts `run-confirm-*` ahead of `run-2026-*` (`'c' > '2'`), so `--latest` returned a confirm-token filename. `loadRunState` parses the confirm-token JSON, then `formatStatusText` crashes at `Object.keys(state.issues)` because the confirm-token shape has no `issues` field.

After this PR, `vp-dev status --latest` works against any `state/` directory containing `run-confirm-*.json` files (i.e. anyone who has used the `--plan`/`--confirm` flow recently — almost everyone, since Claude Code's non-TTY use case requires it).

## Fix

Tighten the filter to the canonical run-state filename shape — `run-<ISO-timestamp>.json` matching `/^run-\d{4}-\d{2}-\d{2}T.*\.json$/`, anchored against `makeRunId`'s `toISOString().replace(/[:.]/g, "-")` output. Defensive against any future `run-*-<x>.json` state-file kinds sharing the `run-` prefix.

Extracted the filter as a pure helper `pickLatestRunIdFromEntries(entries)` so the test is fs-free and cheap; the IO orchestrator `findLatestRunId()` now delegates to it.

## Why CI didn't catch this

`findLatestRunId` was added in PR #123 without a test, and `statusFormatter.test.ts` only covers `formatStatusText` against valid `RunState` fixtures — never the directory-listing path. Added `src/state/runState.test.ts` covering the bug shape + adjacent edge cases (empty dir, only-non-run-state-files, lex-sort = chronological invariant, ambiguous `run-*` prefix rejection).

This is the first test under `src/state/`, so the test glob in `package.json` gains `dist/src/state/*.test.js`.

## Smoke tests

Verified end-to-end against a synthetic `state/` directory:
- Both `run-2026-...json` + `run-confirm-...json` present → `--latest` resolves to the run-state file, no crash.
- Only `run-confirm-...json` present → `--latest` prints `No runs on disk.` (no crash).

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run build` clean.
- [x] `npm test` — 237 tests pass (232 prior + 5 new).
- [x] Repro shape from the issue (real run + confirm token in `state/`) → `--latest` now resolves to the real run.
- [x] Confirm-token-only directory → `--latest` prints "No runs on disk." instead of crashing.