### PR TITLE
feat(cli): --auto-phase-followup flag + lifecycle wiring (#142)

### DIFF
--- a/src/agent/codingAgent.ts
+++ b/src/agent/codingAgent.ts
@@ -38,6 +38,14 @@ export interface CodingAgentInput {
    * get here (see `createWorktree(resumeFromBranch)`).
    */
   resumeContext?: ResumeContext;
+  /**
+   * Issue #142 (Phase 2 of #134): when `true`, the workflow prompt's
+   * `autoPhaseFollowup` render switch fires and the agent's seed gets
+   * the Step N+1 "Auto-file next phase" section. CLI-driven via
+   * `vp-dev run --auto-phase-followup`. Default `false` — Step N+1 is
+   * absent and no follow-up issue is filed.
+   */
+  autoPhaseFollowup?: boolean;
 }
 
 export interface CodingAgentResult {
@@ -98,6 +106,12 @@ export async function runCodingAgent(input: CodingAgentInput): Promise<CodingAge
             runId: input.resumeContext.runId,
           }
         : undefined,
+      // Issue #142 (Phase 2 of #134): forward the per-run flag into the
+      // workflow renderer. When `true`, `renderWorkflow` adds the Step
+      // N+1 section + the `nextPhaseIssueUrl` envelope-schema field.
+      // Phase 1 (#141) shipped the renderer; this is the call site that
+      // actually flips the switch.
+      autoPhaseFollowup: input.autoPhaseFollowup,
     },
     targetRepoPath: input.targetRepoPath,
     resumeContext: input.resumeContext,

--- a/src/agent/runIssueCore.ts
+++ b/src/agent/runIssueCore.ts
@@ -55,6 +55,14 @@ export interface RunIssueCoreInput {
    * entry from its map before invoking this helper.
    */
   resumeContext?: ResumeContext;
+  /**
+   * Issue #142 (Phase 2 of #134): per-run flag that turns on the
+   * workflow prompt's auto-file-next-phase Step N+1 section. Forwarded
+   * verbatim to `runCodingAgent`, which threads it into
+   * `buildAgentSystemPrompt`. Optional: undefined / false preserves the
+   * pre-#142 behavior (no Step N+1 rendered, no follow-up issue filed).
+   */
+  autoPhaseFollowup?: boolean;
 }
 
 export interface RunIssueCoreResult {
@@ -124,6 +132,7 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
       inspectPaths: input.inspectPaths,
       costTracker: input.costTracker,
       resumeContext: input.resumeContext,
+      autoPhaseFollowup: input.autoPhaseFollowup,
     });
 
     envelope = result.envelope;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -163,6 +163,10 @@ export function buildCli(): Command {
       "Phase 1 (#118): record the intent to resume from a salvageable `*-incomplete-<runId>` branch on origin. Phase 1 only logs the intent + carries it through --plan/--confirm; the actual worktree-from-partial-branch behavior is Phase 2's territory (still routes from main today).",
     )
     .option(
+      "--auto-phase-followup",
+      "Phase 2 of #134 (#142): when set, every coding agent dispatched in this run gets the workflow prompt's Step N+1 'Auto-file next phase' section rendered (#141). Agents working on phase-marked issues (title 'Phase X:' or '## Phases' body section) file a follow-up Phase N+1 issue after `gh pr create` succeeds and surface its URL via the envelope's `nextPhaseIssueUrl`. Off by default — explicit opt-in.",
+    )
+    .option(
       "--no-report",
       "Suppress the end-of-run result report on stdout (#136). The terminal sentinel (#128) still fires. Use when piping `vp-dev run` output into structured-log consumers that don't want the bounded text block.",
     )
@@ -379,6 +383,11 @@ interface RunOpts {
   maxCostUsd?: string;
   preferAgent?: string;
   resumeIncomplete?: boolean;
+  // Issue #142 (Phase 2 of #134): per-run flag that enables the
+  // workflow prompt's Step N+1 ("Auto-file next phase") section. Off by
+  // default. Persisted into the confirm token so a `--plan` → `--confirm`
+  // round-trip preserves the operator's opt-in.
+  autoPhaseFollowup?: boolean;
   // Commander `--no-report` auto-generates `report: boolean` on opts: true
   // by default, false when `--no-report` is passed. Issue #136.
   report?: boolean;
@@ -443,6 +452,9 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     // Phase 1 has no behavior coupling beyond the run-start log line, but
     // the flag must persist so Phase 2 can light up cleanly.
     opts.resumeIncomplete = p.resumeIncomplete;
+    // #142 Phase 2: same plan→confirm carry for the auto-phase-followup
+    // opt-in. Token-roundtrip-tested in `runConfirm.test.ts`.
+    opts.autoPhaseFollowup = p.autoPhaseFollowup;
   }
 
   if (opts.agents === undefined || !opts.targetRepo) {
@@ -679,6 +691,12 @@ async function cmdRun(opts: RunOpts): Promise<void> {
         maxCostUsd: opts.maxCostUsd,
         // #118 Phase 1: carry the resume intent across --plan → --confirm.
         resumeIncomplete: opts.resumeIncomplete,
+        // #142 Phase 2: persist the auto-phase-followup opt-in so the
+        // confirm-side launch sees the same flag the user authorized at
+        // plan time. The previewHash already binds this — flipping the
+        // value between plan and confirm rebuilds the preview text and
+        // rejects with a drift diff.
+        autoPhaseFollowup: opts.autoPhaseFollowup,
       },
     });
     process.stdout.write("Plan saved. No agents launched.\n");
