### PR TITLE
Phase 1: auto-phase-followup data + render (envelope schema + workflow section)

### DIFF
--- a/src/agent/parseResult.test.ts
+++ b/src/agent/parseResult.test.ts
@@ -1,0 +1,45 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { extractEnvelope } from "./parseResult.js";
+
+// Issue #141 (Phase 1 of #134): the `ResultEnvelope` Zod schema accepts an
+// optional `nextPhaseIssueUrl` URL field. These tests pin the field's
+// presence + URL validation so a future schema refactor (e.g., dropping
+// `.url()` for plain `.string()`) is caught immediately. The schema itself
+// lives in `src/types.ts` but `extractEnvelope` is the call site every
+// production parse goes through, so testing here covers the round-trip
+// shape callers actually see.
+
+const base = {
+  decision: "implement" as const,
+  reason: "Did the thing.",
+  prUrl: "https://github.com/o/r/pull/1",
+  memoryUpdate: { addTags: ["x"] },
+};
+
+function envelope(extra: Record<string, unknown> = {}): string {
+  return "```json\n" + JSON.stringify({ ...base, ...extra }) + "\n```";
+}
+
+test("extractEnvelope: nextPhaseIssueUrl is accepted when a valid URL", () => {
+  const r = extractEnvelope(
+    envelope({ nextPhaseIssueUrl: "https://github.com/o/r/issues/142" }),
+  );
+  assert.equal(r.ok, true);
+  assert.equal(
+    r.envelope?.nextPhaseIssueUrl,
+    "https://github.com/o/r/issues/142",
+  );
+});
+
+test("extractEnvelope: nextPhaseIssueUrl is optional — absence does not fail validation", () => {
+  const r = extractEnvelope(envelope());
+  assert.equal(r.ok, true);
+  assert.equal(r.envelope?.nextPhaseIssueUrl, undefined);
+});
+
+test("extractEnvelope: nextPhaseIssueUrl rejects malformed values", () => {
+  const r = extractEnvelope(envelope({ nextPhaseIssueUrl: "not-a-url" }));
+  assert.equal(r.ok, false);
+  assert.match(r.error ?? "", /Schema validation failed/);
+});

--- a/src/agent/workflow.test.ts
+++ b/src/agent/workflow.test.ts
@@ -56,3 +56,55 @@ test("renderWorkflow: resumeContext without agentName falls back to agentId in t
   });
   assert.match(out, /— agent-92ff \(agent-92ff, partial — run-X\)/);
 });
