### PR TITLE
feat(status): surface live progress signals in vp-dev status

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -106,6 +106,7 @@ import { RunCostTracker, resolveBudgetUsd } from "./util/costTracker.js";
 import { formatRunCompletedSentinel } from "./util/runCompletedSentinel.js";
 import type { AgentRecord, IssueRangeSpec, IssueSummary, ResumeContext, RunState } from "./types.js";
 import { STATE_DIR } from "./state/runState.js";
+import { defaultRunLogPath, loadRunActivity } from "./state/runActivity.js";
 import path from "node:path";
 
 const DEFAULT_STALLED_THRESHOLD_DAYS = 14;
@@ -1151,11 +1152,27 @@ async function cmdStatus(runIdArg?: string, opts: StatusOpts = {}): Promise<void
     process.exit(2);
   }
 
+  // Issue #131: best-effort load of the JSONL log so the status output
+  // can surface tool counts, time-since-last-activity, and a recent
+  // events tail. Fresh runs may not have any events on disk yet —
+  // `loadRunActivity` returns an empty activity for ENOENT; other I/O
+  // errors are surfaced as a warning so the formatter still gets to
+  // render the per-issue status block (the original pre-#131 view).
+  const activity = await tryLoadRunActivity(runId);
   if (opts.json) {
-    process.stdout.write(JSON.stringify(formatStatusJson(state, { agentNames }), null, 2) + "\n");
+    process.stdout.write(JSON.stringify(formatStatusJson(state, { agentNames, activity }), null, 2) + "\n");
     return;
   }
