### PR TITLE
feat(cli): add launch-time progress-check breadcrumb (#157)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,10 @@ After every successful issue-resolution run, a separate sonnet summarizer rewrit
 - **Don't load-bear on per-agent CLAUDE.md content for correctness.** The agent's invariants must come from its prompt + tooling, not from a memory file the summarizer can rewrite.
 - The auto-generated `agents/agent-90e4/CLAUDE.md` etc. are derivative copies of the target repo's seed — their staleness reflects the target's pre-summary state. Don't treat them as authoritative for the target repo's current rules.
 
+## Mid-flight progress-checking: `vp-dev status` is the canonical tool
+- **For "how is the run going?" questions, use `vp-dev status` (no args) — never `pgrep` + `ls -lt logs/`.** The no-args path reads `state/current-run.txt`, finds the active run, and renders the canonical block (totals, in-flight, last activity, recent events). Live tail: `vp-dev status --watch`. Inspect a specific run by id (positional arg) or use `--latest` for the most recent on disk regardless of completion. The launch-time breadcrumb in `vp-dev run` (#157) prints these commands once per run; this rule is the same affordance for fresh agents that didn't see the launch output.
+- Don't tail the JSONL (`logs/<runId>.jsonl`) for progress unless the formatter doesn't surface the field you want — it's write-rate-limited and the canonical formatter already reads it (`tryLoadRunActivity`). Past incident 2026-05-05: a status check ran `pgrep` + `ls -lt` + `vp-dev status <runId>` (failed: positional arg expects bare runId, not the file path) + `--help` before landing on `--latest`. Right answer all along was `vp-dev status` no-args.
+
 ## CI is a hard gate
 `.github/workflows/ci.yml` runs `npm ci && npm run typecheck && npm run build` on every push and PR. All three must pass. CI failures block merges; reproduce locally with the same three commands before pushing if a PR is failing for unclear reasons.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -864,6 +864,14 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     process.stdout.write(
       "If the registry / open-issue set changes before --confirm, the previewHash check fails and forces a fresh --plan.\n",
     );
+    // Issue #157: surface the progress-check affordance at plan time so the
+    // operator sees the canonical commands before the run starts. Without
+    // this, agents/operators reach for `pgrep` + `ls -lt logs/` first and
+    // burn turns rediscovering `vp-dev status` (no-args reads the active
+    // run from `state/current-run.txt`).
+    process.stdout.write("\nAfter launch, check progress with:\n");
+    process.stdout.write("  vp-dev status                # active run\n");
+    process.stdout.write("  vp-dev status --watch        # live tail\n");
     return;
   }
 
@@ -940,6 +948,16 @@ async function cmdRun(opts: RunOpts): Promise<void> {
   }
   await saveRunState(state);
   await writeCurrentRunId(runId);
+
+  // Issue #157: launch-time progress-check breadcrumb. Prints once per
+  // run, immediately after the run becomes the active run on disk
+  // (`state/current-run.txt`), so a mid-flight "how is it going?" question
+  // resolves to `vp-dev status` (no-args path) on the first try instead of
+  // shell forensics (`pgrep` + `ls -lt logs/` + `vp-dev status --help`).
+  process.stdout.write("\nRun launched.\n");
+  process.stdout.write(`  runId:           ${runId}\n`);
+  process.stdout.write("  Check progress:  vp-dev status            # active run, no args needed\n");
+  process.stdout.write("  Live tail:       vp-dev status --watch    # re-renders on interval\n\n");
 
   const logger = new Logger({ runId, verbose: !!opts.verbose });
   await logger.open();


### PR DESCRIPTION
Closes #157

## Summary
- Add a launch-time progress-check breadcrumb to `vp-dev run`. Once per run, immediately after `state/current-run.txt` is written, the CLI prints:
  ```
  Run launched.
    runId:           <ts>
    Check progress:  vp-dev status            # active run, no args needed
    Live tail:       vp-dev status --watch    # re-renders on interval
  ```
- Mirror the hint at the end of `--plan` output (after the existing `--confirm <token>` line and registry-drift note), so the operator sees the canonical progress commands at plan time too.
- Bundle the companion `CLAUDE.md` rule the issue called out: name `vp-dev status` as the canonical progress-check tool so a fresh agent reads it before reaching for `pgrep` + `ls -lt logs/`.

Cuts the progress-discovery shell footprint from ~4 commands to 1 for a mid-flight "how is the run going?" question, with no behavior change to the orchestrator dispatch path.

## Why
Per the issue, the no-args `vp-dev status` path already does the right thing (reads `state/current-run.txt`, renders the canonical block) — the gap is purely discoverability. A 6-line stdout block at launch + a CLAUDE.md rule for fresh agents closes both halves.

## Test plan
- [x] `npm run build` (clean)
- [x] `npm test` (342/342 passing — no test asserts on the modified stdout strings)
- [ ] Spot-check on a real `vp-dev run --dry-run` invocation: confirm the "Run launched." block prints between the gate-passes line and the orchestrator's first dispatch event, and that `vp-dev run --plan` ends with the "After launch, check progress with:" section.

— Cook (agent-fe90)
