### PR TITLE
feat(dedup): wire dedup pass into cli + advisory gate render (Phase 2a-ii of #133)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,8 +13,9 @@ import {
 } from "./state/runState.js";
 import { createAgent, loadRegistry, mutateRegistry } from "./state/registry.js";
 import { parseRangeSpec, describeRange } from "./github/range.js";
-import { getIssue, resolveRangeToIssues } from "./github/gh.js";
+import { getIssue, getIssueDetail, resolveRangeToIssues, type IssueDetail } from "./github/gh.js";
 import { pickAgents, runOrchestrator } from "./orchestrator/orchestrator.js";
+import { detectDuplicates } from "./orchestrator/dedup.js";
 import {
   approveSetup,
   buildSetupPreview,
@@ -107,7 +108,7 @@ import { RunCostTracker, resolveBudgetUsd } from "./util/costTracker.js";
 import { formatRunCompletedSentinel } from "./util/runCompletedSentinel.js";
 import { formatRunReport } from "./util/runReport.js";
 import { diffPreview } from "./util/previewDiff.js";
-import type { AgentRecord, IssueRangeSpec, IssueSummary, ResumeContext, RunState } from "./types.js";
+import type { AgentRecord, DuplicateCluster, IssueRangeSpec, IssueSummary, ResumeContext, RunState } from "./types.js";
 import { STATE_DIR } from "./state/runState.js";
 import { defaultRunLogPath, loadRunActivity } from "./state/runActivity.js";
 import path from "node:path";
@@ -560,6 +561,63 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     process.exit(2);
   }
 
+  // Issue #151 (Phase 2a-ii of #133): pre-dispatch dedup pass.
+  // Runs against the triage-passed set so the operator sees clusters of
+  // semantically-overlapping candidates in the gate. Phase 2a-ii is
+  // advisory only — all cluster members still dispatch. Phase 2b layers
+  // `--apply-dedup` to optionally close duplicates with a canonical
+  // cross-reference. Single Opus call (`maxTurns: 1`); fail-soft inside
+  // `detectDuplicates` so a flaky model never blocks a run.
+  const dedupLogger = new Logger({
+    runId: `dedup-${new Date().toISOString().replace(/[:.]/g, "-")}`,
+    verbose: !!opts.verbose,
+  });
+  await dedupLogger.open();
+  let duplicateClusters: DuplicateCluster[] = [];
+  let dedupCostUsd: number | undefined;
+  try {
+    if (dispatchIssues.length < 2) {
+      dedupLogger.info("dedup.bypassed", {
+        reason: "fewer than 2 candidate issues",
+        issueCount: dispatchIssues.length,
+      });
+    } else {
+      // Hoist to a local so the narrowing survives the .map() closure;
+      // TS widens `opts.targetRepo` back to `string | undefined` inside
+      // the arrow even though the line-461 guard rejected `undefined`.
+      const targetRepo = opts.targetRepo;
+      const detailResults = await Promise.all(
+        dispatchIssues.map((i) => getIssueDetail(targetRepo, i.id)),
+      );
+      const issueDetails = detailResults.filter(
+        (d): d is IssueDetail => d !== null,
+      );
+      if (issueDetails.length < 2) {
+        dedupLogger.warn("dedup.insufficient_details", {
+          requested: dispatchIssues.length,
+          fetched: issueDetails.length,
+        });
+      } else {
+        const result = await detectDuplicates({
+          issues: issueDetails,
+          logger: dedupLogger,
+        });
+        duplicateClusters = result.clusters;
+        dedupCostUsd = result.costUsd;
+        // Same accounting pattern as triage: dedup runs before the runId
+        // is minted, but its cost belongs to the same per-run total.
+        costTracker.add(dedupCostUsd);
+        dedupLogger.info("dedup.completed", {
+          issueCount: issueDetails.length,
+          clusterCount: duplicateClusters.length,
+          costUsd: dedupCostUsd,
+        });
+      }
+    }
+  } finally {
+    await dedupLogger.close();
+  }
+
   // Issues with an open vp-dev PR can't be re-dispatched: `git worktree add
   // -b <branch>` collides on the branch the prior run pushed. Filter them
   // before the gate so the user sees the skip in the preview. Per #62 — the
