### PR TITLE
feat(dedup): pre-dispatch duplicate-detection module + schema (no integration yet)

### DIFF
--- a/src/orchestrator/dedup.ts
+++ b/src/orchestrator/dedup.ts
@@ -1,0 +1,249 @@
+// Pre-dispatch deduplication detection (issue #150, Phase 2a-i of #133).
+//
+// `detectDuplicates` makes a single Opus model call to cluster a batch of
+// GitHub issues by semantic overlap. For each cluster of 2+ duplicates the
+// model proposes a canonical (most-detailed body, most-comments, oldest
+// creation) plus a one-sentence rationale.
+//
+// Phase 2a-i scope: this module is exported and unit-tested but NOT wired
+// into the orchestrator or CLI. Phase 2a-ii (separate issue) threads the
+// dedup pass between triage and `pickAgents`, persists the result into
+// `RunState.duplicateClustersDetected`, and renders a "Duplicate clusters"
+// block in the approval-gate preview. Phase 2b layers the destructive
+// `--apply-dedup` close path on top.
+//
+// Design notes:
+// - Single `query()` call with `maxTurns: 1` — same shape as `triage.ts`.
+// - Fail-soft: any model error / malformed JSON returns `{ clusters: [],
+//   costUsd }` rather than throwing. The dedup pass is a pre-flight
+//   convenience; a flaky model call must never block a run.
+// - The Zod-validated parse is split into a pure helper
+//   (`parseDedupResponse`) so tests can exercise the parsing rubric
+//   without spinning up the SDK or paying for a real Opus call.
+
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import { ORCHESTRATOR_MODEL_DEDUP } from "./models.js";
+import type { IssueDetail } from "../github/gh.js";
+import type { DuplicateCluster } from "../types.js";
+import type { Logger } from "../log/logger.js";
+
+// Resolved at module load from `models.ts` (env-overridable). See
+// `src/orchestrator/models.ts` for tier rationale and override env vars.
+const DEDUP_MODEL = ORCHESTRATOR_MODEL_DEDUP;
+
+const RATIONALE_MAX = 400;
+
+const DuplicateClusterSchema = z.object({
+  canonical: z.number().int().positive(),
+  duplicates: z.array(z.number().int().positive()).min(1),
+  rationale: z.string().min(1).max(RATIONALE_MAX),
+});
+
+const DedupResponseSchema = z.object({
+  clusters: z.array(DuplicateClusterSchema),
+});
+
+export interface DetectDuplicatesInput {
+  issues: IssueDetail[];
+  logger?: Logger;
+}
+
+export interface DetectDuplicatesResult {
+  clusters: DuplicateCluster[];
+  costUsd: number;
+}
+
+/**
+ * Cluster a batch of issues by semantic duplication.
+ *
+ * Returns `{ clusters: [], costUsd: 0 }` when called with fewer than two
+ * issues (no duplicates possible) — the model is not invoked. Otherwise
+ * issues a single Opus call (`maxTurns: 1`) and parses the response into
+ * `DuplicateCluster[]`.
+ *
+ * Fail-soft: model errors, exceptions, and malformed JSON are logged
+ * (when a logger is provided) and surface as `{ clusters: [], costUsd }`.
+ * Callers MUST treat an empty result as "no duplicates detected" — never
+ * as "dedup pass succeeded with high confidence".
+ */
+export async function detectDuplicates(
+  input: DetectDuplicatesInput,
+): Promise<DetectDuplicatesResult> {
+  if (input.issues.length < 2) {
+    return { clusters: [], costUsd: 0 };
+  }
+
+  const userPrompt = buildPrompt(input.issues);
+  let raw = "";
+  let costUsd = 0;
+  try {
+    const stream = query({
+      prompt: userPrompt,
+      options: {
+        model: DEDUP_MODEL,
+        systemPrompt: DEDUP_SYSTEM_PROMPT,
+        tools: [],
+        permissionMode: "default",
+        env: process.env,
+        maxTurns: 1,
+        settingSources: [],
+        persistSession: false,
+      },
+    });
+    for await (const msg of stream) {
+      if (msg.type === "result") {
+        if (msg.subtype === "success") {
+          raw = msg.result;
+          costUsd = msg.total_cost_usd ?? 0;
+        } else {
+          input.logger?.warn("dedup.model_failed", { subtype: msg.subtype });
+          return { clusters: [], costUsd: 0 };
+        }
+      }
+    }
+  } catch (err) {
+    input.logger?.warn("dedup.exception", { err: (err as Error).message });
+    return { clusters: [], costUsd: 0 };
+  }
+
+  const validIds = new Set(input.issues.map((i) => i.id));
+  const parsed = parseDedupResponse(raw, validIds);
+  if (!parsed) {
+    input.logger?.warn("dedup.malformed_payload", {
+      raw: raw.slice(0, 4000),
+    });
+    return { clusters: [], costUsd };
+  }
+  return { clusters: parsed, costUsd };
+}
+
+/**
+ * Parse a raw model response into validated `DuplicateCluster[]`.
+ *
+ * Returns `null` on any parse failure (not an empty array — the caller
+ * needs to distinguish "model said no duplicates" from "couldn't parse").
+ * When `validIssueIds` is supplied, clusters whose `canonical` or
+ * `duplicates` reference issues outside the input batch are dropped:
+ * the model occasionally hallucinates a number, and a fabricated
+ * canonical would silently misroute Phase 2a-ii's preview.
+ *
+ * Exported so unit tests can exercise the parsing rubric without
+ * invoking the SDK.
+ */
+export function parseDedupResponse(
+  raw: string,
+  validIssueIds?: Set<number>,
+): DuplicateCluster[] | null {
+  const json = parseJsonLoose(raw);
+  if (!json) return null;
+  const result = DedupResponseSchema.safeParse(json);
+  if (!result.success) return null;
+  const clusters: DuplicateCluster[] = [];
+  for (const c of result.data.clusters) {
+    // canonical must not also appear in the duplicates list
+    if (c.duplicates.includes(c.canonical)) continue;
+    // de-dupe the duplicates array defensively
+    const uniqueDups = Array.from(new Set(c.duplicates));
+    if (uniqueDups.length === 0) continue;
+    if (validIssueIds) {
+      if (!validIssueIds.has(c.canonical)) continue;
+      const allKnown = uniqueDups.every((d) => validIssueIds.has(d));
+      if (!allKnown) continue;
+    }
+    clusters.push({
+      canonical: c.canonical,
+      duplicates: uniqueDups,
+      rationale: c.rationale,
+    });
+  }
+  return clusters;
+}
+
+const DEDUP_SYSTEM_PROMPT = `You are a deduplication agent. Given a batch of GitHub issues (body + comments), identify clusters of issues that are semantic duplicates of each other.
+
+Rubric:
+- Two or more issues form a duplicate CLUSTER when they describe the same problem, propose the same feature, or request the same change — even if worded differently or filed by different reporters.
+- Issues that share a topic but propose distinct solutions, scopes, or phases are NOT duplicates. Be CONSERVATIVE; prefer to omit a cluster than to merge non-duplicates.
+- Phase splits (Phase 1 / Phase 2 of the same parent) are NOT duplicates of each other.
+- For each cluster, pick a CANONICAL using this priority:
+    (1) most-detailed body (longest substantive body, not boilerplate),
+    (2) most comments (active discussion),
+    (3) oldest creation (earliest filed).
+  The canonical is the issue to KEEP; the others are duplicates of it.
+- The "rationale" must be ONE short sentence that (a) names the canonical issue number and (b) explains in one phrase why the cluster is a duplicate set ("both request X", "both report Y", etc.).
+
+Output: a single JSON object, no fences, no prose around it.
+{
+  "clusters": [
+    {
+      "canonical": <issue number>,
+      "duplicates": [<issue number>, <issue number>, ...],
+      "rationale": "<one short sentence, ≤400 chars, names canonical>"
+    }
+  ]
+}
+
+Hard rules:
+- If no clusters are found, return {"clusters": []}.
+- Each issue number appears in AT MOST one cluster, either as canonical or in duplicates — never both.
+- "duplicates" must contain at least one issue number; never an empty array.
+- "canonical" must be an issue number from the input batch; never invent a number.
+- No markdown, no code fences, no explanatory prose outside the JSON object.`;
+
+function buildPrompt(issues: IssueDetail[]): string {
+  const issueBlocks = issues.map((issue) => {
+    const commentBlocks = issue.comments
+      .map((c, i) => {
+        const ordinal = `${i + 1}/${issue.comments.length}`;
+        return `  comment ${ordinal} by ${c.author} at ${c.createdAt}: ${truncate(c.body, 800)}`;
+      })
+      .join("\n");
+    return `### Issue #${issue.id} — ${issue.title}
+Labels: ${JSON.stringify(issue.labels)}
+Body:
+${truncate(issue.body || "(empty)", 2000)}
+Comments (${issue.comments.length}):
+${commentBlocks || "(none)"}`;
+  });
+  return `Cluster the following ${issues.length} GitHub issues by semantic duplication per the rubric.
+
+${issueBlocks.join("\n\n---\n\n")}
+
+JSON only.`;
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 3) + "...";
+}
+
+// Same shape as `triage.ts:parseJsonLoose` — accepts a JSON object in the
+// raw text whether or not the model wrapped it in a ```json fence or
+// emitted prose around it. Kept private to this module; the only loose-
+// JSON call site here is `parseDedupResponse`.
+function parseJsonLoose(raw: string): unknown {
+  const trimmed = raw.trim();
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    const match = /```(?:json)?\s*\n([\s\S]*?)\n```/i.exec(trimmed);
+    if (match) {
+      try {
+        return JSON.parse(match[1]);
+      } catch {
+        return null;
+      }
+    }
+    const start = trimmed.indexOf("{");
+    const end = trimmed.lastIndexOf("}");
+    if (start >= 0 && end > start) {
+      try {
+        return JSON.parse(trimmed.slice(start, end + 1));
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,26 @@ export interface RunAgentEntry {
   status: AgentStatus;
 }
 
+/**
+ * One cluster of semantically-duplicate issues identified by the
+ * pre-dispatch dedup pass (issue #150, Phase 2a-i of #133).
+ *
+ * `canonical` is the issue number to KEEP; `duplicates` are the issue
+ * numbers that should yield to it. The canonical is selected by the
+ * dedup model with priority: (1) most-detailed body, (2) most comments,
+ * (3) oldest creation. `rationale` is a one-sentence justification that
+ * names the canonical and explains why the cluster is a duplicate set.
+ *
+ * Phase 2a-i ships this shape and the `detectDuplicates` function that
+ * returns it; nothing in the orchestrator or CLI consumes the result
+ * yet — that integration lands in Phase 2a-ii.
+ */
+export interface DuplicateCluster {
+  canonical: number;
+  duplicates: number[];
+  rationale: string;
+}
+
 export interface RunIssueEntry {
   status: IssueStatus;
   agentId?: string;
@@ -150,6 +170,23 @@ export interface RunState {
   // tracker. Updated immediately before each `saveRunState` call in
   // `runOrchestrator` — see `src/orchestrator/orchestrator.ts`.
   costAccumulatedUsd?: number;
+  // Issue #150 (Phase 2a-i of #133): clusters of semantically-duplicate
+  // issues identified by the pre-dispatch dedup pass. Phase 2a-i ships
+  // the field as an optional schema extension only — no orchestrator or
+  // CLI code currently writes or reads it. Phase 2a-ii wires the dedup
+  // pass into `cli.ts` between triage and `pickAgents`, populates this
+  // field at run-start, and renders a "Duplicate clusters" block in the
+  // approval-gate preview. Phase 2b layers the destructive
+  // `--apply-dedup` close path on top. Optional for back-compat with
+  // run-state files written before this surface existed.
+  duplicateClustersDetected?: DuplicateCluster[];
+  // Issue #150 (Phase 2a-i of #133): USD cost of the dedup pass's single
+  // model call (Opus, see `ORCHESTRATOR_MODEL_DEDUP`). Persisted alongside
+  // `duplicateClustersDetected` so post-run audits can attribute the
+  // dedup spend without scraping the JSONL log. Phase 2a-i populates
+  // nothing; Phase 2a-ii's integration writes both fields together.
+  // Optional for back-compat.
+  dedupCostUsd?: number;
 }
 
 export const ResultEnvelopeSchema = z.object({

--- a/src/util/dedup.test.ts
+++ b/src/util/dedup.test.ts
@@ -1,0 +1,228 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseDedupResponse } from "../orchestrator/dedup.js";
+import type { RunState, DuplicateCluster } from "../types.js";
+
+// Pure-function unit tests for the dedup response parser (issue #150,
+// Phase 2a-i of #133). These do NOT invoke the SDK or the dedup model —
+// the parsing rubric is exercised directly so the tests stay fast,
+// deterministic, and free of API spend.
+
+test("parseDedupResponse: well-formed model output → typed DuplicateCluster[]", () => {
+  const raw = JSON.stringify({
+    clusters: [
+      {
+        canonical: 100,
+        duplicates: [110, 120],
+        rationale:
+          "Canonical #100 has the most-detailed body and predates the others; all three request the same feature flag.",
+      },
+    ],
+  });
+  const out = parseDedupResponse(raw);
+  assert.ok(out, "expected typed array on well-formed output");
+  assert.equal(out!.length, 1);
+  assert.equal(out![0].canonical, 100);
+  assert.deepEqual(out![0].duplicates, [110, 120]);
+  assert.match(out![0].rationale, /#100/);
+});
+
+test("parseDedupResponse: rationale is non-empty and references the canonical", () => {
+  // The system prompt asks the model to name the canonical in the
+  // rationale so the gate-render block in Phase 2a-ii can show "why
+  // #100 was kept" without re-deriving the rationale at render time.
+  const raw = JSON.stringify({
+    clusters: [
+      {
+        canonical: 42,
+        duplicates: [50, 51],
+        rationale:
+          "Canonical #42 was filed earliest and accumulated 8 review comments; #50 and #51 restate the same bug.",
+      },
+    ],
+  });
+  const out = parseDedupResponse(raw);
+  assert.ok(out);
+  assert.equal(out!.length, 1);
+  const cluster = out![0];
+  assert.ok(cluster.rationale.length > 0, "rationale must be non-empty");
+  assert.ok(
+    cluster.rationale.includes(`#${cluster.canonical}`),
+    `rationale should reference canonical #${cluster.canonical}; got: ${cluster.rationale}`,
+  );
+});
+
+test("parseDedupResponse: no overlap → empty cluster array, NOT null", () => {
+  // Critical contract: an empty `clusters` array is the model's signal
+  // that no duplicates were found. The parser must return `[]` (not
+  // `null`) so the caller can distinguish "no duplicates" from "couldn't
+  // parse". `null` is reserved for the parse-failure case.
+  const raw = JSON.stringify({ clusters: [] });
+  const out = parseDedupResponse(raw);
+  assert.ok(Array.isArray(out), "no-overlap must return an array, not null");
+  assert.equal(out!.length, 0);
+});
+
+test("parseDedupResponse: malformed JSON → null (parse failure case)", () => {
+  for (const bad of [
+    "not json at all",
+    '{"clusters": [malformed',
+    '{"foo": "bar"}', // valid JSON, wrong shape
+    '{"clusters": [{"canonical": "not a number", "duplicates": [1], "rationale": "x"}]}',
+    '{"clusters": [{"canonical": 1, "duplicates": [], "rationale": "empty dup list"}]}',
+    '{"clusters": [{"canonical": 1, "duplicates": [2], "rationale": ""}]}',
+  ]) {
+    assert.equal(
+      parseDedupResponse(bad),
+      null,
+      `expected null for malformed input: ${bad.slice(0, 60)}`,
+    );
+  }
+});
+
+test("parseDedupResponse: tolerates ```json``` fence wrapper around the object", () => {
+  // The model occasionally fences its JSON output despite the prompt
+  // forbidding it. The parser falls back to fence-stripping (mirrors
+  // triage.ts's parseJsonLoose) so a single naughty model output
+  // doesn't fail the whole dedup pass.
+  const raw = "```json\n" + JSON.stringify({
+    clusters: [
+      {
+        canonical: 7,
+        duplicates: [8],
+        rationale: "Canonical #7 has more comments than #8; both request the same refactor.",
+      },
+    ],
+  }) + "\n```";
+  const out = parseDedupResponse(raw);
+  assert.ok(out);
+  assert.equal(out!.length, 1);
+  assert.equal(out![0].canonical, 7);
+});
+
+test("parseDedupResponse: drops cluster where canonical also appears in duplicates", () => {
+  // Hard rule from the system prompt: "Each issue number appears in AT
+  // MOST one cluster, either as canonical or in duplicates — never both."
+  // A model that violates this would ship a cluster like {canonical: 5,
+  // duplicates: [5, 6]} which silently corrupts Phase 2a-ii's render.
+  const raw = JSON.stringify({
+    clusters: [
+      {
+        canonical: 5,
+        duplicates: [5, 6],
+        rationale: "Canonical #5 — invalid self-reference",
+      },
+      {
+        canonical: 10,
+        duplicates: [11],
+        rationale: "Canonical #10 has more comments than #11.",
+      },
+    ],
+  });
+  const out = parseDedupResponse(raw);
+  assert.ok(out);
+  assert.equal(out!.length, 1, "the self-referencing cluster must be filtered out");
+  assert.equal(out![0].canonical, 10);
+});
+
+test("parseDedupResponse: drops clusters referencing issues outside validIssueIds", () => {
+  // Hallucinated issue numbers are a real failure mode — the model
+  // occasionally invents a plausible-looking integer. The validIssueIds
+  // gate keeps phantom canonicals out of the run-state field that
+  // Phase 2a-ii will eventually render in the approval gate.
+  const raw = JSON.stringify({
+    clusters: [
+      {
+        canonical: 999, // not in the batch
+        duplicates: [100],
+        rationale: "Canonical #999 hallucinated by the model.",
+      },
+      {
+        canonical: 100,
+        duplicates: [110],
+        rationale: "Canonical #100 has the most-detailed body.",
+      },
+    ],
+  });
+  const validIds = new Set([100, 110, 120]);
+  const out = parseDedupResponse(raw, validIds);
+  assert.ok(out);
+  assert.equal(out!.length, 1, "the hallucinated-canonical cluster must be filtered out");
+  assert.equal(out![0].canonical, 100);
+});
+
+test("parseDedupResponse: dedupes a duplicates array containing repeated entries", () => {
+  // Defensive parsing — the model occasionally lists the same duplicate
+  // twice. The downstream gate-render block expects unique entries.
+  const raw = JSON.stringify({
+    clusters: [
+      {
+        canonical: 1,
+        duplicates: [2, 2, 3, 2],
+        rationale: "Canonical #1 keeps; the others restate the same proposal.",
+      },
+    ],
+  });
+  const out = parseDedupResponse(raw);
+  assert.ok(out);
+  assert.equal(out!.length, 1);
+  assert.deepEqual(out![0].duplicates, [2, 3]);
+});
+
+// Schema round-trip test for the RunState extension (issue #150).
+// Optional fields must survive JSON.stringify → JSON.parse without
+// crashing or losing data; equally, a state object that omits the
+// fields entirely must remain a valid RunState shape.
+test("RunState round-trip: duplicateClustersDetected + dedupCostUsd survive JSON serialization", () => {
+  const clusters: DuplicateCluster[] = [
+    {
+      canonical: 100,
+      duplicates: [110, 120],
+      rationale: "Canonical #100 has the most-detailed body of the three.",
+    },
+  ];
+  const original: RunState = {
+    runId: "run-2026-05-05T00-00-00-000Z",
+    targetRepo: "owner/repo",
+    issueRange: { kind: "csv", ids: [100, 110, 120] },
+    parallelism: 1,
+    agents: [],
+    issues: {
+      "100": { status: "pending" },
+      "110": { status: "pending" },
+      "120": { status: "pending" },
+    },
+    tickCount: 0,
+    lastTickAt: "2026-05-05T00:00:00.000Z",
+    startedAt: "2026-05-05T00:00:00.000Z",
+    dryRun: false,
+    duplicateClustersDetected: clusters,
+    dedupCostUsd: 0.0473,
+  };
+  const round: RunState = JSON.parse(JSON.stringify(original));
+  assert.deepEqual(round.duplicateClustersDetected, clusters);
+  assert.equal(round.dedupCostUsd, 0.0473);
+});
+
+test("RunState round-trip: omitted dedup fields stay omitted (back-compat)", () => {
+  // A pre-#150 run-state file has neither field. The interface marks
+  // both optional so the type-checker accepts the omission, and a
+  // round-trip leaves them undefined — never `null`, which would surface
+  // as a falsy-but-present field that breaks `if (state.dedupCostUsd)`
+  // call sites in Phase 2a-ii.
+  const original: RunState = {
+    runId: "run-2026-05-05T00-00-00-000Z",
+    targetRepo: "owner/repo",
+    issueRange: { kind: "all-open" },
+    parallelism: 2,
+    agents: [],
+    issues: {},
+    tickCount: 0,
+    lastTickAt: "2026-05-05T00:00:00.000Z",
+    startedAt: "2026-05-05T00:00:00.000Z",
+    dryRun: true,
+  };
+  const round: RunState = JSON.parse(JSON.stringify(original));
+  assert.equal(round.duplicateClustersDetected, undefined);
+  assert.equal(round.dedupCostUsd, undefined);
+});


### PR DESCRIPTION
Closes #150

## Summary

Phase 2a-i of #133's pre-dispatch deduplication work. Ships the **detection function + schema additions** as a self-contained data-layer change — callable but uncalled. Phase 2a-ii (separate issue) wires the orchestrator integration on top.

## What lands

- **`src/orchestrator/dedup.ts`** (new) — `detectDuplicates({ issues, logger? })` makes a single Opus call (`ORCHESTRATOR_MODEL_DEDUP`, `maxTurns: 1`) over the issue batch and returns `{ clusters, costUsd }`. The Zod-validated parsing logic is split into a pure `parseDedupResponse` helper so unit tests can exercise the rubric without invoking the SDK. Fail-soft on every error path: model failures, exceptions, and malformed JSON return `{ clusters: [], costUsd }` rather than throwing — a flaky pre-flight must never block a run. Defensive validation includes a `validIssueIds` gate that drops hallucinated canonicals, a self-reference filter (`canonical ∈ duplicates`), and duplicate-array de-dup.
- **`src/types.ts`** — adds `DuplicateCluster` interface (`{ canonical, duplicates, rationale }`) and extends `RunState` with optional `duplicateClustersDetected?: DuplicateCluster[]` and `dedupCostUsd?: number` fields. Both optional for back-compat with pre-#150 run-state files.
- **`src/util/dedup.test.ts`** (new) — 10 unit tests: well-formed parse → typed array, rationale references canonical, no-overlap returns `[]` (not `null`), malformed-JSON → `null`, fence-wrapper tolerance, self-reference cluster dropped, hallucinated-canonical dropped via `validIssueIds`, duplicate-array de-duped, `RunState` JSON round-trip with + without the new fields.

## Behavior change

**None.** Nothing in `cli.ts`, the orchestrator, the dispatcher, or the CLI gate calls `detectDuplicates`. The function is exported, typed, and tested but uncalled — exactly as the issue's "Phase 2a-i scope" specifies. Phase 2a-ii's integration adds the call site between triage and `pickAgents`, persists the result into `RunState`, and extends the approval-gate preview.

## Notes on file placement (vs. issue body)

The issue body listed `src/state/runState.ts` as the file to extend with the new run-state fields, but the `RunState` interface itself is defined in `src/types.ts` — `runState.ts` only consumes it. The schema extension lives in `types.ts` (the actual source of truth); no code change was needed in `runState.ts` because `loadRunState` / `saveRunState` are JSON-generic and optional fields automatically survive the round-trip. A round-trip test in `src/util/dedup.test.ts` confirms this.

## Verification

- `npm run typecheck` — clean
- `npm run build` — clean
- `npm test` — **322/322 pass** (10 new dedup tests, 312 pre-existing)

## Out of scope (deferred to Phase 2a-ii / 2b)

- `SetupPreview.duplicateClusters` extension and the gate-render block.
- `src/cli.ts` threading the dedup pass between triage and `pickAgents`.
- Any `--apply-dedup` / `--skip-dedup` flag (Phase 2b's territory).

— Advisory Scope Boundary (agent-916a)
