### PR TITLE
feat(cli): emit complete result report on vp-dev run completion

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -104,6 +104,7 @@ import {
 } from "./state/outcomes.js";
 import { RunCostTracker, resolveBudgetUsd } from "./util/costTracker.js";
 import { formatRunCompletedSentinel } from "./util/runCompletedSentinel.js";
+import { formatRunReport } from "./util/runReport.js";
 import type { AgentRecord, IssueRangeSpec, IssueSummary, ResumeContext, RunState } from "./types.js";
 import { STATE_DIR } from "./state/runState.js";
 import { defaultRunLogPath, loadRunActivity } from "./state/runActivity.js";
@@ -158,6 +159,14 @@ export function buildCli(): Command {
     .option(
       "--resume-incomplete",
       "Phase 1 (#118): record the intent to resume from a salvageable `*-incomplete-<runId>` branch on origin. Phase 1 only logs the intent + carries it through --plan/--confirm; the actual worktree-from-partial-branch behavior is Phase 2's territory (still routes from main today).",
+    )
+    .option(
+      "--no-report",
+      "Suppress the end-of-run result report on stdout (#136). The terminal sentinel (#128) still fires. Use when piping `vp-dev run` output into structured-log consumers that don't want the bounded text block.",
+    )
+    .option(
+      "--json-report",
+      "Emit the end-of-run result report as JSON instead of the bounded text block (#136). Same shape as `vp-dev status <runId> --json`. The terminal sentinel still trails on its own line for watcher compatibility.",
     )
     .action(async (opts) => {
       await cmdRun(opts);
@@ -368,6 +377,13 @@ interface RunOpts {
   maxCostUsd?: string;
   preferAgent?: string;
   resumeIncomplete?: boolean;
+  // Commander `--no-report` auto-generates `report: boolean` on opts: true
+  // by default, false when `--no-report` is passed. Issue #136.
+  report?: boolean;
+  // Issue #136: route the report through the JSON formatter instead of
+  // the bounded text block. Mutually orthogonal to `--no-report`: passing
+  // both is a contradiction, treated as suppress.
+  jsonReport?: boolean;
 }
 
 async function cmdRun(opts: RunOpts): Promise<void> {
@@ -828,17 +844,21 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     // it fires on the throw path too — operators want the log path even
     // when something blew up). Always precedes the terminal sentinel.
     process.stdout.write(`Run ${runId} log: logs/${runId}.jsonl\n`);
-    // Terminal sentinel (issue #128) — MUST be the very last stdout line so
-    // external watchers grepping `^run.completed ` can `print; exit` on it.
-    // Fires uniformly across success / dry-run / aborted-budget / failure
-    // / orchestrator-throw paths, ensuring exactly one terminal line per
-    // launched run.
+    // Issue #136: emit the end-of-run result report inline, then the
+    // terminal sentinel. The bounded `=========` block reuses the same
+    // `formatStatusText` operators already see from `vp-dev status` so
+    // there's no second rendering codepath to maintain. `--no-report`
+    // suppresses the block (operators piping into structured-log
+    // consumers); the sentinel still trails on its own line so watchers
+    // anchored on `^run\.completed ` (#128) keep working unchanged.
     process.stdout.write(
-      formatRunCompletedSentinel({
+      await renderEndOfRunBlock({
         runId,
         state,
         totalCostUsd: costTracker.total(),
         durationMs: Date.now() - runStartMs,
+        report: opts.report,
+        json: opts.jsonReport,
       }),
     );
   }
@@ -1087,19 +1107,77 @@ async function runResume(opts: RunOpts): Promise<void> {
     runError = err;
   } finally {
     await logger.close();
-    // Terminal sentinel (issue #128) — last stdout line, fires uniformly
-    // across all exit paths so `tail -F | awk '/^run.completed /{exit}'`
-    // watchers terminate cleanly on resumed runs too.
+    // Issue #136: same end-of-run report on resume — operators rerun
+    // `vp-dev run --resume` after a crash and want the same per-issue
+    // rollup the originating run would have produced. The terminal
+    // sentinel (#128) still trails the report so external watchers
+    // anchored on `^run\.completed ` keep working uniformly.
     process.stdout.write(
-      formatRunCompletedSentinel({
+      await renderEndOfRunBlock({
         runId,
         state,
         totalCostUsd: costTracker.total(),
         durationMs: Date.now() - runStartMs,
+        report: opts.report,
+        json: opts.jsonReport,
       }),
     );
   }
   if (runError) throw runError;
+}
+
+/**
+ * Issue #136: shared helper that turns the run-final state into the stdout
+ * block emitted by both `cmdRun` and `runResume`. Two switches:
+ *
+ *   - `report: false` (passed by `--no-report`) → emit only the terminal
+ *     sentinel from #128. Existing pre-#136 behavior — operators piping
+ *     into structured-log consumers.
+ *   - `json: true` (passed by `--json-report`) → emit the JSON variant of
+ *     the report (same shape as `vp-dev status <runId> --json`) ahead of
+ *     the sentinel.
+ *   - default (neither) → emit the bounded `=========` text block ahead
+ *     of the sentinel.
+ *
+ * Loads the registry once for the agentNames lookup (best-effort — if the
+ * read fails we render with bare agent IDs, since corrupting an
+ * end-of-run report is strictly worse than losing display names).
+ */
+async function renderEndOfRunBlock(input: {
+  runId: string;
+  state: RunState;
+  totalCostUsd: number;
+  durationMs: number;
+  report?: boolean;
+  json?: boolean;
+}): Promise<string> {
+  // Default report=true unless explicitly `false` (Commander `--no-report`).
+  const wantReport = input.report !== false;
+  if (!wantReport) {
+    return formatRunCompletedSentinel({
+      runId: input.runId,
+      state: input.state,
+      totalCostUsd: input.totalCostUsd,
+      durationMs: input.durationMs,
+    });
+  }
+  let agentNames: Map<string, string | undefined> | undefined;
+  try {
+    const reg = await loadRegistry();
+    agentNames = new Map<string, string | undefined>(
+      reg.agents.map((a) => [a.agentId, a.name]),
+    );
+  } catch {
+    agentNames = undefined;
+  }
+  return formatRunReport({
+    runId: input.runId,
+    state: input.state,
+    totalCostUsd: input.totalCostUsd,
+    durationMs: input.durationMs,
+    agentNames,
+    json: input.json,
+  });
 }
 
 interface StatusOpts {

--- a/src/util/runReport.test.ts
+++ b/src/util/runReport.test.ts
@@ -1,0 +1,119 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { newRunState } from "../state/runState.js";
+import type { IssueStatus, RunState } from "../types.js";
+import { formatRunReport } from "./runReport.js";
+
+// Issue #136: the end-of-run report block printed inline by `vp-dev run` /
+// `vp-dev run --resume`. Format stability matters because external tooling
+// is expected to find the block via the bounded `=========` separators and
+// the terminal sentinel via `^run\.completed `.
+
+function makeStateWithStatuses(statuses: IssueStatus[]): RunState {
+  const ids = statuses.map((_, i) => i + 1);
+  const state = newRunState({
+    runId: "run-2026-05-05T16-33-14-458Z",
+    targetRepo: "x/y",
+    issueRange: { kind: "csv", ids },
+    parallelism: 1,
+    issueIds: ids,
+    dryRun: false,
+  });
+  for (let i = 0; i < statuses.length; i++) {
+    state.issues[String(ids[i])].status = statuses[i];
+  }
+  // Pin a deterministic startedAt / lastTickAt so duration formatting is
+  // stable across CI clocks.
+  state.startedAt = "2026-05-05T16:33:14.458Z";
+  state.lastTickAt = "2026-05-05T16:33:17.549Z";
+  return state;
+}
+
+test("formatRunReport: text variant wraps formatStatusText in =========-bounded block", () => {
+  const state = makeStateWithStatuses(["done"]);
+  const out = formatRunReport({
+    runId: "run-2026-05-05T16-33-14-458Z",
+    state,
+    totalCostUsd: 1.42,
+    durationMs: 3091,
+  });
+
+  const lines = out.split("\n");
+  // Leading blank, then separator, header, separator, blank, then the body.
+  assert.equal(lines[0], "");
+  assert.equal(lines[1], "=========");
+  assert.equal(lines[2], "Run complete: run-2026-05-05T16-33-14-458Z");
+  assert.equal(lines[3], "=========");
+  assert.equal(lines[4], "");
+  // Body must start with the standard `Run <id> on <repo>` header from
+  // `formatStatusText` so existing operator muscle memory + tooling
+  // scrapers recognize the same shape.
+  assert.equal(lines[5], "Run run-2026-05-05T16-33-14-458Z on x/y");
+});
+
+test("formatRunReport: text variant ends with the run.completed sentinel as the final non-empty line", () => {
+  const state = makeStateWithStatuses(["done", "failed"]);
+  const out = formatRunReport({
+    runId: "run-2026-05-05T16-33-14-458Z",
+    state,
+    totalCostUsd: 0.5,
+    durationMs: 3091,
+  });
+
+  // Last non-empty line must start with `run.completed ` so watchers
+  // anchored on `^run\.completed ` (issue #128) keep working.
+  const nonEmpty = out.split("\n").filter((l) => l.length > 0);
+  const final = nonEmpty[nonEmpty.length - 1];
+  assert.match(final, /^run\.completed runId=run-2026-05-05T16-33-14-458Z status=partial/);
+  assert.match(final, /total=2 done=1 failed=1/);
+});
+
+test("formatRunReport: JSON variant emits ---FINAL--- marker + StatusJson + trailing sentinel", () => {
+  const state = makeStateWithStatuses(["done"]);
+  const out = formatRunReport({
+    runId: "run-2026-05-05T16-33-14-458Z",
+    state,
+    totalCostUsd: 0,
+    durationMs: 0,
+    json: true,
+  });
+
+  assert.match(out, /\n---FINAL---\n/);
+  // JSON body must include the runId so consumers can confirm they have
+  // the right report.
+  assert.match(out, /"runId": "run-2026-05-05T16-33-14-458Z"/);
+  // Sentinel still trails — pulled out of the very last line.
+  const nonEmpty = out.split("\n").filter((l) => l.length > 0);
+  const final = nonEmpty[nonEmpty.length - 1];
+  assert.match(final, /^run\.completed runId=run-2026-05-05T16-33-14-458Z/);
+});
+
+test("formatRunReport: agentNames threads through to per-issue rendering", () => {
+  const state = makeStateWithStatuses(["done"]);
+  state.issues["1"].agentId = "agent-92ff";
+  state.agents.push({ agentId: "agent-92ff", status: "idle" });
+
+  const out = formatRunReport({
+    runId: "run-2026-05-05T16-33-14-458Z",
+    state,
+    totalCostUsd: 0,
+    durationMs: 0,
+    agentNames: new Map([["agent-92ff", "Alonzo"]]),
+  });
+
+  // The display name must appear in the rendered text — confirms
+  // `agentNames` is forwarded into `formatStatusText`.
+  assert.match(out, /Alonzo \(agent-92ff\)/);
+});
+
+test("formatRunReport: text variant for incomplete (in-flight) state surfaces incomplete classification", () => {
+  const state = makeStateWithStatuses(["in-flight", "done"]);
+  const out = formatRunReport({
+    runId: "run-2026-05-05T16-33-14-458Z",
+    state,
+    totalCostUsd: 0,
+    durationMs: 0,
+  });
+
+  assert.match(out, /^run\.completed .*status=incomplete /m);
+});

--- a/src/util/runReport.ts
+++ b/src/util/runReport.ts
@@ -1,0 +1,100 @@
+import type { RunState } from "../types.js";
+import { formatStatusJson, formatStatusText } from "../state/statusFormatter.js";
+import {
+  formatRunCompletedSentinel,
+  type RunCompletedSentinelInput,
+} from "./runCompletedSentinel.js";
+
+/**
+ * Issue #136: at the end of every `vp-dev run` (and `runResume`), the CLI
+ * needs to print a complete result report to stdout — the sentinel line
+ * alone (#128) tells external watchers "run is over" but doesn't answer the
+ * operator's actual question ("what happened?"). Without the report, every
+ * run-completion this session was followed by a bespoke python script that
+ * read state/<runId>.json and re-rendered the per-issue table. This util
+ * closes that gap.
+ *
+ * Format choices:
+ *   - Bounded by `=========` separators so external tooling can find the
+ *     block deterministically (anchored: `^=========$` followed by a
+ *     `Run complete:` line).
+ *   - Reuses `formatStatusText` / `formatStatusJson` (PR #123) — the same
+ *     shape the operator already sees from `vp-dev status <runId>` after
+ *     the fact, no second rendering codepath to keep aligned.
+ *   - The sentinel from #128 is appended as the very last line so watchers
+ *     anchored on `^run\.completed ` keep working unchanged.
+ *
+ * The report is emitted to stdout in cmdRun's / runResume's `finally` block
+ * — not the main try body — so the report fires uniformly across success,
+ * dry-run, aborted-budget, orchestrator-throw paths. This matches the same
+ * discipline #128 codified for the sentinel itself.
+ */
+export interface RunReportInput {
+  runId: string;
+  state: RunState;
+  /** Total spend in USD, summed across triage + orchestrator + coding agent. */
+  totalCostUsd: number;
+  /** Wall-clock duration from run-start to report-emit. */
+  durationMs: number;
+  /**
+   * Map of agentId -> display name. Forwarded to `formatStatusText` /
+   * `formatStatusJson` so per-issue / per-agent rows render with the
+   * registry name when available, falling back to bare agentId when not.
+   */
+  agentNames?: Map<string, string | undefined>;
+  /**
+   * When true, render the report as JSON (the `formatStatusJson` shape) on
+   * stdout instead of the text block. Wired to `--json-report` on the CLI.
+   * The terminal sentinel line still follows on its own line so watchers
+   * keep working — JSON consumers that anchor on the sentinel can split
+   * on it; consumers that read the JSON itself can stop at the trailing
+   * newline before `run.completed`.
+   */
+  json?: boolean;
+}
+
+const SEPARATOR = "=========";
+
+/**
+ * Build the full stdout block for a completed run: the bounded report
+ * (text or JSON) plus the trailing terminal sentinel from #128. Returns
+ * the string in one piece so callers can `process.stdout.write` it as a
+ * single atomic emission — no risk of an interleaving event-stream line
+ * landing between the report and its sentinel.
+ *
+ * Pure: no I/O. The caller is responsible for resolving the registry-name
+ * map and threading it through `agentNames`.
+ */
+export function formatRunReport(input: RunReportInput): string {
+  const sentinelInput: RunCompletedSentinelInput = {
+    runId: input.runId,
+    state: input.state,
+    totalCostUsd: input.totalCostUsd,
+    durationMs: input.durationMs,
+  };
+  const sentinelLine = formatRunCompletedSentinel(sentinelInput);
+  if (input.json) {
+    // JSON variant — same shape as `vp-dev status <runId> --json`. We add
+    // a `---FINAL---` marker line above it so consumers that mix verbose
+    // event-stream output with the report can split unambiguously, and
+    // emit the sentinel after the JSON's trailing newline so watchers
+    // anchored on `^run\.completed ` still find it.
+    const json = JSON.stringify(
+      formatStatusJson(input.state, { agentNames: input.agentNames }),
+      null,
+      2,
+    );
+    return `\n---FINAL---\n${json}\n${sentinelLine}`;
+  }
+  const header = [
+    "",
+    SEPARATOR,
+    `Run complete: ${input.runId}`,
+    SEPARATOR,
+    "",
+  ].join("\n");
+  const body = formatStatusText(input.state, { agentNames: input.agentNames });
+  // `formatStatusText` already terminates with a newline, so we only need
+  // a single blank-line gap before the sentinel.
+  return `${header}\n${body}\n${sentinelLine}`;
+}


### PR DESCRIPTION
Closes #136

## Summary

`vp-dev run` and `vp-dev run --resume` now print a complete result report inline as their final stdout output. Previously the only end-of-run signal was the single-line `run.completed` sentinel from #128 — useful for watchers but not the rollup operators actually want, so every run completion this session was followed by a bespoke python script that re-rendered `state/<runId>.json`.

## What ships

- New `src/util/runReport.ts` — pure formatter. Wraps `formatStatusText` (PR #123) in a `=========`-bounded block with a `Run complete: <runId>` header, then trails the `run.completed` sentinel on its own line so `tail -F | awk '/^run\.completed /{print; exit}'` watchers (#128) keep working unchanged.
- `--no-report` — suppresses the block, restoring pre-#136 behavior. For operators piping `vp-dev run` output into structured-log consumers.
- `--json-report` — emits the same `formatStatusJson` shape as `vp-dev status <runId> --json`, fenced above by a `---FINAL---` marker so consumers can split it from the verbose event stream. Sentinel still trails.
- Wired into both `cmdRun` and `runResume` in their `finally` blocks (matches the discipline #128 already codified for the sentinel — fires uniformly across success, dry-run, aborted-budget, orchestrator-throw paths).
- Registry name lookup is best-effort: a registry-read failure renders with bare agent IDs rather than corrupting the report.

## Tests

5 new tests in `src/util/runReport.test.ts` covering text variant separator framing, sentinel-trailing invariant (watcher contract), JSON variant `---FINAL---` marker, agentNames forwarding, and incomplete-status classification. Full suite: 291/291 pass; `tsc --noEmit` clean; `tsc` (build) clean.

## Test plan

- [ ] `npm run build && npm test` locally
- [ ] `vp-dev run --dry-run --agents 1 --target-repo … --issues N` — confirm the bounded block appears before the sentinel on stdout
- [ ] `vp-dev run … --no-report` — confirm only the sentinel appears (pre-#136 behavior)
- [ ] `vp-dev run … --json-report` — confirm `---FINAL---\n<json>\nrun.completed …` shape
- [ ] `vp-dev run --resume` — confirm the same report fires on the resume path

— Alonzo (agent-92ff)