@@ -664,6 +722,8 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     budgetUsd,
     preferAgentId: opts.preferAgent,
     incompleteBranchesAvailable,
+    duplicateClusters,
+    dedupCostUsd,
   });
 
   if (opts.plan) {
@@ -770,6 +830,17 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     // can re-apply it without the operator re-typing the flag (#86).
     maxCostUsd: budgetUsd,
   });
+  // #151 Phase 2a-ii: persist the dedup pass's outcome so post-run audits
+  // can attribute the spend (`dedupCostUsd`) and read which clusters were
+  // surfaced (`duplicateClustersDetected`) without re-deriving from the
+  // JSONL log. Both fields are optional — back-compat with run-state
+  // files written before this surface existed (#150 shipped the schema).
+  if (duplicateClusters.length > 0) {
+    state.duplicateClustersDetected = duplicateClusters;
+  }
+  if (dedupCostUsd !== undefined) {
+    state.dedupCostUsd = dedupCostUsd;
+  }
   await saveRunState(state);
   await writeCurrentRunId(runId);
 
@@ -783,6 +854,12 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     range: opts.issues,
     issueCount: dispatchIssues.length,
     triageSkippedCount: triageSkipped.length,
+    // #151 Phase 2a-ii: surface dedup outcome on the run-start line so
+    // post-run audits can count clusters without parsing the dedup
+    // logger's separate file. `null` (not omitted) when the pass was
+    // bypassed — distinguishes "no candidates" from "ran free".
+    duplicateClusterCount: duplicateClusters.length,
+    dedupCostUsd: dedupCostUsd ?? null,
     dryRun: !!opts.dryRun,
     // `null` (not omitted) when no budget is set so log consumers can
     // distinguish "Phase-1 run with no cap" from "older log without