+
+// renderWorkflow's auto-phase-followup section (issue #141, Phase 1 of #134)
+// must render ONLY when `autoPhaseFollowup === true`. Default-off behavior
+// is the load-bearing invariant of Phase 1 — Phase 2 wires the CLI flag,
+// and until then the production prompt must remain byte-identical to the
+// pre-#141 baseline. Tests pin both the off-by-default and the rendered-on
+// shapes against future refactors that might silently flip the default.
+
+test("renderWorkflow: autoPhaseFollowup defaults to off — Step N+1 section is absent", () => {
+  const out = renderWorkflow(baseVars);
+  assert.doesNotMatch(out, /Step N\+1/);
+  assert.doesNotMatch(out, /Auto-file next phase/);
+  assert.doesNotMatch(out, /nextPhaseIssueUrl/);
+});
+
+test("renderWorkflow: autoPhaseFollowup === false — Step N+1 section is absent (explicit)", () => {
+  const out = renderWorkflow({ ...baseVars, autoPhaseFollowup: false });
+  assert.doesNotMatch(out, /Step N\+1/);
+  assert.doesNotMatch(out, /Auto-file next phase/);
+  assert.doesNotMatch(out, /nextPhaseIssueUrl/);
+});
+
+test("renderWorkflow: autoPhaseFollowup === true — Step N+1 section + envelope-schema field render", () => {
+  const out = renderWorkflow({ ...baseVars, autoPhaseFollowup: true });
+  // The instructional section.
+  assert.match(out, /## Step N\+1 — Auto-file next phase \(if applicable\)/);
+  assert.match(out, /Phase X:/);
+  assert.match(out, /## Phases/);
+  assert.match(out, /gh issue create --title 'Phase N\+1:/);
+  assert.match(out, /Set `nextPhaseIssueUrl` in your envelope/);
+  // The envelope-schema example in Step 4 documents the field.
+  assert.match(out, /"nextPhaseIssueUrl":/);
+  // Section sits between Step 3.5 and Step 4.
+  const stepNplus1 = out.indexOf("## Step N+1");
+  const step4 = out.indexOf("## Step 4 — Emit the JSON envelope");
+  assert.ok(stepNplus1 > 0, "Step N+1 must appear");
+  assert.ok(step4 > stepNplus1, "Step 4 must follow Step N+1");
+});
+
+test("renderWorkflow: autoPhaseFollowup off vs on differ ONLY by the new section + envelope field", () => {
+  const off = renderWorkflow(baseVars);
+  const on = renderWorkflow({ ...baseVars, autoPhaseFollowup: true });
+  assert.ok(on.length > off.length, "on-rendering must be a strict superset");
+  // Removing the on-only fragments yields the off-rendering (modulo
+  // the leading newlines that bracket the conditional template).
+  // This is the regression guard: any other drift between the two
+  // renderings would be a sign the conditional leaked into a default.
+  assert.ok(on.includes("## Step N+1 — Auto-file next phase"));
+  assert.ok(!off.includes("Step N+1"));
+  assert.ok(on.includes('"nextPhaseIssueUrl":'));
+  assert.ok(!off.includes("nextPhaseIssueUrl"));
+});

--- a/src/agent/workflow.ts
+++ b/src/agent/workflow.ts
@@ -22,6 +22,20 @@ export interface WorkflowVars {
     agentName?: string;
     runId: string;
   };
+  /**
+   * Issue #141 (Phase 1 of #134): when `true`, render an additional
+   * "## Step N+1 — Auto-file next phase (if applicable)" section that
+   * instructs the agent to detect a phase-marked issue (title prefix
+   * "Phase X:" or a "## Phases" body section) and, after a successful
+   * `gh pr create`, file a follow-up issue for Phase N+1 and surface its
+   * URL via the envelope's `nextPhaseIssueUrl` field.
+   *
+   * Default: `false` — this Phase 1 ships data-layer + render-only with
+   * zero observable behavior change. Phase 2 will thread a CLI flag
+   * (`--auto-phase-followup`) through `OrchestratorInput → RunIssueCoreInput
+   * → CodingAgentInput → WorkflowVars` so the section actually fires.
+   */
+  autoPhaseFollowup?: boolean;
 }
 
 export function renderWorkflow(v: WorkflowVars): string {
@@ -103,7 +117,21 @@ These post-push checks are the verification-ceremony anti-pattern — they cost 
 The orchestrator's recovery pass (PR [#92](https://github.com/szhygulin/vaultpilot-development-agents/pull/92)) salvages the partial branch — a known-incomplete attempt with a clean \`error\` envelope is strictly better than running out of turns mid-debug with no envelope at all.
 
 **Investigative-coding signal.** If you find yourself re-reading the same source file twice during the closing third of your turns, that's a tell that the change map wasn't complete before you started editing. Stop reading; make the smallest additional edit that compiles + passes tests; ship. Save the "I should have planned more" insight for a memory tag, not for more reads on this run.
+${v.autoPhaseFollowup ? `
+## Step N+1 — Auto-file next phase (if applicable)
 
+If this issue is part of a multi-phase split (title contains \`Phase X:\` or
+body has a \`## Phases\` section listing future phases), after \`gh pr create\`
+succeeds and BEFORE emitting the JSON envelope:
+  1. Read the original issue body for Phase N+1's intent.
+  2. Compose a fresh issue body referencing your just-shipped PR by URL,
+     with concrete API citations from your actual diff (no speculation).
+  3. \`gh issue create --title 'Phase N+1: <derived title>' --body-file <tmp>\`
+  4. Post a comment on the original issue: \`Phase N+1 filed at #<new-N>.\`
+  5. Set \`nextPhaseIssueUrl\` in your envelope to the new issue's URL.
+
+If the issue is NOT phase-marked, skip this step entirely.
+` : ''}
 ## Step 4 — Emit the JSON envelope as your FINAL message
 
 Wrap it in a fenced \`\`\`json block. Schema:
@@ -114,7 +142,8 @@ Wrap it in a fenced \`\`\`json block. Schema:
   "reason": "1-3 sentences on what you did and why",
   "prUrl": "<only for implement>",
   "commentUrl": "<only for pushback>",
-  "scopeNotes": "<optional, e.g. skill issue filed at vaultpilot-security-skill#NN>",
+  "scopeNotes": "<optional, e.g. skill issue filed at vaultpilot-security-skill#NN>",${v.autoPhaseFollowup ? `
+  "nextPhaseIssueUrl": "<optional, only when Step N+1 fired and filed a follow-up>",` : ''}
   "memoryUpdate": {
     "addTags": ["<lowercase domain tags this issue exercised>"],
     "removeTags": ["<optional>"]

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -547,6 +547,12 @@ async function runOneIssue(opts: {
       prUrl: env.prUrl,
       commentUrl: env.commentUrl,
       partialBranchUrl: result.partialBranchUrl,
+      // Issue #141 (Phase 1 of #134): pass the auto-filed Phase N+1 issue
+      // URL through to the run-state entry when the agent emitted one.
+      // Inert today (no caller renders the workflow prompt's Step N+1 yet);
+      // Phase 2 wires the CLI flag that flips `autoPhaseFollowup` on and
+      // makes this assignment observable.
+      nextPhaseIssueUrl: env.nextPhaseIssueUrl,
     };
     nonCleanExit = env.decision === "error";
   } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,14 @@ export interface RunIssueEntry {
   // Optional; only populated on no-envelope failure paths where
   // extractEnvelope failed.
   parseError?: string;
+  // Issue #141 (Phase 1 of #134): URL of the auto-filed Phase N+1 follow-up
+  // issue, when the just-shipped issue was part of a multi-phase split and
+  // the run was dispatched with the (Phase 2-only) auto-phase-followup flag.
+  // Phase 1 only persists this from the envelope through to the run-state
+  // entry — no observable behavior change until Phase 2 wires the CLI flag
+  // and the workflow prompt's Step N+1 actually fires. Optional for
+  // back-compat with run-state entries written before this surface existed.
+  nextPhaseIssueUrl?: string;
 }
 
 // A `vp-dev/agent-*/issue-*` branch the stale-branch sweep determined was
@@ -150,6 +158,15 @@ export const ResultEnvelopeSchema = z.object({
   prUrl: z.string().optional(),
   commentUrl: z.string().optional(),
   scopeNotes: z.string().optional(),
+  // Issue #141 (Phase 1 of #134): URL of the auto-filed Phase N+1 follow-up
+  // issue. Set by the agent only when the workflow's Step N+1 (rendered when
+  // `autoPhaseFollowup === true`) determined the issue was phase-marked and
+  // filed a follow-up via `gh issue create`. URL-validated when present so
+  // a malformed value fails envelope validation rather than landing in
+  // run-state silently. Phase 2 wires the orchestrator-side flag that
+  // enables Step N+1 rendering; Phase 1 is data-layer + render-only and
+  // ships zero observable behavior change.
+  nextPhaseIssueUrl: z.string().url().optional(),
   memoryUpdate: z.object({
     addTags: z.array(z.string()).default([]),
     removeTags: z.array(z.string()).optional(),


### PR DESCRIPTION
Closes #141

## Summary

Phase 1 of #134 (split via this issue): ships the **data-layer schema additions** and the **conditionally-rendered workflow prompt section** for the auto-phase-followup feature. **Zero observable behavior change** — the new render is gated on a `WorkflowVars.autoPhaseFollowup` flag that nothing currently sets, and the new envelope field is optional. Phase 2 will wire the `--auto-phase-followup` CLI flag through `OrchestratorInput → RunIssueCoreInput → CodingAgentInput → WorkflowVars` to flip the switch on.

## What changed

- **`src/types.ts`**:
  - `ResultEnvelopeSchema` accepts an optional `nextPhaseIssueUrl: z.string().url().optional()` field. Malformed URLs fail envelope validation (so a bug in the agent's emitted URL is surfaced as a parse error rather than silently landing in run-state).
  - `RunIssueEntry` carries `nextPhaseIssueUrl?: string` for run-state persistence.
- **`src/orchestrator/orchestrator.ts`**: pipes `env.nextPhaseIssueUrl` into the `RunIssueEntry` written at envelope-decision time. Inert until Phase 2 enables the workflow render.
- **`src/agent/workflow.ts`**:
  - `WorkflowVars` gains optional `autoPhaseFollowup?: boolean`.
  - When `true`, `renderWorkflow` inserts a "## Step N+1 — Auto-file next phase (if applicable)" section between Step 3.5 and Step 4, and surfaces `"nextPhaseIssueUrl"` in the Step-4 envelope-schema example.
  - When `false` / `undefined` (current production), output is byte-identical to the pre-#141 baseline.
- **Tests**:
  - `src/agent/parseResult.test.ts` (new): pins schema validation — accepted-when-URL, optional-when-absent, rejected-when-malformed.
  - `src/agent/workflow.test.ts` (extended): default-off, explicit-off, explicit-on (including section ordering between Steps 3.5 and 4), and a diff-shape regression guard ensuring on-vs-off differ only by the conditional fragments.

## Out of scope (Phase 2's territory)

- `--auto-phase-followup` CLI flag in `src/cli.ts`.
- Threading the flag through `OrchestratorInput → RunIssueCoreInput → CodingAgentInput → WorkflowVars`.
- Persisting the flag in `RunConfirmParams` for the `--plan`/`--confirm` round-trip.
- Surfacing `nextPhaseIssueUrl` in `vp-dev status` output.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 298/298 pass; 7 new subtests confirmed firing (3 schema + 4 render)
- [ ] Phase 2 integration smoke once the CLI flag lands

— Advisory Scope Boundary (agent-916a)