@@ -778,6 +796,11 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     // their starting commit.
     resumeIncomplete: !!opts.resumeIncomplete,
     incompleteBranchesAvailableCount: incompleteBranchesAvailable.length,
+    // #142 Phase 2: flat boolean in the run-start log so post-run audits
+    // can confirm the opt-in was active for this run. Pairs naturally
+    // with the `nextPhaseIssueUrl` field surfaced on the per-issue
+    // `RunIssueEntry` (#141 Phase 1).
+    autoPhaseFollowup: !!opts.autoPhaseFollowup,
     // Issue #139 (Phase 1 of #133): emit the resolved model tier each
     // orchestrator-side LLM call site is configured to use, so post-hoc
     // audits can confirm what tier was actually used (especially when the
@@ -846,6 +869,10 @@ async function cmdRun(opts: RunOpts): Promise<void> {
       costTracker,
       budgetUsd,
       resumeContextByIssue,
+      // #142 Phase 2: thread the per-run opt-in down to every
+      // `runIssueCore` so each coding agent's seed gets the Step N+1
+      // section rendered when the operator passed `--auto-phase-followup`.
+      autoPhaseFollowup: !!opts.autoPhaseFollowup,
     });
     const abortedBudgetCount = countByStatus(state, "aborted-budget");
     logger.info("run.completed", {
@@ -1119,6 +1146,11 @@ async function runResume(opts: RunOpts): Promise<void> {
       targetRepoPath: repoPath,
       costTracker,
       budgetUsd,
+      // #142 Phase 2: same flag plumbing on resume for symmetry with
+      // `--prefer-agent`. Operators who started a run with
+      // `--auto-phase-followup` and need to resume after a crash re-pass
+      // the flag on the resume invocation; otherwise it stays off.
+      autoPhaseFollowup: !!opts.autoPhaseFollowup,
     });
     const abortedBudgetCount = countByStatus(state, "aborted-budget");
     logger.info("run.completed", {

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -72,6 +72,16 @@ export interface OrchestratorInput {
    * as before (no Phase 2 routing).
    */
   resumeContextByIssue?: Map<number, ResumeContext>;
+  /**
+   * Issue #142 (Phase 2 of #134): per-run flag forwarded to every
+   * `runIssueCore` call so each coding agent's workflow prompt gets the
+   * Step N+1 "Auto-file next phase" section rendered. Phase 1 (#141)
+   * shipped the renderer + envelope schema; this orchestrator-level
+   * field is the lifecycle wiring that makes the flag observable.
+   * Optional: undefined / false preserves pre-#142 behavior (no Step
+   * N+1 rendered, no follow-up issue filed).
+   */
+  autoPhaseFollowup?: boolean;
 }
 
 export async function runOrchestrator(input: OrchestratorInput): Promise<void> {
@@ -161,6 +171,7 @@ export async function runOrchestrator(input: OrchestratorInput): Promise<void> {
           costTracker: input.costTracker,
           budgetUsd: input.budgetUsd,
           resumeContext: input.resumeContextByIssue?.get(issue.id),
+          autoPhaseFollowup: input.autoPhaseFollowup,
         }).catch(async (err) => {
           input.logger.error("agent.uncaught", {
             agentId: agent.agentId,
@@ -519,6 +530,7 @@ async function runOneIssue(opts: {
   costTracker?: RunCostTracker;
   budgetUsd?: number;
   resumeContext?: ResumeContext;
+  autoPhaseFollowup?: boolean;
 }): Promise<void> {
   const result = await runIssueCore({
     agent: opts.agent,
@@ -531,6 +543,7 @@ async function runOneIssue(opts: {
     costTracker: opts.costTracker,
     budgetUsd: opts.budgetUsd,
     resumeContext: opts.resumeContext,
+    autoPhaseFollowup: opts.autoPhaseFollowup,
   });
 
   // Track whether this run was a non-clean exit so the post-mortem comment

--- a/src/state/runConfirm.test.ts
+++ b/src/state/runConfirm.test.ts
@@ -1,0 +1,141 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import {
+  hashPreview,
+  mintToken,
+  readRunConfirmToken,
+  writeRunConfirmToken,
+  deleteRunConfirmToken,
+  type RunConfirmParams,
+} from "./runConfirm.js";
+import { STATE_DIR } from "./runState.js";
+
+// Issue #142 (Phase 2 of #134): the `autoPhaseFollowup` opt-in must
+// survive a `--plan` → `--confirm` round-trip via the on-disk token
+// file. Without this guarantee, an operator who passes the flag at
+// `--plan` time would silently see the run launch without it on
+// `--confirm`, with no error surface — the most expensive failure mode
+// for a feature whose only behavior change is opt-in.
+//
+// The previewHash binds the field too (a flag toggle between plan and
+// confirm rebuilds the preview text and trips the drift diff), but
+// hash-binding alone doesn't prove the value persists; the test below
+// pins the persistence-layer invariant the previewHash check depends
+// on.
+
+const baseParams: RunConfirmParams = {
+  agents: 2,
+  targetRepo: "owner/repo",
+  issues: "100-105",
+  dryRun: false,
+  maxTicks: 50,
+  stalledThresholdDays: 30,
+  includeNonReady: false,
+  verbose: false,
+};
+
+async function ensureStateDir(): Promise<void> {
+  await fs.mkdir(STATE_DIR, { recursive: true });
+}
+
+test("runConfirm token round-trip: autoPhaseFollowup === true persists", async () => {
+  await ensureStateDir();
+  const token = mintToken();
+  await writeRunConfirmToken({
+    token,
+    previewHash: hashPreview("preview-1"),
+    params: { ...baseParams, autoPhaseFollowup: true },
+  });
+  try {
+    const r = await readRunConfirmToken(token);
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.record.params.autoPhaseFollowup, true);
+    }
+  } finally {
+    await deleteRunConfirmToken(token);
+  }
+});
+
+test("runConfirm token round-trip: autoPhaseFollowup === false persists distinctly", async () => {
+  await ensureStateDir();
+  const token = mintToken();
+  await writeRunConfirmToken({
+    token,
+    previewHash: hashPreview("preview-2"),
+    params: { ...baseParams, autoPhaseFollowup: false },
+  });
+  try {
+    const r = await readRunConfirmToken(token);
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.record.params.autoPhaseFollowup, false);
+    }
+  } finally {
+    await deleteRunConfirmToken(token);
+  }
+});
+
+test("runConfirm token round-trip: omitted autoPhaseFollowup stays undefined (back-compat)", async () => {
+  // Tokens written before #142 (or by a CLI invocation that didn't pass
+  // `--auto-phase-followup`) carry no `autoPhaseFollowup` field. The
+  // read path must surface that as `undefined`, not coerce to a boolean
+  // — `cmdRun` treats undefined as "off" via `!!opts.autoPhaseFollowup`,
+  // which is the correct default-off behavior.
+  await ensureStateDir();
+  const token = mintToken();
+  await writeRunConfirmToken({
+    token,
+    previewHash: hashPreview("preview-3"),
+    params: { ...baseParams }, // no autoPhaseFollowup at all
+  });
+  try {
+    const r = await readRunConfirmToken(token);
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.record.params.autoPhaseFollowup, undefined);
+    }
+  } finally {
+    await deleteRunConfirmToken(token);
+  }
+});
+
+test("runConfirm token round-trip: pre-#142 token shape (no autoPhaseFollowup field on disk) reads cleanly", async () => {
+  // Hand-write a token file shaped like a pre-#142 plan: no
+  // `autoPhaseFollowup` key at all, no `resumeIncomplete` either —
+  // the on-disk JSON predates both. The read path must not throw and
+  // must return undefined for the missing field.
+  await ensureStateDir();
+  const token = mintToken();
+  const tokenPath = path.join(STATE_DIR, `run-confirm-${token}.json`);
+  const legacyRecord = {
+    token,
+    previewHash: hashPreview("legacy-preview"),
+    createdAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    params: {
+      agents: 1,
+      targetRepo: "owner/repo",
+      issues: "1",
+      dryRun: false,
+      maxTicks: 10,
+      stalledThresholdDays: 30,
+      includeNonReady: false,
+      verbose: false,
+      // Note: no autoPhaseFollowup, no resumeIncomplete
+    },
+  };
+  await fs.writeFile(tokenPath, JSON.stringify(legacyRecord), "utf-8");
+  try {
+    const r = await readRunConfirmToken(token);
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.record.params.autoPhaseFollowup, undefined);
+      assert.equal(r.record.params.resumeIncomplete, undefined);
+    }
+  } finally {
+    await deleteRunConfirmToken(token);
+  }
+});

--- a/src/state/runConfirm.ts
+++ b/src/state/runConfirm.ts
@@ -47,6 +47,14 @@ export interface RunConfirmParams {
   // that the two-step approval flow surfaces the same intent at confirm
   // time as at plan time.
   resumeIncomplete?: boolean;
+  // Issue #142 Phase 2 of #134: per-run flag that flips the workflow
+  // prompt's `autoPhaseFollowup` render switch on. When `true`, the
+  // coding agent's seed renders Step N+1 ("Auto-file next phase") and
+  // the agent files a follow-up issue + sets `nextPhaseIssueUrl` in its
+  // envelope when the issue it just shipped was phase-marked. Optional
+  // for back-compat: tokens written before #142 default to `false` /
+  // `undefined` and the existing no-auto-file behavior is preserved.
+  autoPhaseFollowup?: boolean;
 }
 
 export interface RunConfirmToken {


### PR DESCRIPTION
Closes #142.

Phase 2 of #134. Phase 1 ([#144](https://github.com/szhygulin/vaultpilot-development-agents/pull/144)) shipped the data layer + render switch (`autoPhaseFollowup` on `WorkflowVars`, `nextPhaseIssueUrl` on `ResultEnvelopeSchema` / `RunIssueEntry`) with zero observable behavior change. This PR wires the per-run flag end-to-end so the auto-file behavior actually fires when the operator opts in.

## Summary

- **`src/cli.ts`** — registers `--auto-phase-followup` on `vp-dev run`. Threads to `RunOpts.autoPhaseFollowup`. Persists into `RunConfirmParams` so `--plan` → `--confirm` preserves the opt-in. The `run.started` log line surfaces the flag as a flat boolean for post-run audits. `runResume` accepts the flag too for symmetry with `--prefer-agent`.
- **`src/state/runConfirm.ts`** — adds optional `autoPhaseFollowup?: boolean` to `RunConfirmParams`. Back-compat with pre-#142 tokens (default `undefined` → treated as off via `!!opts.autoPhaseFollowup`).
- **`src/orchestrator/orchestrator.ts`** + **`src/agent/runIssueCore.ts`** — extend `OrchestratorInput` and `RunIssueCoreInput` with the flag and forward it to `CodingAgentInput`.
- **`src/agent/codingAgent.ts`** — accepts `autoPhaseFollowup?: boolean` and forwards it into `buildAgentSystemPrompt({ workflow: { ..., autoPhaseFollowup } })`. The workflow renderer (Phase 1) already conditionally inserts Step N+1 + the `nextPhaseIssueUrl` envelope-schema field on this switch.

## Default-off invariant

Without `--auto-phase-followup`, no Step N+1 is rendered and no follow-up issue is filed even on phase-marked input. Pre-#142 token shape (no field on disk at all) reads back as `undefined` and `cmdRun` coerces via `!!opts.autoPhaseFollowup`. The four new round-trip tests pin all four shapes (true / false / omitted / pre-#142 legacy on-disk).

## Out-of-scope follow-ups (per the issue)

- Surfacing `nextPhaseIssueUrl` in the human-readable `vp-dev status` extended formatter — natural follow-up after this phase. Phase 1 already persists the field into `RunIssueEntry` so the JSON `vp-dev status --json` shape carries it today.
- Auto-dispatching the new Phase N+1 issue immediately — operator should review first.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` — 312 passing (4 new in `src/state/runConfirm.test.ts`):
  - `autoPhaseFollowup === true persists`
  - `autoPhaseFollowup === false persists distinctly`
  - `omitted autoPhaseFollowup stays undefined (back-compat)`
  - `pre-#142 token shape (no autoPhaseFollowup field on disk) reads cleanly`
- [x] `renderWorkflow` snapshot tests from Phase 1 (#141) verify Step N+1 + envelope-schema field render exactly when `autoPhaseFollowup === true`. The threading from CLI flag → `WorkflowVars.autoPhaseFollowup` is type-checked end-to-end (no `as`/`any` casts in the new code).
- [ ] End-to-end smoke: dispatch a phase-marked issue with `vp-dev run --auto-phase-followup --target-repo X --issues N` and confirm the agent files a follow-up Phase N+1 issue + sets `nextPhaseIssueUrl` in its envelope. (Smoke test deferred to a real run; deterministic unit coverage above is sufficient for merge.)

— Alonzo (agent-92ff)
