### PR TITLE
feat(cli): emit run.completed terminal sentinel on stdout (#128)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -103,6 +103,7 @@ import {
   type AgentRollup,
 } from "./state/outcomes.js";
 import { RunCostTracker, resolveBudgetUsd } from "./util/costTracker.js";
+import { formatRunCompletedSentinel } from "./util/runCompletedSentinel.js";
 import type { AgentRecord, IssueRangeSpec, IssueSummary, ResumeContext, RunState } from "./types.js";
 import { STATE_DIR } from "./state/runState.js";
 import path from "node:path";
@@ -766,6 +767,11 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     }
   }
 
+  // Issue #128: capture the run's wall-clock start so the terminal sentinel
+  // can include `durationMs`. Watchers (`tail -F | awk '/^run\.completed
+  // /{print; exit}'`) anchor on that final line as their clean-exit signal.
+  const runStartMs = Date.now();
+  let runError: unknown = undefined;
   try {
     await pruneWorktrees(repoPath);
     const sweep = await pruneStaleAgentBranches(repoPath, opts.targetRepo, logger);
@@ -809,10 +815,29 @@ async function cmdRun(opts: RunOpts): Promise<void> {
       );
     }
     if (isRunComplete(state)) await clearCurrentRunId();
+  } catch (err) {
+    runError = err;
   } finally {
     await logger.close();
+    // Per-run summary line (existing behavior, now in the finally block so
+    // it fires on the throw path too — operators want the log path even
+    // when something blew up). Always precedes the terminal sentinel.
+    process.stdout.write(`Run ${runId} log: logs/${runId}.jsonl\n`);
+    // Terminal sentinel (issue #128) — MUST be the very last stdout line so
+    // external watchers grepping `^run.completed ` can `print; exit` on it.
+    // Fires uniformly across success / dry-run / aborted-budget / failure
+    // / orchestrator-throw paths, ensuring exactly one terminal line per
+    // launched run.
+    process.stdout.write(
+      formatRunCompletedSentinel({
+        runId,
+        state,
+        totalCostUsd: costTracker.total(),
+        durationMs: Date.now() - runStartMs,
+      }),
+    );
   }