-  process.stdout.write(formatStatusText(state, { agentNames }));
+  process.stdout.write(formatStatusText(state, { agentNames, activity }));
+}
+
+async function tryLoadRunActivity(runId: string) {
+  try {
+    return await loadRunActivity({ logPath: defaultRunLogPath(runId) });
+  } catch (err) {
+    process.stderr.write(`WARN: could not read run log for ${runId}: ${(err as Error).message}\n`);
+    return undefined;
+  }
 }
 
 async function runStatusWatch(
@@ -1176,9 +1193,14 @@ async function runStatusWatch(
     const result = await watchStatus({
       tickFn: async () => {
         const state = await loadRunState(runId);
+        // Re-load the JSONL log every tick so cost-burn, tool counts,
+        // and the recent-events tail track in-flight progress. Cheap
+        // on small log files; if this becomes a bottleneck on long
+        // runs, switch to a tail-position cache here.
+        const activity = await tryLoadRunActivity(runId);
         const output = opts.json
-          ? JSON.stringify(formatStatusJson(state, { agentNames }))
-          : formatStatusText(state, { agentNames });
+          ? JSON.stringify(formatStatusJson(state, { agentNames, activity }))
+          : formatStatusText(state, { agentNames, activity });
         return { done: isRunComplete(state), output };
       },
       intervalMs,

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -82,9 +82,21 @@ export async function runOrchestrator(input: OrchestratorInput): Promise<void> {
 
   const inFlight = new Map<string, Promise<void>>();
 
+  // Persist the running USD total into RunState before each save so
+  // `vp-dev status` (issue #131) can render the live cost-burn signal
+  // off-disk without re-attaching to this process. The tracker's
+  // `total()` is monotonic; a missing tracker leaves the field
+  // undefined (matches the no-budget run shape).
+  const persistCost = (): void => {
+    if (input.costTracker) {
+      input.state.costAccumulatedUsd = input.costTracker.total();
+    }
+  };
+
   while (!isRunComplete(input.state) && input.state.tickCount < input.maxTicks) {
     input.state.tickCount += 1;
     input.state.lastTickAt = new Date().toISOString();
+    persistCost();
     await saveRunState(input.state);
 
     const pending = pendingIssueIds(input.state)
@@ -136,6 +148,7 @@ export async function runOrchestrator(input: OrchestratorInput): Promise<void> {
         if (!agent || !issue) continue;
 
         markInFlight(input.state, agent.agentId, assignment.issueId);
+        persistCost();
         await saveRunState(input.state);
 
         const promise = runOneIssue({
@@ -155,6 +168,7 @@ export async function runOrchestrator(input: OrchestratorInput): Promise<void> {
             err: (err as Error).message,
           });
           markFailed(input.state, agent.agentId, issue.id, (err as Error).message);
+          persistCost();
           await saveRunState(input.state);
         }).finally(() => {
           inFlight.delete(`${agent.agentId}:${issue.id}`);
@@ -194,12 +208,14 @@ export async function runOrchestrator(input: OrchestratorInput): Promise<void> {
         inFlightAtAbort: inFlight.size,
       });
       for (const id of stillPending) markAborted(input.state, id);
+      persistCost();
       await saveRunState(input.state);
       break;
     }
   }
 
   await Promise.allSettled(inFlight.values());
+  persistCost();
   await saveRunState(input.state);
 }
 

--- a/src/state/runActivity.test.ts
+++ b/src/state/runActivity.test.ts
@@ -1,0 +1,177 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  defaultRunLogPath,
+  emptyRunActivity,
+  formatTimeSince,
+  parseRunActivity,
+} from "./runActivity.js";
+
+const T0 = "2026-05-05T16:00:00.000Z";
+const T1 = "2026-05-05T16:00:05.000Z";
+const T2 = "2026-05-05T16:00:10.000Z";
+const T3 = "2026-05-05T16:00:15.000Z";
+
+function jsonl(...lines: object[]): string {
+  return lines.map((l) => JSON.stringify(l)).join("\n");
+}
+
+test("parseRunActivity: empty buffer yields empty result", () => {
+  const a = parseRunActivity({ jsonl: "" });
+  assert.deepEqual(a, emptyRunActivity());
+});
+
+test("parseRunActivity: tool_use events accumulate per-issue tool counts", () => {
+  const buf = jsonl(
+    { ts: T0, event: "agent.tool_use", agentId: "agent-916a", issueId: 131, tool: "Read", input: '"src/cli.ts"' },
+    { ts: T1, event: "agent.tool_use", agentId: "agent-916a", issueId: 131, tool: "Bash", input: "npm test" },
+    { ts: T2, event: "agent.tool_use", agentId: "agent-916a", issueId: 131, tool: "Read", input: '"src/types.ts"' },
+    { ts: T3, event: "agent.tool_use", agentId: "agent-92ff", issueId: 128, tool: "Edit", input: "src/foo.ts" },
+  );
+  const a = parseRunActivity({ jsonl: buf });
+  assert.deepEqual(a.byIssue["131"].toolCounts, { Read: 2, Bash: 1 });
+  assert.equal(a.byIssue["131"].totalToolCalls, 3);
+  assert.deepEqual(a.byIssue["128"].toolCounts, { Edit: 1 });
+  assert.equal(a.byIssue["128"].totalToolCalls, 1);
+});
+
+test("parseRunActivity: lastEventTs tracks the most recent issue-scoped event regardless of type", () => {
+  // agent.message after agent.tool_use should bump lastEventTs even
+  // though it doesn't increment any tool count.
+  const buf = jsonl(
+    { ts: T0, event: "agent.tool_use", issueId: 131, tool: "Read", input: '"src/x.ts"' },
+    { ts: T1, event: "agent.message", issueId: 131, preview: "Now let me build" },
+  );
+  const a = parseRunActivity({ jsonl: buf });
+  assert.equal(a.byIssue["131"].lastEventTs, T1);
+  assert.match(a.byIssue["131"].lastEventDescription ?? "", /Now let me build/);
+});
+
+test("parseRunActivity: lastEventDescription combines tool + truncated input", () => {
+  const buf = jsonl(
+    { ts: T0, event: "agent.tool_use", issueId: 131, tool: "Bash", input: "npm test" },
+  );
+  const a = parseRunActivity({ jsonl: buf });
+  assert.equal(a.byIssue["131"].lastEventDescription, "Bash npm test");
+});
+
+test("parseRunActivity: lastEventDescription truncates long inputs to <=80 chars", () => {
+  const longInput = "x".repeat(200);
+  const buf = jsonl(
+    { ts: T0, event: "agent.tool_use", issueId: 131, tool: "Bash", input: longInput },
+  );
+  const a = parseRunActivity({ jsonl: buf });
+  const desc = a.byIssue["131"].lastEventDescription ?? "";
+  assert.ok(desc.length <= 80, `description should fit within 80 chars, got ${desc.length}`);
+  assert.match(desc, /\.\.\.$/);
+});
+
+test("parseRunActivity: malformed lines are silently skipped", () => {
+  const buf = [
+    "not-json-at-all",
+    JSON.stringify({ ts: T0, event: "agent.tool_use", issueId: 131, tool: "Read" }),
+    "{half-broken",
+    JSON.stringify({ ts: T1, event: "agent.tool_use", issueId: 131, tool: "Bash" }),
+  ].join("\n");
+  const a = parseRunActivity({ jsonl: buf });
+  assert.deepEqual(a.byIssue["131"].toolCounts, { Read: 1, Bash: 1 });
+});
+
+test("parseRunActivity: lines missing ts or event are dropped", () => {
+  const buf = jsonl(
+    { event: "agent.tool_use", issueId: 131, tool: "Read" }, // no ts
+    { ts: T0, issueId: 131, tool: "Read" }, // no event
+    { ts: T1, event: "agent.tool_use", issueId: 131, tool: "Edit" }, // valid
+  );
+  const a = parseRunActivity({ jsonl: buf });
+  assert.deepEqual(a.byIssue["131"].toolCounts, { Edit: 1 });
+});
+
+test("parseRunActivity: events without issueId are not aggregated per-issue", () => {
+  // Run-level events (run.started, tick.proposal) must not corrupt
+  // per-issue activity. They can still appear in recentEvents if the
+  // event type is in the tail allowlist.
+  const buf = jsonl(
+    { ts: T0, event: "run.started", runId: "run-x" },
+    { ts: T1, event: "agent.tool_use", issueId: 131, tool: "Read" },
+  );
+  const a = parseRunActivity({ jsonl: buf });
+  assert.deepEqual(Object.keys(a.byIssue), ["131"]);
+});
+
+test("parseRunActivity: recentEvents limited to N most-recent entries in chronological order", () => {
+  const events = Array.from({ length: 20 }, (_, i) => ({
+    ts: `2026-05-05T16:00:${String(i).padStart(2, "0")}.000Z`,
+    event: "agent.tool_use",
+    issueId: 131,
+    tool: "Read",
+    input: `"file-${i}.ts"`,
+  }));
+  const a = parseRunActivity({ jsonl: jsonl(...events), recentEventsLimit: 5 });
+  assert.equal(a.recentEvents.length, 5);
+  // Last 5 by ts → file-15..file-19
+  assert.match(a.recentEvents[0].detail ?? "", /file-15/);
+  assert.match(a.recentEvents[4].detail ?? "", /file-19/);
+});
+
+test("parseRunActivity: recentEvents tail excludes orchestrator/permission noise but keeps spawned + completed", () => {
+  const buf = jsonl(
+    { ts: T0, event: "agent.spawned", issueId: 131 },
+    { ts: T1, event: "permission.evaluated", issueId: 131, tool: "Bash", behavior: "allow" },
+    { ts: T2, event: "agent.tool_use", issueId: 131, tool: "Bash" },
+    { ts: T3, event: "agent.completed", issueId: 131 },
+  );
+  const a = parseRunActivity({ jsonl: buf });
+  const eventNames = a.recentEvents.map((e) => e.event);
+  assert.ok(eventNames.includes("agent.spawned"));
+  assert.ok(eventNames.includes("agent.tool_use"));
+  assert.ok(eventNames.includes("agent.completed"));
+  assert.ok(!eventNames.includes("permission.evaluated"));
+});
+
+test("parseRunActivity: recentEvents stays sorted chronologically even on out-of-order input", () => {
+  const buf = jsonl(
+    { ts: T2, event: "agent.tool_use", issueId: 131, tool: "Read" },
+    { ts: T0, event: "agent.tool_use", issueId: 131, tool: "Bash" },
+    { ts: T1, event: "agent.tool_use", issueId: 131, tool: "Edit" },
+  );
+  const a = parseRunActivity({ jsonl: buf });
+  assert.deepEqual(
+    a.recentEvents.map((e) => e.ts),
+    [T0, T1, T2],
+  );
+});
+
+test("formatTimeSince: seconds-only when under a minute", () => {
+  const now = new Date("2026-05-05T16:00:30.000Z");
+  assert.equal(formatTimeSince("2026-05-05T16:00:18.000Z", now), "12s ago");
+});
+
+test("formatTimeSince: minutes + seconds when between 1 and 60 minutes", () => {
+  const now = new Date("2026-05-05T16:05:42.000Z");
+  assert.equal(formatTimeSince("2026-05-05T16:00:30.000Z", now), "5m12s ago");
+});
+
+test("formatTimeSince: drops seconds suffix when on a minute boundary", () => {
+  const now = new Date("2026-05-05T16:05:00.000Z");
+  assert.equal(formatTimeSince("2026-05-05T16:00:00.000Z", now), "5m ago");
+});
+
+test("formatTimeSince: hours + minutes for runs over an hour", () => {
+  const now = new Date("2026-05-05T18:34:00.000Z");
+  assert.equal(formatTimeSince("2026-05-05T16:00:00.000Z", now), "2h34m ago");
+});
+
+test("formatTimeSince: returns undefined for missing or future-dated ts", () => {
+  const now = new Date("2026-05-05T16:00:00.000Z");
+  assert.equal(formatTimeSince(undefined, now), undefined);
+  assert.equal(formatTimeSince("2026-05-05T16:01:00.000Z", now), undefined);
+  assert.equal(formatTimeSince("not-a-timestamp", now), undefined);
+});
+
+test("defaultRunLogPath: builds <baseDir>/logs/<runId>.jsonl", () => {
+  assert.equal(
+    defaultRunLogPath("run-2026-05-05T16-33-14-458Z", "/tmp/repo"),
+    "/tmp/repo/logs/run-2026-05-05T16-33-14-458Z.jsonl",
+  );
+});

--- a/src/state/runActivity.ts
+++ b/src/state/runActivity.ts
@@ -1,0 +1,211 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+/**
+ * Pure helpers (apart from `loadRunActivity`'s file read) for surfacing
+ * in-flight progress signals from a run's JSONL log file. Issue #131:
+ * `vp-dev status` was too thin for "what is the run doing right now?" —
+ * operators kept writing one-off `python3 -c '...'` scripts against
+ * `logs/<runId>.jsonl` to count tool calls per agent, find the most
+ * recent activity per issue, and tail the recent-events stream. This
+ * module replaces those scripts with one structured loader the formatter
+ * consumes.
+ *
+ * Schema-stable: depends only on `event`, `ts`, `issueId`, `tool`,
+ * `input`, and `preview` field names from `src/agent/codingAgent.ts`'s
+ * `agent.tool_use` / `agent.message` / `agent.completed` / `agent.spawned`
+ * events. Other event types (orchestrator-level, permission, dry-run
+ * intercepts) are folded into the recent-events tail when relevant but
+ * not aggregated per-issue.
+ */
+
+export interface IssueActivity {
+  /** Tool-name -> call count, summed across the run. */
+  toolCounts: Record<string, number>;
+  /** Sum of values in `toolCounts`. Convenience for the formatter. */
+  totalToolCalls: number;
+  /** ISO-8601 timestamp of the most recent event observed for this issue. */
+  lastEventTs?: string;
+  /**
+   * Short human-readable summary of the most recent event — `<tool> <input>`
+   * for `agent.tool_use`, the message preview for `agent.message`, or the
+   * raw event name for terminal events. Truncated to ~80 chars.
+   */
+  lastEventDescription?: string;
+}
+
+export interface RecentEvent {
+  ts: string;
+  /** Numeric issue id when the event was issue-scoped; absent for run-level events. */
+  issueId?: number;
+  event: string;
+  /** Same shape as `IssueActivity.lastEventDescription` — tool+input or message preview. */
+  detail?: string;
+}
+
+export interface RunActivity {
+  /** Keyed by stringified issue id (matches RunState.issues key shape). */
+  byIssue: Record<string, IssueActivity>;
+  /** Last N events in chronological order (oldest → newest). */
+  recentEvents: RecentEvent[];
+}
+
+interface ParsedLogLine {
+  ts?: string;
+  event?: string;
+  issueId?: number;
+  tool?: string;
+  input?: string;
+  preview?: string;
+}
+
+const RECENT_EVENT_DEFAULT_LIMIT = 8;
+const DESCRIPTION_MAX = 80;
+
+/**
+ * Event types kept in the recent-events tail. The orchestrator + permission
+ * + dry-run-intercept families are intentionally excluded — operators
+ * asking "what is the agent doing right now?" want to see edits, reads,
+ * Bashes, and message previews, not gate evaluations or tick proposals.
+ * `agent.completed` / `agent.spawned` are kept so terminal/start markers
+ * still surface in the tail.
+ */
+const TAIL_RELEVANT_EVENTS = new Set([
+  "agent.tool_use",
+  "agent.message",
+  "agent.completed",
+  "agent.spawned",
+]);
+
+export function emptyRunActivity(): RunActivity {
+  return { byIssue: {}, recentEvents: [] };
+}
+
+/**
+ * Default JSONL log path for a given runId. Matches the path computation
+ * in `Logger`'s constructor (`<cwd>/logs/<runId>.jsonl`). Exported so
+ * `cmdStatus` can resolve the same path the run wrote to without
+ * instantiating a Logger (which opens a write stream as a side effect).
+ */
+export function defaultRunLogPath(runId: string, baseDir: string = process.cwd()): string {
+  return path.join(baseDir, "logs", `${runId}.jsonl`);
+}
+
+/**
+ * Parse a JSONL buffer and return aggregated activity. Pure; no clock,
+ * no I/O. Malformed lines are silently skipped (a partial trailing line
+ * during a live tail is the most common cause).
+ */
+export function parseRunActivity(opts: {
+  jsonl: string;
+  recentEventsLimit?: number;
+}): RunActivity {
+  const limit = opts.recentEventsLimit ?? RECENT_EVENT_DEFAULT_LIMIT;
+  const byIssue: Record<string, IssueActivity> = {};
+  const tail: RecentEvent[] = [];
+
+  for (const rawLine of opts.jsonl.split(/\n/)) {
+    if (!rawLine.trim()) continue;
+    let line: ParsedLogLine;
+    try {
+      line = JSON.parse(rawLine) as ParsedLogLine;
+    } catch {
+      continue;
+    }
+    const event = line.event;
+    const ts = line.ts;
+    if (typeof event !== "string" || typeof ts !== "string") continue;
+
+    const issueId = typeof line.issueId === "number" ? line.issueId : undefined;
+    const description = describeEvent(event, line);
+
+    if (issueId !== undefined) {
+      const key = String(issueId);
+      const ent = (byIssue[key] ??= { toolCounts: {}, totalToolCalls: 0 });
+      if (event === "agent.tool_use" && typeof line.tool === "string") {
+        ent.toolCounts[line.tool] = (ent.toolCounts[line.tool] ?? 0) + 1;
+        ent.totalToolCalls += 1;
+      }
+      // Track the most recent ts for any event that touches this issue —
+      // not just agent.tool_use — so `lastEventTs` stays current even
+      // during the message-only stretches between tool calls.
+      if (!ent.lastEventTs || ts > ent.lastEventTs) {
+        ent.lastEventTs = ts;
+        ent.lastEventDescription = description;
+      }
+    }
+
+    if (TAIL_RELEVANT_EVENTS.has(event)) {
+      tail.push({ ts, issueId, event, detail: description });
+    }
+  }
+
+  // Defensive sort: events are written in append order, but a malformed
+  // ts somewhere in the file shouldn't scramble the tail. ISO-8601
+  // strings sort chronologically as plain strings.
+  tail.sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0));
+  const recentEvents = tail.slice(-limit);
+
+  return { byIssue, recentEvents };
+}
+
+/**
+ * Disk wrapper around `parseRunActivity`. Returns empty activity when
+ * the log file doesn't exist yet — fresh runs may not have logged any
+ * events at the moment `vp-dev status` is invoked, and older runs may
+ * have had their logs pruned. Other I/O errors propagate.
+ */
+export async function loadRunActivity(opts: {
+  logPath: string;
+  recentEventsLimit?: number;
+}): Promise<RunActivity> {
+  let jsonl: string;
+  try {
+    jsonl = await fs.readFile(opts.logPath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return emptyRunActivity();
+    }
+    throw err;
+  }
+  return parseRunActivity({ jsonl, recentEventsLimit: opts.recentEventsLimit });
+}
+
+/**
+ * Render an ISO-8601 timestamp as a short "Xs ago" / "Xm Ys ago" /
+ * "Xh Ym ago" string relative to `now`. Used by the formatter for the
+ * "last activity: 12s ago" annotation per in-flight issue. Returns
+ * undefined for unparseable input rather than throwing.
+ */
+export function formatTimeSince(ts: string | undefined, now: Date): string | undefined {
+  if (!ts) return undefined;
+  const ms = now.getTime() - Date.parse(ts);
+  if (!Number.isFinite(ms) || ms < 0) return undefined;
+  const total = Math.floor(ms / 1000);
+  if (total < 60) return `${total}s ago`;
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  if (m < 60) return s > 0 ? `${m}m${s}s ago` : `${m}m ago`;
+  const h = Math.floor(m / 60);
+  const remM = m % 60;
+  return remM > 0 ? `${h}h${remM}m ago` : `${h}h ago`;
+}
+
+function describeEvent(event: string, line: ParsedLogLine): string | undefined {
+  if (event === "agent.tool_use") {
+    const tool = line.tool;
+    if (typeof tool !== "string") return undefined;
+    const detail = typeof line.input === "string" && line.input.length > 0 ? `${tool} ${line.input}` : tool;
+    return truncate(detail, DESCRIPTION_MAX);
+  }
+  if (event === "agent.message") {
+    return typeof line.preview === "string" ? truncate(line.preview, DESCRIPTION_MAX) : undefined;
+  }
+  if (event === "agent.completed") return "completed";
+  if (event === "agent.spawned") return "spawned";
+  return undefined;
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 3) + "..." : s;
+}

