### PR TITLE
feat(status): surface nextPhaseIssueUrl in vp-dev status formatters

### DIFF
--- a/src/state/statusFormatter.ts
+++ b/src/state/statusFormatter.ts
@@ -172,6 +172,14 @@ export interface StatusJson {
     error?: string;
     errorSubtype?: string;
     parseError?: string;
+    /**
+     * URL of the auto-filed Phase N+1 follow-up issue (issue #141 Phase 1
+     * persists this onto `RunIssueEntry`; #142 wires the CLI flag that
+     * actually populates it; #149 surfaces it through the formatter). Absent
+     * for runs dispatched without `--auto-phase-followup`, agents that ran
+     * pushback / error paths, and pre-#141 run-state entries.
+     */
+    nextPhaseIssueUrl?: string;
     /** Present only when `opts.activity` was supplied and the issue had any events. */
     liveActivity?: IssueLiveActivityJson;
   }[];
@@ -226,6 +234,7 @@ export function formatStatusJson(state: RunState, opts: StatusFormatOpts = {}): 
           error: e.error,
           errorSubtype: e.errorSubtype,
           parseError: e.parseError,
+          nextPhaseIssueUrl: e.nextPhaseIssueUrl,
           liveActivity: issueActivity
             ? {
                 lastEventTs: issueActivity.lastEventTs,
@@ -293,6 +302,13 @@ function renderIssueLines(
   }
   if (e.commentUrl && e.prUrl) {
     out.push(`           comment: ${e.commentUrl}`);
+  }
+  // Issue #149 (follow-up to #142 / #141 Phase 1): surface the auto-filed
+  // Phase N+1 follow-up issue URL when the orchestrator persisted one onto
+  // the entry. Mirrors the `partial:` indent so multi-line addenda stay
+  // visually aligned in the per-issue block.
+  if (e.nextPhaseIssueUrl) {
+    out.push(`           next phase: ${e.nextPhaseIssueUrl}`);
   }
   return out;
 }

--- a/src/util/statusFormatter.test.ts
+++ b/src/util/statusFormatter.test.ts
@@ -324,3 +324,69 @@ test("formatStatusJson: liveActivity + recentEvents undefined when activity not 
   const json = formatStatusJson(fixture());
   assert.equal(json.recentEvents, undefined);
 });
+
+// Issue #149 (follow-up to #142 / #141 Phase 1): surface nextPhaseIssueUrl
+// in both formatters so the auto-filed Phase N+1 follow-up issue is
+// discoverable from `vp-dev status` without scraping run-state JSON.
+
+test("formatStatusText: surfaces nextPhaseIssueUrl on a 'next phase:' addendum line when set", () => {
+  const text = formatStatusText(
+    fixture({
+      issues: {
+        "142": {
+          status: "done",
+          agentId: "agent-92ff",
+          outcome: "implement",
+          prUrl: "https://github.com/x/y/pull/200",
+          nextPhaseIssueUrl: "https://github.com/x/y/issues/201",
+        },
+      },
+    }),
+  );
+  assert.match(text, /next phase: https:\/\/github\.com\/x\/y\/issues\/201/);
+});
+
+test("formatStatusText: omits 'next phase:' line when nextPhaseIssueUrl absent (back-compat)", () => {
+  const text = formatStatusText(
+    fixture({
+      issues: {
+        "142": {
+          status: "done",
+          agentId: "agent-92ff",
+          outcome: "implement",
+          prUrl: "https://github.com/x/y/pull/200",
+        },
+      },
+    }),
+  );
+  assert.doesNotMatch(text, /next phase:/);
+});
+
+test("formatStatusJson: includes nextPhaseIssueUrl on per-issue object when set", () => {
+  const json = formatStatusJson(
+    fixture({
+      issues: {
+        "142": {
+          status: "done",
+          agentId: "agent-92ff",
+          outcome: "implement",
+          prUrl: "https://github.com/x/y/pull/200",
+          nextPhaseIssueUrl: "https://github.com/x/y/issues/201",
+        },
+      },
+    }),
+  );
+  assert.equal(
+    json.issues[0].nextPhaseIssueUrl,
+    "https://github.com/x/y/issues/201",
+  );
+});
+
+test("formatStatusJson: nextPhaseIssueUrl undefined on per-issue object when entry omits it (back-compat)", () => {
+  const json = formatStatusJson(
+    fixture({
+      issues: { "142": { status: "done", agentId: "agent-92ff", outcome: "implement" } },
+    }),
+  );
+  assert.equal(json.issues[0].nextPhaseIssueUrl, undefined);
+});


### PR DESCRIPTION
Closes #149.

## Summary

Surfaces `nextPhaseIssueUrl` (auto-filed Phase N+1 follow-up issue URL) in both the human-readable and JSON `vp-dev status` formatters. Phase 1 (#141) persisted the field onto `RunIssueEntry`; Phase 2 (#142) wired the `--auto-phase-followup` CLI flag. Until now neither formatter rendered the field, so the follow-up was only discoverable by scraping `state/<runId>.json`.

## Changes

- **`formatStatusText`**: emits a `next phase: <url>` addendum line under the per-issue row when set, mirroring the existing `partial:` indent.
- **`formatStatusJson`**: forwards `e.nextPhaseIssueUrl` onto the per-issue object and documents the field on `StatusJson`.
- The same `formatStatusJson` shape feeds `vp-dev status --json`, the end-of-run report (#136), and `--watch --json` NDJSON — one change covers all three surfaces.

## Back-compat

Both additions are opt-in by data presence: absent on every pre-#141 entry and on runs dispatched without `--auto-phase-followup`. No schema migration needed; no observable change for runs that don't fire Step N+1.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 316/316 pass (4 new tests added)
- [x] New tests cover: text-formatter present/absent, JSON-formatter present/absent for `nextPhaseIssueUrl`

— Alonzo (agent-92ff)