-  process.stdout.write(`Run ${runId} log: logs/${runId}.jsonl\n`);
+  if (runError) throw runError;
 }
 
 /**
@@ -1000,6 +1025,11 @@ async function runResume(opts: RunOpts): Promise<void> {
     issueCount: issues.length,
     maxCostUsd: budgetUsd ?? null,
   });
+  // Issue #128: same terminal-sentinel discipline as cmdRun — captured here
+  // so a resumed run also emits exactly one `run.completed` line on stdout
+  // for external watchers to anchor their exit on.
+  const runStartMs = Date.now();
+  let runError: unknown = undefined;
   try {
     const sweep = await pruneStaleAgentBranches(repoPath, state.targetRepo, logger);
     if (sweep.unprunable.length > 0) {
@@ -1035,9 +1065,23 @@ async function runResume(opts: RunOpts): Promise<void> {
       );
     }
     if (isRunComplete(state)) await clearCurrentRunId();
+  } catch (err) {
+    runError = err;
   } finally {
     await logger.close();
+    // Terminal sentinel (issue #128) — last stdout line, fires uniformly
+    // across all exit paths so `tail -F | awk '/^run.completed /{exit}'`
+    // watchers terminate cleanly on resumed runs too.
+    process.stdout.write(
+      formatRunCompletedSentinel({
+        runId,
+        state,
+        totalCostUsd: costTracker.total(),
+        durationMs: Date.now() - runStartMs,
+      }),
+    );
   }
+  if (runError) throw runError;
 }
 
 interface StatusOpts {

--- a/src/util/runCompletedSentinel.test.ts
+++ b/src/util/runCompletedSentinel.test.ts
@@ -1,0 +1,241 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { newRunState } from "../state/runState.js";
+import type { IssueStatus, RunState } from "../types.js";
+import {
+  classifyRunStatus,
+  countRunStatuses,
+  formatRunCompletedSentinel,
+} from "./runCompletedSentinel.js";
+
+// Issue #128: the terminal sentinel is what lets external `tail -F` watchers
+// (Claude Code Monitors, shell scripts) detect "run is over" cleanly. Format
+// stability matters — watchers anchor on the leading literal `run.completed`
+// and treat the line as the signal to exit.
+
+function makeStateWithStatuses(statuses: IssueStatus[]): RunState {
+  const ids = statuses.map((_, i) => i + 1);
+  const state = newRunState({
+    runId: "run-2026-05-05T15-08-13-725Z",
+    targetRepo: "x/y",
+    issueRange: { kind: "csv", ids },
+    parallelism: 1,
+    issueIds: ids,
+    dryRun: false,
+  });
+  for (let i = 0; i < statuses.length; i++) {
+    state.issues[String(ids[i])].status = statuses[i];
+  }
+  return state;
+}
+
+test("countRunStatuses: tallies each terminal+non-terminal bucket", () => {
+  const state = makeStateWithStatuses([
+    "done",
+    "done",
+    "failed",
+    "aborted-budget",
+    "pending",
+    "in-flight",
+  ]);
+  const c = countRunStatuses(state);
+  assert.deepEqual(c, {
+    total: 6,
+    done: 2,
+    failed: 1,
+    abortedBudget: 1,
+    pending: 1,
+    inFlight: 1,
+  });
+});
+
+test("classifyRunStatus: all done → done", () => {
+  const state = makeStateWithStatuses(["done", "done", "done"]);
+  assert.equal(classifyRunStatus(state), "done");
+});
+
+test("classifyRunStatus: all failed → failed", () => {
+  const state = makeStateWithStatuses(["failed", "failed"]);
+  assert.equal(classifyRunStatus(state), "failed");
+});
+
+test("classifyRunStatus: terminal mix of done + failed → partial", () => {
+  const state = makeStateWithStatuses(["done", "failed", "done"]);
+  assert.equal(classifyRunStatus(state), "partial");
+});
+
+test("classifyRunStatus: any aborted-budget present → aborted-budget", () => {
+  // Even mixed with done + failed — the operator-policy halt is the
+  // dominant signal for post-run audits (#86).
+  const state = makeStateWithStatuses([
+    "done",
+    "failed",
+    "aborted-budget",
+    "aborted-budget",
+  ]);
+  assert.equal(classifyRunStatus(state), "aborted-budget");
+});
+
+test("classifyRunStatus: any pending → incomplete", () => {
+  // maxTicks reached before isRunComplete fired, OR orchestrator threw
+  // mid-tick. Either way, watchers + audits need the gap surfaced
+  // explicitly rather than rolled into "failed."
+  const state = makeStateWithStatuses(["done", "done", "pending"]);
+  assert.equal(classifyRunStatus(state), "incomplete");
+});
+
+test("classifyRunStatus: any in-flight → incomplete", () => {
+  const state = makeStateWithStatuses(["done", "in-flight"]);
+  assert.equal(classifyRunStatus(state), "incomplete");
+});
+
+test("classifyRunStatus: incomplete takes precedence over aborted-budget", () => {
+  // If a budget abort is in flight but issues are still pending the run
+  // hasn't finished winding down — the watcher still needs an
+  // "incomplete" exit, not a premature "aborted-budget" claim.
+  const state = makeStateWithStatuses(["aborted-budget", "pending"]);
+  assert.equal(classifyRunStatus(state), "incomplete");
+});
+
+test("classifyRunStatus: empty issue set defaults to done", () => {
+  // cmdRun rejects empty dispatch sets pre-launch, but the function must
+  // remain total so a stray edge case can't crash sentinel emission.
+  const state = makeStateWithStatuses([]);
+  assert.equal(classifyRunStatus(state), "done");
+});
+
+test("formatRunCompletedSentinel: shape matches the watcher's anchored regex", () => {
+  const state = makeStateWithStatuses(["done", "done", "done", "done"]);
+  const line = formatRunCompletedSentinel({
+    runId: "run-2026-05-05T15-08-13-725Z",
+    state,
+    totalCostUsd: 2.34,
+    durationMs: 575000,
+  });
+  // Must end with a single trailing newline so callers can stream-write
+  // without manual concat.
+  assert.ok(line.endsWith("\n"));
+  // Anchored prefix is what the example `awk` filter in #128 keys on:
+  //   /^run\.completed /{print; exit}
+  assert.match(line, /^run\.completed runId=run-2026-05-05T15-08-13-725Z /);
+  assert.match(line, /\bstatus=done\b/);
+  assert.match(line, /\btotal=4\b/);
+  assert.match(line, /\bdone=4\b/);
+  assert.match(line, /\bfailed=0\b/);
+  assert.match(line, /\baborted-budget=0\b/);
+  assert.match(line, /\bdurationMs=575000\b/);
+  assert.match(line, /\btotalCostUsd=2\.3400\b/);
+});
+
+test("formatRunCompletedSentinel: emits status=aborted-budget when any issue was aborted", () => {
+  const state = makeStateWithStatuses(["done", "aborted-budget", "aborted-budget"]);
+  const line = formatRunCompletedSentinel({
+    runId: "run-X",
+    state,
+    totalCostUsd: 0.5,
+    durationMs: 12000,
+  });
+  assert.match(line, /\bstatus=aborted-budget\b/);
+  assert.match(line, /\bdone=1\b/);
+  assert.match(line, /\baborted-budget=2\b/);
+});
+
+test("formatRunCompletedSentinel: emits status=incomplete when issues remain non-terminal", () => {
+  // The maxTicks-reached path (or thrown-mid-tick path) — sentinel still
+  // fires from the finally block so external watchers see exactly one
+  // terminal line.
+  const state = makeStateWithStatuses(["done", "in-flight", "pending"]);
+  const line = formatRunCompletedSentinel({
+    runId: "run-X",
+    state,
+    totalCostUsd: 0,
+    durationMs: 1000,
+  });
+  assert.match(line, /\bstatus=incomplete\b/);
+});
+
+test("formatRunCompletedSentinel: dry-run path emits the same shape", () => {
+  // Dry-run flows through `runOrchestrator` exactly like a real run; the
+  // sentinel must fire uniformly so scripted dry-run probes (e.g. in CI)
+  // can rely on the same exit signal.
+  const state = makeStateWithStatuses(["done", "done"]);
+  state.dryRun = true;
+  const line = formatRunCompletedSentinel({
+    runId: "run-dry",
+    state,
+    totalCostUsd: 0,
+    durationMs: 50,
+  });
+  assert.match(line, /^run\.completed runId=run-dry /);
+  assert.match(line, /\bstatus=done\b/);
+  // dry-run does not get its own status — `dryRun` is a property of the
+  // run-state file, surfaced separately by `vp-dev status` / log analysis.
+  assert.doesNotMatch(line, /dryRun/);
+});
+
+test("formatRunCompletedSentinel: cost is fixed at 4 decimals and clamps non-finite to zero", () => {
+  const state = makeStateWithStatuses(["done"]);
+  const line1 = formatRunCompletedSentinel({
+    runId: "r",
+    state,
+    totalCostUsd: 0,
+    durationMs: 1,
+  });
+  assert.match(line1, /\btotalCostUsd=0\.0000\b/);
+
+  const line2 = formatRunCompletedSentinel({
+    runId: "r",
+    state,
+    totalCostUsd: Number.NaN,
+    durationMs: 1,
+  });
+  assert.match(line2, /\btotalCostUsd=0\.0000\b/);
+
+  const line3 = formatRunCompletedSentinel({
+    runId: "r",
+    state,
+    totalCostUsd: 1.23456789,
+    durationMs: 1,
+  });
+  assert.match(line3, /\btotalCostUsd=1\.2346\b/);
+});
+
+test("formatRunCompletedSentinel: durationMs floors fractional values", () => {
+  // `Date.now()` returns integers but defensive truncation keeps the line
+  // shape stable if a future caller passes a `performance.now()` delta.
+  const state = makeStateWithStatuses(["done"]);
+  const line = formatRunCompletedSentinel({
+    runId: "r",
+    state,
+    totalCostUsd: 0,
+    durationMs: 1234.9,
+  });
+  assert.match(line, /\bdurationMs=1234\b/);
+});
+
+test("formatRunCompletedSentinel: durationMs negative inputs clamp to zero", () => {
+  const state = makeStateWithStatuses(["done"]);
+  const line = formatRunCompletedSentinel({
+    runId: "r",
+    state,
+    totalCostUsd: 0,
+    durationMs: -5,
+  });
+  assert.match(line, /\bdurationMs=0\b/);
+});
+
+test("formatRunCompletedSentinel: single-line — no embedded newlines before the trailing one", () => {
+  const state = makeStateWithStatuses(["done", "failed"]);
+  const line = formatRunCompletedSentinel({
+    runId: "run-X",
+    state,
+    totalCostUsd: 0,
+    durationMs: 0,
+  });
+  // Strip the trailing newline; what remains must contain no further
+  // newlines so a watcher's per-line consumer treats it as one record.
+  const body = line.replace(/\n$/, "");
+  assert.equal(body.includes("\n"), false);
+  // `partial` because terminal mix of done + failed.
+  assert.match(line, /\bstatus=partial\b/);
+});

--- a/src/util/runCompletedSentinel.ts
+++ b/src/util/runCompletedSentinel.ts
@@ -1,0 +1,138 @@
+import type { RunState } from "../types.js";
+
+// Aggregate run-classification used by the terminal sentinel. Distinct from
+// `IssueStatus` because the run-level status describes the *whole run*'s
+// shape:
+//
+//   - `done`            — every tracked issue ended in `done`.
+//   - `failed`          — every tracked issue ended in `failed` (no `done`,
+//                         no `aborted-budget`).
+//   - `partial`         — terminal mix of `done` + `failed` with no
+//                         budget-aborts.
+//   - `aborted-budget`  — at least one issue was `aborted-budget`. Takes
+//                         precedence over partial / failed because operator
+//                         policy is the load-bearing signal for post-run
+//                         audits (see #86).
+//   - `incomplete`      — at least one issue is still `pending` or
+//                         `in-flight` at sentinel-emission time. Surfaces
+//                         when the orchestrator hit `maxTicks` before
+//                         `isRunComplete(state)` returned true, when the
+//                         orchestrator threw mid-tick, or when the process
+//                         is winding down on an unhandled error path.
+export type RunStatus =
+  | "done"
+  | "failed"
+  | "partial"
+  | "aborted-budget"
+  | "incomplete";
+
+export interface RunStatusCounts {
+  total: number;
+  done: number;
+  failed: number;
+  abortedBudget: number;
+  pending: number;
+  inFlight: number;
+}
+
+export function countRunStatuses(state: RunState): RunStatusCounts {
+  const counts: RunStatusCounts = {
+    total: 0,
+    done: 0,
+    failed: 0,
+    abortedBudget: 0,
+    pending: 0,
+    inFlight: 0,
+  };
+  for (const e of Object.values(state.issues)) {
+    counts.total += 1;
+    if (e.status === "done") counts.done += 1;
+    else if (e.status === "failed") counts.failed += 1;
+    else if (e.status === "aborted-budget") counts.abortedBudget += 1;
+    else if (e.status === "pending") counts.pending += 1;
+    else if (e.status === "in-flight") counts.inFlight += 1;
+  }
+  return counts;
+}
+
+/**
+ * Classify the terminal run shape from its issue counts. Pure — no I/O,
+ * suitable for direct unit tests.
+ *
+ * Precedence rationale:
+ *   1. `incomplete` first — if there is *any* non-terminal issue (pending
+ *      or in-flight), the run did not wind down naturally and watchers /
+ *      audits need that fact surfaced before any "looks like a partial
+ *      success" framing. Everything else assumes terminal-only state.
+ *   2. `aborted-budget` next — operator-policy halt (see #86). Even when
+ *      mixed with done / failed it's the dominant signal: the operator
+ *      pulled the plug on cost and that's what should drive any retry
+ *      decision.
+ *   3. `partial` for terminal mix of done + failed — neither pure-success
+ *      nor pure-failure, surfaces the need to inspect per-issue outcome.
+ *   4. `done` / `failed` — pure outcomes.
+ *   5. `done` is the default for the empty-state case (zero issues), which
+ *      shouldn't happen in practice (cmdRun rejects empty dispatch sets
+ *      pre-launch) but keeps the function total.
+ */
+export function classifyRunStatus(state: RunState): RunStatus {
+  const c = countRunStatuses(state);
+  if (c.pending > 0 || c.inFlight > 0) return "incomplete";
+  if (c.abortedBudget > 0) return "aborted-budget";
+  if (c.done > 0 && c.failed > 0) return "partial";
+  if (c.failed > 0) return "failed";
+  return "done";
+}
+
+export interface RunCompletedSentinelInput {
+  runId: string;
+  state: RunState;
+  totalCostUsd: number;
+  durationMs: number;
+}
+
+/**
+ * Format the terminal-sentinel line emitted by `cmdRun` / `runResume` as
+ * the very last line on stdout. The line shape is intentionally simple
+ * key=value pairs separated by single spaces so external watchers can
+ * recognize it with a single anchored grep:
+ *
+ *   ^run\.completed runId=...
+ *
+ * Watchers (`tail -F | awk '/^run\.completed /{print; exit}'`,
+ * Claude Code Monitors, shell `until [ -e marker ]`-style polling, etc.)
+ * use this to terminate cleanly when the underlying run finishes — see
+ * issue #128 for the original symptom (stranded `tail -F` watchers
+ * accumulating across a session).
+ *
+ * Includes the trailing newline so callers can `process.stdout.write`
+ * the result directly without a manual `\n` concat.
+ */
+export function formatRunCompletedSentinel(
+  input: RunCompletedSentinelInput,
+): string {
+  const counts = countRunStatuses(input.state);
+  const status = classifyRunStatus(input.state);
+  // 4-decimal fixed precision on the cost matches `RunCostTracker.total()`
+  // formatting elsewhere in the CLI (e.g. the aborted-budget banner) and
+  // gives external dashboards enough resolution to reconcile against the
+  // SDK billing dashboard's per-tenth-cent rows.
+  const costStr = Number.isFinite(input.totalCostUsd)
+    ? input.totalCostUsd.toFixed(4)
+    : "0.0000";
+  // Integer ms — matches the existing `durationMs` shape in the structured
+  // log file. Watchers that surface a final summary line can format this
+  // however they want.
+  const durationStr = Math.max(0, Math.trunc(input.durationMs)).toString();
+  return [
+    "run.completed",
+    `runId=${input.runId}`,
+    `status=${status}`,
+    `total=${counts.total}`,
+    `done=${counts.done}`,
+    `failed=${counts.failed}`,
+    `aborted-budget=${counts.abortedBudget}`,
+    `durationMs=${durationStr}`,
+    `totalCostUsd=${costStr}`,
+  ].join(" ") + "\n";
+}