--- a/src/state/statusFormatter.ts
+++ b/src/state/statusFormatter.ts
@@ -1,14 +1,26 @@
 import type { IssueStatus, RunIssueEntry, RunState } from "../types.js";
+import { formatTimeSince, type RunActivity, type IssueActivity, type RecentEvent } from "./runActivity.js";
 
 /**
  * Pure formatters for `vp-dev status` output. Both the text and JSON
  * variants take a `RunState` plus an optional `agentNames` lookup (so the
  * registry I/O stays in the CLI layer and these helpers are testable
  * without touching disk).
+ *
+ * Issue #131: an optional `activity` plus `now` clock can be threaded
+ * through to surface in-flight progress signals (per-issue tool counts,
+ * time since last activity, recent events tail). Both are optional —
+ * the formatter degrades gracefully to the pre-#131 output when not
+ * supplied so terminal-state runs and tests that don't care about
+ * activity stay simple.
  */
 export interface StatusFormatOpts {
   /** Map of agentId -> display name. Agents not in the map render with bare ID. */
   agentNames?: Map<string, string | undefined>;
+  /** Aggregated JSONL-log activity from `loadRunActivity`. Optional. */
+  activity?: RunActivity;
+  /** Reference clock for "X ago" computations. Defaults to `new Date()`. */
+  now?: Date;
 }
 
 const STATUS_KEYS: IssueStatus[] = [
@@ -23,6 +35,8 @@ export function formatStatusText(state: RunState, opts: StatusFormatOpts = {}): 
   const total = Object.keys(state.issues).length;
   const counts = countByStatus(state);
   const nameOf = opts.agentNames ?? new Map<string, string | undefined>();
+  const activity = opts.activity;
+  const now = opts.now ?? new Date();
 
   const lines: string[] = [];
   lines.push(`Run ${state.runId} on ${state.targetRepo}`);
@@ -42,6 +56,19 @@ export function formatStatusText(state: RunState, opts: StatusFormatOpts = {}): 
     lines.push(`  maxCostUsd=${state.maxCostUsd}`);
   }
 