--- a/src/orchestrator/setup.test.ts
+++ b/src/orchestrator/setup.test.ts
@@ -1,0 +1,141 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { formatSetupPreview, type SetupPreview } from "./setup.js";
+import type { DuplicateCluster } from "../types.js";
+
+// Issue #151 (Phase 2a-ii of #133): integration tests for the dedup
+// advisory block + dedup-cost line. Pure-function tests against
+// `formatSetupPreview` — no SDK, no orchestrator, no live model. The
+// surface under test is the gate-text rendering that the user reads
+// before y/N (and that `hashPreview` binds into the plan→confirm token).
+
+function basePreview(overrides: Partial<SetupPreview> = {}): SetupPreview {
+  return {
+    targetRepo: "octocat/repo",
+    targetRepoPath: "/tmp/octocat-repo",
+    rangeLabel: "100-110",
+    openIssues: [
+      { id: 100, title: "first", state: "open", labels: [] },
+      { id: 110, title: "second", state: "open", labels: [] },
+    ],
+    closedSkipped: [],
+    parallelism: 2,
+    dryRun: false,
+    resume: false,
+    reusedAgents: [],
+    newAgentsToMint: 1,
+    authorized: 2,
+    planned: 1,
+    specialistCount: 0,
+    generalCount: 1,
+    overloadWarnings: [],
+    triageSkipped: [],
+    openPrSkipped: [],
+    costForecast: [],
+    budgetExceededSkipped: [],
+    incompleteBranchesAvailable: [],
+    duplicateClusters: [],
+    ...overrides,
+  };
+}
+
+test("formatSetupPreview: empty duplicateClusters renders no advisory block", () => {
+  const text = formatSetupPreview(basePreview({ duplicateClusters: [] }));
+  assert.doesNotMatch(
+    text,
+    /duplicate cluster/i,
+    "no advisory block when clusters is empty",
+  );
+  assert.doesNotMatch(
+    text,
+    /Phase 2b will add --apply-dedup/,
+    "no Phase 2b reference when no clusters were detected",
+  );
+});
+
+test("formatSetupPreview: non-empty duplicateClusters renders the advisory block + rationale", () => {
+  const clusters: DuplicateCluster[] = [
+    {
+      canonical: 100,
+      duplicates: [110, 120],
+      rationale:
+        "Canonical #100 has the most-detailed body; #110 and #120 restate the same proposal.",
+    },
+  ];
+  const text = formatSetupPreview(basePreview({ duplicateClusters: clusters }));
+  assert.match(text, /1 duplicate cluster\(s\) detected/);
+  assert.match(text, /advisory — all issues still dispatch/);
+  assert.match(text, /canonical #100\s+duplicates #110, #120/);
+  // Rationale is rendered indented beneath the cluster line.
+  assert.match(text, /Canonical #100 has the most-detailed body/);
+  assert.match(text, /Phase 2b will add --apply-dedup/);
+});
+
+test("formatSetupPreview: multiple clusters each render canonical + duplicates + rationale", () => {
+  const clusters: DuplicateCluster[] = [
+    {
+      canonical: 5,
+      duplicates: [6],
+      rationale: "Canonical #5 keeps; #6 restates the same bug.",
+    },
+    {
+      canonical: 50,
+      duplicates: [51, 52],
+      rationale: "Canonical #50 has more comments than #51/#52.",
+    },
+  ];
+  const text = formatSetupPreview(basePreview({ duplicateClusters: clusters }));
+  assert.match(text, /2 duplicate cluster\(s\) detected/);
+  assert.match(text, /canonical #5\s+duplicates #6/);
+  assert.match(text, /canonical #50\s+duplicates #51, #52/);
+});
+
+test("formatSetupPreview: dedupCostUsd renders parallel to triageCostUsd", () => {
+  // Both lines present — the user sees what was already spent on each
+  // pre-dispatch pass before y/N. Same "already incurred" framing.
+  const text = formatSetupPreview(
+    basePreview({ triageCostUsd: 0.0123, dedupCostUsd: 0.0456 }),
+  );
+  assert.match(text, /Triage cost:\s+~\$0\.0123 \(already incurred\)/);
+  assert.match(text, /Dedup cost:\s+~\$0\.0456 \(already incurred\)/);
+});
+
+test("formatSetupPreview: undefined dedupCostUsd omits the line entirely (matches triage convention)", () => {
+  // Mirrors #55 — distinguish "pass was bypassed" (omit) from "ran free"
+  // (would show $0.0000). The renderer keys on `=== undefined`.
+  const text = formatSetupPreview(basePreview({ dedupCostUsd: undefined }));
+  assert.doesNotMatch(text, /Dedup cost:/);
+});
+
+test("formatSetupPreview: dedupCostUsd 0 still renders the line", () => {
+  // A bypass returns `undefined`; a real call that costs $0 (cache hit
+  // semantics, future-proofing) still renders so the audit trail shows
+  // the pass actually executed.
+  const text = formatSetupPreview(basePreview({ dedupCostUsd: 0 }));
+  assert.match(text, /Dedup cost:\s+~\$0\.0000 \(already incurred\)/);
+});
+
+test("formatSetupPreview: cluster set + dedup cost are bound into the rendered text (previewHash coverage)", () => {
+  // `hashPreview` runs on the formatted text, so anything rendered here
+  // is automatically bound into the plan→confirm token. Two snapshots
+  // that differ only in the cluster set MUST produce different text;
+  // otherwise drift between --plan and --confirm would silently pass
+  // the hash check.
+  const a = formatSetupPreview(basePreview({ duplicateClusters: [] }));
+  const b = formatSetupPreview(
+    basePreview({
+      duplicateClusters: [
+        {
+          canonical: 1,
+          duplicates: [2],
+          rationale: "Canonical #1 keeps.",
+        },
+      ],
+    }),
+  );
+  assert.notEqual(a, b, "cluster drift must change rendered preview text");
+
+  const c = formatSetupPreview(basePreview({ dedupCostUsd: undefined }));
+  const d = formatSetupPreview(basePreview({ dedupCostUsd: 0.01 }));
+  assert.notEqual(c, d, "dedup cost drift must change rendered preview text");
+});

--- a/src/orchestrator/setup.ts
+++ b/src/orchestrator/setup.ts
@@ -1,5 +1,5 @@
 import { createInterface } from "node:readline/promises";
-import type { AgentRegistryFile, IssueSummary } from "../types.js";
+import type { AgentRegistryFile, DuplicateCluster, IssueSummary } from "../types.js";
 import { pickAgents, type PickedAgent } from "./orchestrator.js";
 import {
   detectOverload,
@@ -110,6 +110,27 @@ export interface SetupPreview {
    * salvage refs drifted between plan and confirm forces a fresh plan.
    */
   incompleteBranchesAvailable: IncompleteBranchAvailable[];
+  /**
+   * Issue #151 (Phase 2a-ii of #133): clusters of semantically-duplicate
+   * issues identified by the pre-dispatch dedup pass (#150). Always an
+   * array — empty when the pass detected no overlap or was bypassed
+   * (e.g. fewer than 2 candidates). The advisory block renders only when
+   * the array is non-empty; rendering through `formatSetupPreview` binds
+   * the cluster set into the previewHash so plan→confirm rejects drift.
+   *
+   * Phase 2a-ii is **advisory only**: clusters are surfaced, all issues
+   * still dispatch. Phase 2b layers `--apply-dedup` on top to optionally
+   * close duplicates with a cross-reference comment.
+   */
+  duplicateClusters: DuplicateCluster[];
+  /**
+   * Issue #151: USD cost of the dedup pass's single Opus call. Surfaced
+   * in the gate parallel to `triageCostUsd`. Optional — `undefined` when
+   * the pass was bypassed (fewer than 2 candidates) so the renderer
+   * omits the line entirely instead of showing "$0.0000", mirroring the
+   * "no triage" vs "free triage" distinction from #55.
+   */
+  dedupCostUsd?: number;
 }
 
 export interface BuildPreviewInput {
@@ -141,6 +162,14 @@ export interface BuildPreviewInput {
    *  clone (or are running in a test harness) pass `[]` / omit; the
    *  preview renders no section in that case. */
   incompleteBranchesAvailable?: IncompleteBranchAvailable[];
+  /** Issue #151 (Phase 2a-ii): caller-provided dedup detection result.
+   *  Empty array (or omitted) renders no advisory section — same shape
+   *  as `triageSkipped` / `openPrSkipped`. */
+  duplicateClusters?: DuplicateCluster[];
+  /** Issue #151: USD cost of the dedup pass. `undefined` (or omitted)
+   *  when the pass was bypassed; the renderer skips the line entirely
+   *  in that case rather than showing $0.0000. */
+  dedupCostUsd?: number;
 }
 
 export async function buildSetupPreview(input: BuildPreviewInput): Promise<SetupPreview> {
@@ -183,6 +212,8 @@ export async function buildSetupPreview(input: BuildPreviewInput): Promise<Setup
     budgetUsd: input.budgetUsd,
     preferAgentId: input.preferAgentId,
     incompleteBranchesAvailable: input.incompleteBranchesAvailable ?? [],
+    duplicateClusters: input.duplicateClusters ?? [],
+    dedupCostUsd: input.dedupCostUsd,
   };
 }
 
@@ -211,6 +242,13 @@ export function formatSetupPreview(p: SetupPreview): string {
   // bypassed via --include-non-ready (per issue #55: not zero-valued).
   if (p.triageCostUsd !== undefined) {
     lines.push(`  Triage cost:    ~$${p.triageCostUsd.toFixed(4)} (already incurred)`);
+  }
+  // Issue #151 (Phase 2a-ii of #133): dedup cost — same "already
+  // incurred" framing as triage. Omitted entirely when the pass was
+  // bypassed (fewer than 2 candidates) so the operator can distinguish
+  // "no dedup ran" from "dedup ran free".
+  if (p.dedupCostUsd !== undefined) {
+    lines.push(`  Dedup cost:     ~$${p.dedupCostUsd.toFixed(4)} (already incurred)`);
   }
   // Cost ceiling — the anchor for the per-issue forecast block below.
   // Shown only when the user passed --max-cost-usd / VP_DEV_MAX_COST_USD;
@@ -270,6 +308,29 @@ export function formatSetupPreview(p: SetupPreview): string {
     }
     lines.push(
       "  The PR from the prior run is the in-flight work. Let it land (or close it) before re-dispatching.",
+    );
+    lines.push("");
+  }
+
+  // Issue #151 (Phase 2a-ii of #133): advisory dedup block. Phase 2a-ii
+  // is awareness-only — every cluster member still dispatches. Phase 2b
+  // layers `--apply-dedup` to optionally close duplicates with a
+  // canonical cross-reference comment. Rendering the cluster set here
+  // also binds it into `previewHash` (via `formatSetupPreview`), so a
+  // dedup outcome that drifts between `--plan` and `--confirm` rejects
+  // the confirm and forces a fresh plan — same protection #149 already
+  // gives triage.
+  if (p.duplicateClusters.length > 0) {
+    lines.push(
+      `${p.duplicateClusters.length} duplicate cluster(s) detected (advisory — all issues still dispatch):`,
+    );
+    for (const c of p.duplicateClusters) {
+      const dups = c.duplicates.map((d) => `#${d}`).join(", ");
+      lines.push(`  canonical #${c.canonical}  duplicates ${dups}`);
+      lines.push(`    ${c.rationale}`);
+    }
+    lines.push(
+      "  Phase 2b will add --apply-dedup to optionally close duplicates with a canonical cross-reference.",
     );
     lines.push("");
   }


### PR DESCRIPTION
Closes #151. Phase 2a-ii of #133's dedup work; consumes #150's `detectDuplicates` + schema.

## Summary
- **`src/cli.ts`** — call `detectDuplicates` between triage and `pickAgents` against the triage-passed candidate set. Always runs (no flag yet — Phase 2b owns `--apply-dedup` / `--skip-dedup`). Fail-soft inside `detectDuplicates` already keeps a flaky model from blocking a run; the dedup logger uses a `dedup-<ts>` prefixed runId mirroring the triage logger pattern, since the real runId isn't minted until after the gate.
- **`src/orchestrator/setup.ts`** — extend `SetupPreview` with `duplicateClusters: DuplicateCluster[]` and `dedupCostUsd?: number`. Render an advisory block ("`N duplicate cluster(s) detected (advisory — all issues still dispatch):`") and a `Dedup cost: ~$X.XXXX (already incurred)` line parallel to `Triage cost:`.
- **`src/orchestrator/setup.test.ts`** (new) — 7 pure-function tests against `formatSetupPreview` covering: empty clusters → no block, non-empty → block + rationale, multi-cluster, dedup-cost line presence/absence, $0 vs `undefined` distinction, and a previewHash-coverage smoke test that confirms cluster/cost drift produces different rendered text (so `hashPreview` automatically binds it into the plan→confirm token).

## Acceptance
- ✅ `vp-dev run --plan` against an issue set with overlap will produce a "Duplicate clusters detected" block in the gate (model-generated rationale per cluster).
- ✅ `dedupCostUsd` surfaced parallel to `triageCostUsd`.
- ✅ All issues continue to dispatch — clusters are surfaced for operator awareness only. No `gh issue close` calls.
- ✅ `RunState.duplicateClustersDetected` / `RunState.dedupCostUsd` populated from the live run when non-empty / defined (back-compat preserved — both optional).
- ✅ `--plan` → `--confirm` previewHash includes the dedup output: rendering through `formatSetupPreview` is what `hashPreview` consumes, so dedup drift between plan and confirm rejects the confirm with the unified-line-diff treatment from #137. Tested via the `notEqual` snapshot in `setup.test.ts`.

## Out of scope (Phase 2b)
- `--apply-dedup` flag + `gh issue close` integration.
- `--skip-dedup` flag.
- `RunConfirmParams` extension.

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm run build` — passes
- [x] `npm test` — 333 tests pass (7 new in `src/orchestrator/setup.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)