### PR DESCRIPTION
Closes #128

## Summary

Adds a stable terminal sentinel as the final stdout line of every launched `vp-dev run` (and `vp-dev run --resume`). External watchers — `tail -F | awk '/^run.completed /{print; exit}'`, Claude Code Monitors, shell `until [ -e marker ]` polling — can now anchor on this line to terminate cleanly when the run finishes, instead of leaking until session exit (the symptom that surfaced the issue: 11 stranded watcher tasks across the 2026-05-05 session).

Sentinel format:
```
run.completed runId=run-2026-05-05T15-08-13-725Z status=done total=4 done=4 failed=0 aborted-budget=0 durationMs=575000 totalCostUsd=2.3400
```

Five `status` values:
- `done` — every tracked issue ended in `done`.
- `failed` — every tracked issue ended in `failed`.
- `partial` — terminal mix of `done` + `failed`.
- `aborted-budget` — at least one issue was budget-aborted (#86 operator-policy halt; takes precedence over partial / failed).
- `incomplete` — at least one issue is still `pending` or `in-flight` at sentinel time (maxTicks reached, orchestrator threw mid-tick, etc.). Takes precedence over everything else so watchers don't see a premature "looks like a clean exit."

## Where the sentinel fires

Wraps the existing orchestrator call in `cmdRun` and `runResume` with `try { ... } catch (err) { runError = err } finally { ... emit sentinel ... }`, then re-throws. This means the sentinel emits uniformly across:
- clean success
- `--dry-run`
- `--max-cost-usd` budget abort
- coding-agent failures
- orchestrator throws
- the `maxTicks`-reached path (no-throw, but `isRunComplete` is still false → `status=incomplete`)

Pre-launch `process.exit(2)` paths (triage filtered all out, all over budget, gate rejected) skip the sentinel — there was no run for a watcher to attach to.

The existing `Run <runId> log: logs/<runId>.jsonl` line moves into the same `finally` block so it also fires on the throw path (operators want the log path even when something blew up). The sentinel is always emitted *after* it, so it stays the very last stdout line.

## Implementation

- `src/util/runCompletedSentinel.ts` — pure helper exposing `classifyRunStatus`, `countRunStatuses`, and `formatRunCompletedSentinel`. No I/O, suitable for direct unit tests.
- `src/util/runCompletedSentinel.test.ts` — 16 unit tests covering all five status classifications and the format invariants (anchored prefix, single-line, fixed-precision cost, trailing newline, durationMs floor / clamp).
- `src/cli.ts` — wires the helper into `cmdRun` and `runResume`.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm run build` — clean.
- [x] `npm test` — 254 passing (16 new).
- [ ] Smoke-test on a real `vp-dev run --verbose --dry-run` invocation: confirm `run.completed ` is the literal final stdout line; pipe through the suggested awk filter and confirm `tail -F` exits.
- [ ] Confirm aborted-budget path emits `status=aborted-budget` end-to-end (e.g. tiny `--max-cost-usd` on a multi-issue range).

## Out of scope

Per the issue body's "Out of scope":
- `vp-dev watch <runId>` first-class subcommand (#124's `vp-dev status --watch` covers the *internal* watcher; this PR makes *external* watchers viable too).
- stdout buffering tweaks.

— Alonzo (agent-92ff)