+  // Issue #131: surface live cost-burn whenever the orchestrator has
+  // persisted it. Format depends on whether a per-run ceiling is set —
+  // `$X.XXXX / $Y.YYYY` when bounded so the operator can see headroom,
+  // `$X.XXXX (no ceiling)` when unbounded.
+  if (state.costAccumulatedUsd !== undefined) {
+    const total = state.costAccumulatedUsd.toFixed(4);
+    if (state.maxCostUsd !== undefined) {
+      lines.push(`  cost=$${total} / $${state.maxCostUsd.toFixed(4)}`);
+    } else {
+      lines.push(`  cost=$${total} (no ceiling)`);
+    }
+  }
+
   for (const a of state.agents) {
     const name = nameOf.get(a.agentId);
     const label = name ? `${name} (${a.agentId})` : a.agentId;
@@ -55,10 +82,68 @@ export function formatStatusText(state: RunState, opts: StatusFormatOpts = {}): 
     for (const id of issueIds) {
       const e = state.issues[id];
       lines.push(...renderIssueLines(id, e, nameOf));
+      // Per-issue activity addendum: only renders when we have activity
+      // data for this issue AND the issue is in-flight. Terminal issues
+      // already have their PR / error rendered above; tool counts after
+      // completion add noise without value.
+      if (activity && e.status === "in-flight") {
+        const issueActivity = activity.byIssue[id];
+        if (issueActivity) {
+          lines.push(...renderActivityLines(issueActivity, now));
+        }
+      }
+    }
+  }
+
+  // Recent events tail — only when activity was supplied AND the tail
+  // is non-empty. Stays at the bottom of the output so the operator's
+  // eye lands there last when scanning top-to-bottom.
+  if (activity && activity.recentEvents.length > 0) {
+    lines.push("");
+    lines.push(`  Recent events (last ${activity.recentEvents.length}):`);
+    for (const ev of activity.recentEvents) {
+      lines.push(formatRecentEventLine(ev));
     }
   }
 
   return lines.join("\n") + "\n";
+}
+
+function renderActivityLines(activity: IssueActivity, now: Date): string[] {
+  const out: string[] = [];
+  const sinceLabel = formatTimeSince(activity.lastEventTs, now);
+  if (activity.lastEventDescription) {
+    const since = sinceLabel ? ` (${sinceLabel})` : "";
+    out.push(`           last activity: ${activity.lastEventDescription}${since}`);
+  } else if (sinceLabel) {
+    out.push(`           last activity: ${sinceLabel}`);
+  }
+  if (activity.totalToolCalls > 0) {
+    const breakdown = Object.entries(activity.toolCounts)
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .map(([tool, n]) => `${n} ${tool}`)
+      .join(", ");
+    out.push(`           tools: ${breakdown} (${activity.totalToolCalls} total)`);
+  }
+  return out;
+}
+
+function formatRecentEventLine(ev: RecentEvent): string {
+  const time = ev.ts.length >= 19 ? ev.ts.slice(11, 19) : ev.ts;
+  const issueLabel = ev.issueId !== undefined ? `#${ev.issueId}` : "—";
+  const detail = ev.detail ? `  ${ev.detail}` : "";
+  return `    ${time}  ${issueLabel.padEnd(6)} ${ev.event}${detail}`;
+}
+
+export interface IssueLiveActivityJson {
+  /** ISO-8601 ts of the most recent issue-scoped event. */
+  lastEventTs?: string;
+  /** Short description of the most recent event (tool+input or message preview). */
+  lastEventDescription?: string;
+  /** Tool name -> call count. Empty when no tool calls observed. */
+  toolCounts: Record<string, number>;
+  /** Sum of `toolCounts` values. */
+  totalToolCalls: number;
 }
 
 export interface StatusJson {
@@ -71,6 +156,8 @@ export interface StatusJson {
   dryRun: boolean;
   tickCount: number;
   maxCostUsd?: number;
+  /** Running USD total, when persisted by the orchestrator (issue #131). */
+  costAccumulatedUsd?: number;
   summary: { total: number } & Record<IssueStatus, number>;
   agents: { agentId: string; agentName?: string; status: string }[];
   issues: {
@@ -85,12 +172,17 @@ export interface StatusJson {
     error?: string;
     errorSubtype?: string;
     parseError?: string;
+    /** Present only when `opts.activity` was supplied and the issue had any events. */
+    liveActivity?: IssueLiveActivityJson;
   }[];
+  /** Last N events from the JSONL log, present only when `opts.activity` was supplied. */
+  recentEvents?: { ts: string; issueId?: number; event: string; detail?: string }[];
 }
 
 export function formatStatusJson(state: RunState, opts: StatusFormatOpts = {}): StatusJson {
   const counts = countByStatus(state);
   const nameOf = opts.agentNames ?? new Map<string, string | undefined>();
+  const activity = opts.activity;
   const total = Object.keys(state.issues).length;
   const durationMs =
     state.startedAt && state.lastTickAt
@@ -110,6 +202,7 @@ export function formatStatusJson(state: RunState, opts: StatusFormatOpts = {}): 
     dryRun: state.dryRun,
     tickCount: state.tickCount,
     maxCostUsd: state.maxCostUsd,
+    costAccumulatedUsd: state.costAccumulatedUsd,
     summary: { total, ...counts },
     agents: state.agents.map((a) => ({
       agentId: a.agentId,
@@ -120,6 +213,7 @@ export function formatStatusJson(state: RunState, opts: StatusFormatOpts = {}): 
       .sort((a, b) => Number(a) - Number(b))
       .map((id) => {
         const e = state.issues[id];
+        const issueActivity = activity?.byIssue[id];
         return {
           id: Number(id),
           status: e.status,
@@ -132,8 +226,17 @@ export function formatStatusJson(state: RunState, opts: StatusFormatOpts = {}): 
           error: e.error,
           errorSubtype: e.errorSubtype,
           parseError: e.parseError,
+          liveActivity: issueActivity
+            ? {
+                lastEventTs: issueActivity.lastEventTs,
+                lastEventDescription: issueActivity.lastEventDescription,
+                toolCounts: issueActivity.toolCounts,
+                totalToolCalls: issueActivity.totalToolCalls,
+              }
+            : undefined,
         };
       }),
+    recentEvents: activity ? activity.recentEvents.map((ev) => ({ ...ev })) : undefined,
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,6 +133,15 @@ export interface RunState {
   // remember the original flag. Optional for back-compat with run states
   // written before #86 and for runs dispatched without --max-cost-usd.
   maxCostUsd?: number;
+  // Running USD total accumulated by the in-memory `RunCostTracker`.
+  // Persisted to the run-state file at every orchestrator tick + final
+  // save so `vp-dev status` can render the live cost-burn signal without
+  // re-attaching to the orchestrator's process or scraping the JSONL log.
+  // Optional for back-compat with run states written before this surface
+  // existed (issue #131); absent for resumed runs that bypass the
+  // tracker. Updated immediately before each `saveRunState` call in
+  // `runOrchestrator` — see `src/orchestrator/orchestrator.ts`.
+  costAccumulatedUsd?: number;
 }
 
 export const ResultEnvelopeSchema = z.object({

--- a/src/util/statusFormatter.test.ts
+++ b/src/util/statusFormatter.test.ts
@@ -5,6 +5,7 @@ import {
   formatStatusJson,
   formatStatusText,
 } from "../state/statusFormatter.js";
+import type { RunActivity } from "../state/runActivity.js";
 import type { RunState } from "../types.js";
 
 function fixture(overrides: Partial<RunState> = {}): RunState {
@@ -192,4 +193,134 @@ test("formatDuration: returns undefined for negative span (clock skew)", () => {
     formatDuration("2026-05-05T13:06:09Z", "2026-05-05T13:00:00Z"),
     undefined,
   );
+});
+
+// Issue #131: in-flight progress signals (cost, tool counts, recent events)
+
+test("formatStatusText: cost-burn line bounded by ceiling when maxCostUsd set", () => {
+  const text = formatStatusText(
+    fixture({ costAccumulatedUsd: 2.31, maxCostUsd: 5.0 } as Partial<RunState>),
+  );
+  assert.match(text, /cost=\$2\.3100 \/ \$5\.0000/);
+});
+
+test("formatStatusText: cost-burn line shows '(no ceiling)' when maxCostUsd absent", () => {
+  const text = formatStatusText(
+    fixture({ costAccumulatedUsd: 0.42 } as Partial<RunState>),
+  );
+  assert.match(text, /cost=\$0\.4200 \(no ceiling\)/);
+});
+
+test("formatStatusText: cost line omitted when costAccumulatedUsd undefined (back-compat)", () => {
+  const text = formatStatusText(fixture());
+  assert.doesNotMatch(text, /cost=\$/);
+});
+
+test("formatStatusText: in-flight issue gets activity addendum (last activity + tool counts)", () => {
+  const activity: RunActivity = {
+    byIssue: {
+      "131": {
+        toolCounts: { Read: 22, Bash: 22, Edit: 8, Write: 2 },
+        totalToolCalls: 54,
+        lastEventTs: "2026-05-05T13:38:50.000Z",
+        lastEventDescription: "Bash npm test",
+      },
+    },
+    recentEvents: [],
+  };
+  const text = formatStatusText(
+    fixture({
+      issues: { "131": { status: "in-flight", agentId: "agent-916a" } },
+    }),
+    {
+      activity,
+      now: new Date("2026-05-05T13:38:55.000Z"),
+    },
+  );
+  assert.match(text, /last activity: Bash npm test \(5s ago\)/);
+  // Tool counts sorted by count descending, then alphabetically.
+  assert.match(text, /tools: 22 Bash, 22 Read, 8 Edit, 2 Write \(54 total\)/);
+});
+
+test("formatStatusText: terminal issues skip activity addendum even when activity present", () => {
+  const activity: RunActivity = {
+    byIssue: {
+      "131": {
+        toolCounts: { Bash: 5 },
+        totalToolCalls: 5,
+        lastEventTs: "2026-05-05T13:38:50.000Z",
+        lastEventDescription: "Bash npm test",
+      },
+    },
+    recentEvents: [],
+  };
+  const text = formatStatusText(
+    fixture({
+      issues: {
+        "131": { status: "done", agentId: "agent-916a", outcome: "implement", prUrl: "https://github.com/x/y/pull/1" },
+      },
+    }),
+    { activity, now: new Date("2026-05-05T13:38:55.000Z") },
+  );
+  assert.doesNotMatch(text, /last activity:/);
+  assert.doesNotMatch(text, /tools:/);
+});
+
+test("formatStatusText: recent events tail rendered when activity supplied and non-empty", () => {
+  const activity: RunActivity = {
+    byIssue: {},
+    recentEvents: [
+      { ts: "2026-05-05T13:38:50.000Z", issueId: 131, event: "agent.tool_use", detail: "Read 'src/cli.ts'" },
+      { ts: "2026-05-05T13:38:55.000Z", issueId: 131, event: "agent.message", detail: "Now build and test" },
+    ],
+  };
+  const text = formatStatusText(fixture(), { activity });
+  assert.match(text, /Recent events \(last 2\):/);
+  assert.match(text, /13:38:50/);
+  assert.match(text, /agent\.tool_use/);
+  assert.match(text, /Now build and test/);
+});
+
+test("formatStatusText: recent events tail omitted when activity undefined", () => {
+  const text = formatStatusText(fixture());
+  assert.doesNotMatch(text, /Recent events/);
+});
+
+test("formatStatusJson: includes costAccumulatedUsd when set", () => {
+  const json = formatStatusJson(
+    fixture({ costAccumulatedUsd: 1.23 } as Partial<RunState>),
+  );
+  assert.equal(json.costAccumulatedUsd, 1.23);
+});
+
+test("formatStatusJson: liveActivity present per in-flight issue when activity supplied", () => {
+  const activity: RunActivity = {
+    byIssue: {
+      "131": {
+        toolCounts: { Read: 3 },
+        totalToolCalls: 3,
+        lastEventTs: "2026-05-05T13:38:50.000Z",
+        lastEventDescription: "Read src/x.ts",
+      },
+    },
+    recentEvents: [
+      { ts: "2026-05-05T13:38:50.000Z", issueId: 131, event: "agent.tool_use", detail: "Read src/x.ts" },
+    ],
+  };
+  const json = formatStatusJson(
+    fixture({
+      issues: { "131": { status: "in-flight", agentId: "agent-916a" } },
+    }),
+    { activity },
+  );
+  const issue = json.issues[0];
+  assert.ok(issue.liveActivity);
+  assert.equal(issue.liveActivity?.totalToolCalls, 3);
+  assert.equal(issue.liveActivity?.lastEventDescription, "Read src/x.ts");
+  assert.equal(json.recentEvents?.length, 1);
+});
+
+test("formatStatusJson: liveActivity + recentEvents undefined when activity not supplied (back-compat)", () => {
+  const json = formatStatusJson(fixture());
+  assert.equal(json.recentEvents, undefined);
 });


### PR DESCRIPTION
Closes #131.

## What changed

`vp-dev status` (and `vp-dev status --watch`) now surface the live progress signals operators were repeatedly hand-rolling via `python3 -c '...'` scripts against `state/<runId>.json` + `logs/<runId>.jsonl`:

- **Run-level cost burn** — `cost=$2.3100 / $5.0000` when bounded, `cost=$0.4200 (no ceiling)` otherwise. Persisted into `RunState.costAccumulatedUsd` at every `saveRunState` callsite in `runOrchestrator()` so it's always within one tick of the in-memory `RunCostTracker`.
- **Per in-flight issue** — tool-call breakdown (sorted by count desc), last meaningful action (`Bash npm test`, `Edit src/cli.ts`, message preview), and time since last event (`12s ago` / `5m ago` / `2h34m ago`). Terminal issues skip the addendum since their PR/error already tells the story.
- **Recent events tail** — last 8 events at the bottom, filtered to `agent.*` so orchestrator/permission noise stays off-screen. `agent.spawned` + `agent.completed` are kept so terminal markers still show.

JSON mode (`--json`) extends the existing shape with:
- top-level `costAccumulatedUsd?: number`
- per-issue `liveActivity?: { lastEventTs, lastEventDescription, toolCounts, totalToolCalls }`
- top-level `recentEvents?: [{ ts, issueId, event, detail }]`

All new fields are optional — the formatter degrades to the pre-#131 output when activity is absent (older runs without logs, fresh runs that haven't logged yet, test fixtures).

## Files (7)

- `src/types.ts` — `RunState.costAccumulatedUsd?: number` (optional, back-compat).
- `src/orchestrator/orchestrator.ts` — local `persistCost()` helper called before each `saveRunState`. Five callsites; updates from `costTracker.total()`.
- `src/state/runActivity.ts` (new) — pure JSONL-log parser + `loadRunActivity` disk wrapper + `formatTimeSince` + `defaultRunLogPath`. Skips malformed lines, drops events without `ts`/`event`, doesn't aggregate run-level events into per-issue counts.
- `src/state/statusFormatter.ts` — `StatusFormatOpts.activity?` + `now?`. Renders cost line, per-issue activity addendum, recent-events tail. JSON output gets `costAccumulatedUsd` + `liveActivity` + `recentEvents`.
- `src/cli.ts` — `cmdStatus` + `runStatusWatch` call `tryLoadRunActivity(runId)`. Disk warnings go to stderr; status block still renders so the output is never blocked by a log read failure.
- `src/state/runActivity.test.ts` (new) — 17 cases: tool-count aggregation, ts-tracking across event types, malformed-line handling, recent-events limit + chronological order + tail allowlist, time-since rendering at all three magnitudes, log-path resolution.
- `src/util/statusFormatter.test.ts` — 10 new cases: cost-line both branches + back-compat, in-flight activity addendum, terminal-issue suppression, recent-events tail rendering + omission, JSON shape.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `npm test` — 286 tests pass (was 259; added 17 in `runActivity.test.ts` + 10 in `statusFormatter.test.ts`)
- [x] Back-compat: `formatStatusText(state)` and `formatStatusJson(state)` with no `activity` produce the pre-#131 output (`omit cost line` + `recent events tail omitted` tests).
- [ ] Manual smoke: `vp-dev status --latest` against a recent run shows the cost line + recent events tail.

— Advisory Scope Boundary (agent-916a)
