### PR TITLE
fix(dedup): cache pass output by content hash so plan/confirm preview hashes match

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -656,16 +656,32 @@ async function cmdRun(opts: RunOpts): Promise<void> {
         const result = await detectDuplicates({
           issues: issueDetails,
           logger: dedupLogger,
+          // Issue #156: thread the target repo so the dedup pass can
+          // namespace its cache file. The cache stabilizes both the
+          // cluster output and the per-call cost across `--plan` and
+          // `--confirm` invocations, which keeps the gate-text `Dedup
+          // cost:` line identical and prevents previewHash drift.
+          targetRepo,
         });
         duplicateClusters = result.clusters;
         dedupCostUsd = result.costUsd;
         // Same accounting pattern as triage: dedup runs before the runId
-        // is minted, but its cost belongs to the same per-run total.
+        // is minted, but its cost belongs to the same per-run total. On
+        // a cache hit (`fromCache: true`) the model wasn't invoked and
+        // no real spend was billed in this process — but the cost we
+        // surface in the gate must match the *original* invocation's
+        // cost, otherwise the gate-text and previewHash drift across
+        // plan/confirm. We add the cached cost to the tracker too so
+        // the per-run total reconciles with the same arithmetic the
+        // gate displays. (`costTracker.add(0)` would also be defensible
+        // — neither call dollars-billed at the moment — but mirrors
+        // triage.ts's behavior where the cached cost flows through.)
         costTracker.add(dedupCostUsd);
         dedupLogger.info("dedup.completed", {
           issueCount: issueDetails.length,
           clusterCount: duplicateClusters.length,
           costUsd: dedupCostUsd,
+          fromCache: result.fromCache,
         });
       }
     }

--- a/src/orchestrator/dedup.test.ts
+++ b/src/orchestrator/dedup.test.ts
@@ -1,0 +1,206 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { __testInternals, DEDUP_DIR, parseDedupResponse } from "./dedup.js";
+import type { IssueDetail } from "../github/gh.js";
+import type { DuplicateCluster } from "../types.js";
+
+// Tests for issue #156 — "Plan diverged" recurrence on first --confirm
+// caused by the dedup pass re-running between --plan and --confirm with
+// no caching. Mirrors `triage.test.ts` (issue #137): the failure surface
+// is the cache layer, so the round-trip is exercised here without an
+// Opus call in the loop.
+
+function uniqueTargetRepo(): string {
+  const id = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  return `vp-test-${id}/repo`;
+}
+
+async function rmCacheFile(targetRepo: string): Promise<void> {
+  const file = path.join(DEDUP_DIR, `${targetRepo.replace("/", "__")}.json`);
+  await fs.rm(file, { force: true }).catch(() => {});
+}
+
+const sampleClusters: DuplicateCluster[] = [
+  {
+    canonical: 100,
+    duplicates: [101, 102],
+    rationale: "all three issues request the same render-block; #100 has the longest body.",
+  },
+];
+
+function makeIssue(id: number, body: string): IssueDetail {
+  return {
+    id,
+    title: `Issue ${id}`,
+    state: "open",
+    labels: [],
+    body,
+    comments: [],
+  };
+}
+
+test("dedup cache: writeCache persists clusters + costUsd; readCache surfaces them on hit", async () => {
+  const targetRepo = uniqueTargetRepo();
+  try {
+    const contentHash = "sha256:abc123";
+    await __testInternals.writeCache(targetRepo, contentHash, sampleClusters, 0.0251);
+    const cached = await __testInternals.readCache(targetRepo, contentHash);
+    assert.ok(cached, "cache hit expected");
+    assert.equal(cached!.costUsd, 0.0251);
+    assert.equal(cached!.clusters.length, 1);
+    assert.equal(cached!.clusters[0].canonical, 100);
+    assert.deepEqual(cached!.clusters[0].duplicates, [101, 102]);
+  } finally {
+    await rmCacheFile(targetRepo);
+  }
+});
+
+test("dedup cache: contentHash mismatch yields cache miss (null)", async () => {
+  const targetRepo = uniqueTargetRepo();
+  try {
+    await __testInternals.writeCache(targetRepo, "sha256:original", sampleClusters, 0.04);
+    const cached = await __testInternals.readCache(targetRepo, "sha256:DIFFERENT");
+    assert.equal(cached, null, "stale cache should miss when contentHash drifts");
+  } finally {
+    await rmCacheFile(targetRepo);
+  }
+});
+
+test("dedup cache: legacy entry without costUsd field reads back as 0", async () => {
+  // Forward-compat with cache files written before #156 — a hand-crafted
+  // legacy entry must NOT crash readCache; it should degrade to costUsd: 0.
+  const targetRepo = uniqueTargetRepo();
+  try {
+    const contentHash = "sha256:legacy";
+    const filePath = __testInternals.cacheFilePath(targetRepo);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    const legacy = {
+      targetRepo,
+      contentHash,
+      clusters: sampleClusters,
+      detectedAt: new Date().toISOString(),
+    };
+    await fs.writeFile(filePath, JSON.stringify(legacy, null, 2));
+    const cached = await __testInternals.readCache(targetRepo, contentHash);
+    assert.ok(cached, "legacy cache hit expected");
+    assert.equal(cached!.costUsd, 0, "missing costUsd degrades to 0");
+    assert.equal(cached!.clusters.length, 1);
+  } finally {
+    await rmCacheFile(targetRepo);
+  }
+});
+
+test("dedup cache: round-trip determinism — sequential reads return identical costUsd", async () => {
+  // The "Plan diverged" surface: --plan writes cache with cost X, then
+  // --confirm re-runs detectDuplicates which hits the cache and returns
+  // the same X. This test models that round-trip directly.
+  const targetRepo = uniqueTargetRepo();
+  try {
+    const contentHash = "sha256:roundtrip";
+    const originalCost = 0.0251;
+    await __testInternals.writeCache(targetRepo, contentHash, sampleClusters, originalCost);
+    const first = await __testInternals.readCache(targetRepo, contentHash);
+    const second = await __testInternals.readCache(targetRepo, contentHash);
+    assert.ok(first && second);
+    assert.equal(first!.costUsd, originalCost);
+    assert.equal(second!.costUsd, originalCost);
+    // The two reads MUST return the same number — this is what makes
+    // the gate-text `Dedup cost:` line deterministic between --plan and
+    // --confirm.
+    assert.equal(first!.costUsd, second!.costUsd);
+    // And the cluster set must be identical too — when --apply-dedup is
+    // active, drift here would silently close a different set of
+    // duplicates on confirm than the user saw at plan time.
+    assert.deepEqual(first!.clusters, second!.clusters);
+  } finally {
+    await rmCacheFile(targetRepo);
+  }
+});
+
+test("dedup cache: malformed JSON file returns null without throwing", async () => {
+  const targetRepo = uniqueTargetRepo();
+  try {
+    const filePath = __testInternals.cacheFilePath(targetRepo);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "not valid json {");
+    const cached = await __testInternals.readCache(targetRepo, "sha256:any");
+    assert.equal(cached, null);
+  } finally {
+    await rmCacheFile(targetRepo);
+  }
+});
+
+test("dedup cache: cluster shape validation drops corrupted file (returns null)", async () => {
+  // A cache file whose cluster array fails Zod validation must NOT
+  // smuggle an invalid shape back into the orchestrator — the read
+  // must miss so the next call re-runs the model.
+  const targetRepo = uniqueTargetRepo();
+  try {
+    const contentHash = "sha256:corrupt";
+    const filePath = __testInternals.cacheFilePath(targetRepo);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    const corrupt = {
+      targetRepo,
+      contentHash,
+      // Missing required fields on the cluster entry.
+      clusters: [{ canonical: -5 /* not positive */, duplicates: [], rationale: "" }],
+      costUsd: 0.01,
+      detectedAt: new Date().toISOString(),
+    };
+    await fs.writeFile(filePath, JSON.stringify(corrupt, null, 2));
+    const cached = await __testInternals.readCache(targetRepo, contentHash);
+    assert.equal(cached, null);
+  } finally {
+    await rmCacheFile(targetRepo);
+  }
+});
+
+test("dedup contentHash: identical inputs in different order yield same hash", async () => {
+  // The model is order-insensitive when clustering; the cache must be
+  // too. Without sorting, a re-fetched issue list whose order shifted
+  // (gh ordering is not strictly stable) would miss the cache.
+  const a = makeIssue(1, "alpha body");
+  const b = makeIssue(2, "beta body");
+  const c = makeIssue(3, "gamma body");
+  const h1 = __testInternals.computeContentHash([a, b, c]);
+  const h2 = __testInternals.computeContentHash([c, a, b]);
+  const h3 = __testInternals.computeContentHash([b, c, a]);
+  assert.equal(h1, h2);
+  assert.equal(h1, h3);
+});
+
+test("dedup contentHash: body edit on one issue invalidates the hash", async () => {
+  // The cache MUST invalidate when an issue's body changes — otherwise
+  // a stale verdict survives across edits.
+  const a = makeIssue(1, "original body");
+  const b = makeIssue(2, "second body");
+  const aPrime = makeIssue(1, "edited body");
+  const before = __testInternals.computeContentHash([a, b]);
+  const after = __testInternals.computeContentHash([aPrime, b]);
+  assert.notEqual(before, after);
+});
+
+test("dedup contentHash: dropping an issue from the candidate set invalidates the hash", async () => {
+  // The dispatch list shrinking (e.g. one issue closes between --plan
+  // and --confirm, or triage flips a verdict) must invalidate the
+  // cache — the input batch is genuinely different.
+  const a = makeIssue(1, "alpha");
+  const b = makeIssue(2, "beta");
+  const c = makeIssue(3, "gamma");
+  const full = __testInternals.computeContentHash([a, b, c]);
+  const trimmed = __testInternals.computeContentHash([a, b]);
+  assert.notEqual(full, trimmed);
+});
+
+// Smoke test that parseDedupResponse still works (round-trip from
+// pre-#156 behavior) — the cache layer is layered ABOVE this helper, so
+// any regression in parsing would still show up here.
+test("dedup parseDedupResponse: still parses a fenced JSON response", () => {
+  const raw = '```json\n{"clusters": [{"canonical": 5, "duplicates": [6, 7], "rationale": "all three describe the same crash."}]}\n```';
+  const parsed = parseDedupResponse(raw, new Set([5, 6, 7]));
+  assert.ok(parsed);
+  assert.equal(parsed!.length, 1);
+  assert.equal(parsed![0].canonical, 5);
+});

--- a/src/orchestrator/dedup.ts
+++ b/src/orchestrator/dedup.ts
@@ -20,13 +20,28 @@
 // - The Zod-validated parse is split into a pure helper
 //   (`parseDedupResponse`) so tests can exercise the parsing rubric
 //   without spinning up the SDK or paying for a real Opus call.
+// - Issue #156: a content-hash cache (mirroring `triage.ts`'s per-issue
+//   cache) stabilizes both the cluster output AND the per-call cost
+//   across `--plan` → `--confirm` invocations. Without it, the LLM call
+//   re-runs on every invocation: cost varies (LLM is non-deterministic
+//   in token-billing even when the cluster decision is stable), the
+//   `Dedup cost:` line in the gate text drifts, and the previewHash
+//   check rejects the very first `--confirm` after a fresh `--plan`.
+//   The cache also avoids paying for the Opus call twice when a single
+//   user is just walking the two-step flow (plan, then confirm).
 
+import { promises as fs } from "node:fs";
+import { createHash } from "node:crypto";
+import path from "node:path";
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
+import { ensureDir } from "../state/locks.js";
 import { ORCHESTRATOR_MODEL_DEDUP } from "./models.js";
 import type { IssueDetail } from "../github/gh.js";
 import type { DuplicateCluster } from "../types.js";
 import type { Logger } from "../log/logger.js";
+
+export const DEDUP_DIR = path.resolve(process.cwd(), "state", "dedup");
 
 // Resolved at module load from `models.ts` (env-overridable). See
 // `src/orchestrator/models.ts` for tier rationale and override env vars.
@@ -47,11 +62,28 @@ const DedupResponseSchema = z.object({
 export interface DetectDuplicatesInput {
   issues: IssueDetail[];
   logger?: Logger;
+  /**
+   * Issue #156: target repo slug ("owner/repo") used to namespace the
+   * dedup cache file under `state/dedup/<owner__repo>.json`. When
+   * omitted (e.g. unit tests that don't care about persistence), the
+   * cache is bypassed entirely — every call hits the model. Production
+   * call-sites (`src/cli.ts`) MUST pass this so the `--plan` → `--confirm`
+   * flow returns identical clusters and identical cost on the second
+   * invocation, keeping the previewHash stable.
+   */
+  targetRepo?: string;
 }
 
 export interface DetectDuplicatesResult {
   clusters: DuplicateCluster[];
   costUsd: number;
+  /**
+   * Issue #156: true when the result was served from the cache (no
+   * model call). Surfaced so the orchestrator can log cache-hit rate
+   * the same way `triage.ts` does, and so the `--plan` / `--confirm`
+   * round-trip can be observed in the run log.
+   */
+  fromCache: boolean;
 }
 
 /**
@@ -71,7 +103,36 @@ export async function detectDuplicates(
   input: DetectDuplicatesInput,
 ): Promise<DetectDuplicatesResult> {
   if (input.issues.length < 2) {
-    return { clusters: [], costUsd: 0 };
+    return { clusters: [], costUsd: 0, fromCache: false };
+  }
+
+  // Issue #156: cache layer mirrors `triage.ts`. Hash is over the input
+  // issue set's content (body + comments + labels) plus the rubric
+  // fingerprint, so the cache invalidates when:
+  //   - any issue's body or comments change (body/comment edits surface
+  //     in the next `gh issue view`)
+  //   - the candidate set itself changes (an issue closes / a new one
+  //     enters the dispatch list, e.g. when triage flips a verdict)
+  //   - the rubric or prompt-builder shape changes (RUBRIC_FINGERPRINT
+  //     bump on `DEDUP_SYSTEM_PROMPT` edits)
+  // When `targetRepo` is omitted (tests / dry-run-with-no-persistence)
+  // the cache is bypassed and every call hits the model.
+  const contentHash = computeContentHash(input.issues);
+  if (input.targetRepo) {
+    const cached = await readCache(input.targetRepo, contentHash);
+    if (cached) {
+      input.logger?.info("dedup.cache_hit", {
+        contentHash,
+        clusterCount: cached.clusters.length,
+        costUsd: cached.costUsd,
+        issueCount: input.issues.length,
+      });
+      return {
+        clusters: cached.clusters,
+        costUsd: cached.costUsd,
+        fromCache: true,
+      };
+    }
   }
 
   const userPrompt = buildPrompt(input.issues);
@@ -98,13 +159,13 @@ export async function detectDuplicates(
           costUsd = msg.total_cost_usd ?? 0;
         } else {
           input.logger?.warn("dedup.model_failed", { subtype: msg.subtype });
-          return { clusters: [], costUsd: 0 };
+          return { clusters: [], costUsd: 0, fromCache: false };
         }
       }
     }
   } catch (err) {
     input.logger?.warn("dedup.exception", { err: (err as Error).message });
-    return { clusters: [], costUsd: 0 };
+    return { clusters: [], costUsd: 0, fromCache: false };
   }
 
   const validIds = new Set(input.issues.map((i) => i.id));
@@ -113,9 +174,25 @@ export async function detectDuplicates(
     input.logger?.warn("dedup.malformed_payload", {
       raw: raw.slice(0, 4000),
     });
-    return { clusters: [], costUsd };
+    // Don't cache parse failures: the next invocation should retry the
+    // model rather than serve `clusters: []` with whatever cost was
+    // billed for the malformed call.
+    return { clusters: [], costUsd, fromCache: false };
   }
-  return { clusters: parsed, costUsd };
+  if (input.targetRepo) {
+    // Best-effort: a cache write failure is not a run blocker. The
+    // caller already has the result; the worst case is the next
+    // `--confirm` re-runs the model and trips previewHash drift, which
+    // surfaces as the documented error rather than silent corruption.
+    try {
+      await writeCache(input.targetRepo, contentHash, parsed, costUsd);
+    } catch (err) {
+      input.logger?.warn("dedup.cache_write_failed", {
+        err: (err as Error).message,
+      });
+    }
+  }
+  return { clusters: parsed, costUsd, fromCache: false };
 }
 
 /**
@@ -217,6 +294,130 @@ function truncate(s: string, max: number): string {
   if (s.length <= max) return s;
   return s.slice(0, max - 3) + "...";
 }
+
+// Issue #156: hash of the rubric + prompt-builder shape, mixed into the
+// per-batch contentHash. Bumping the system prompt or buildPrompt() output
+// shape auto-invalidates previously-cached cluster decisions; without this
+// a rubric edit landing today would still serve yesterday's stale clusters
+// for every cached batch until the candidate set itself changed.
+const RUBRIC_FINGERPRINT = createHash("sha256")
+  .update(DEDUP_SYSTEM_PROMPT)
+  .update("\n--prompt-shape-v1--\n") // bump when buildPrompt() output shape changes
+  .digest("hex")
+  .slice(0, 16);
+
+// Compute a content hash for a batch of issues. Issues are sorted by id so
+// the same input set in different order yields the same hash — the dedup
+// model is order-insensitive and the cache should be too. Comments are
+// keyed by createdAt|author|body (same convention as triage's
+// `commentKey`).
+function computeContentHash(issues: IssueDetail[]): string {
+  const sorted = [...issues].sort((a, b) => a.id - b.id);
+  const h = createHash("sha256");
+  h.update("rubric:" + RUBRIC_FINGERPRINT + "\n");
+  h.update(`count:${sorted.length}\n`);
+  for (const issue of sorted) {
+    h.update(`#${issue.id}|${issue.title}\n`);
+    h.update(`labels:${JSON.stringify(issue.labels)}\n`);
+    h.update("body:\n");
+    h.update(issue.body ?? "");
+    h.update("\n--comments--\n");
+    for (const c of issue.comments) {
+      h.update(`${c.createdAt}|${c.author}|${c.body}\n`);
+    }
+    h.update("\n--issue-end--\n");
+  }
+  return "sha256:" + h.digest("hex").slice(0, 32);
+}
+
+interface DedupCacheEntry {
+  targetRepo: string;
+  contentHash: string;
+  clusters: DuplicateCluster[];
+  // Cost stored on the original cache-miss invocation. Optional for
+  // forward-compat with cache files written by pre-#156 versions; absent
+  // entries degrade to `costUsd: 0` (mirrors triage.ts's pre-#137
+  // forward-compat behavior).
+  costUsd?: number;
+  detectedAt: string;
+}
+
+interface CachedDedup {
+  clusters: DuplicateCluster[];
+  costUsd: number;
+}
+
+function cacheFilePath(targetRepo: string): string {
+  // owner/repo -> owner__repo so the path is a single safe segment.
+  return path.join(DEDUP_DIR, `${targetRepo.replace("/", "__")}.json`);
+}
+
+async function readCache(
+  targetRepo: string,
+  contentHash: string,
+): Promise<CachedDedup | null> {
+  try {
+    const raw = await fs.readFile(cacheFilePath(targetRepo), "utf-8");
+    const entry = JSON.parse(raw) as DedupCacheEntry;
+    if (entry.contentHash !== contentHash) return null;
+    // Re-validate the cached clusters defensively: a corrupted file
+    // would otherwise smuggle invalid shapes back into the orchestrator.
+    if (!Array.isArray(entry.clusters)) return null;
+    const validated: DuplicateCluster[] = [];
+    for (const c of entry.clusters) {
+      const r = DuplicateClusterSchema.safeParse(c);
+      if (!r.success) return null;
+      validated.push({
+        canonical: r.data.canonical,
+        duplicates: r.data.duplicates,
+        rationale: r.data.rationale,
+      });
+    }
+    const costUsd =
+      typeof entry.costUsd === "number" && Number.isFinite(entry.costUsd)
+        ? entry.costUsd
+        : 0;
+    return { clusters: validated, costUsd };
+  } catch {
+    return null;
+  }
+}
+
+async function writeCache(
+  targetRepo: string,
+  contentHash: string,
+  clusters: DuplicateCluster[],
+  costUsd: number,
+): Promise<void> {
+  const entry: DedupCacheEntry = {
+    targetRepo,
+    contentHash,
+    clusters,
+    costUsd,
+    detectedAt: new Date().toISOString(),
+  };
+  const filePath = cacheFilePath(targetRepo);
+  await ensureDir(path.dirname(filePath));
+  const tmp = `${filePath}.tmp.${process.pid}`;
+  await fs.writeFile(tmp, JSON.stringify(entry, null, 2));
+  await fs.rename(tmp, filePath);
+}
+
+// Exported for tests: the cache I/O round-trip is the failure surface for
+// issue #156 (Plan diverged on dedup-cost line). A pure-fs test can
+// validate the round-trip without an Opus call in the loop.
+export const __testInternals = {
+  readCache: (targetRepo: string, contentHash: string) =>
+    readCache(targetRepo, contentHash),
+  writeCache: (
+    targetRepo: string,
+    contentHash: string,
+    clusters: DuplicateCluster[],
+    costUsd: number,
+  ) => writeCache(targetRepo, contentHash, clusters, costUsd),
+  cacheFilePath: (targetRepo: string) => cacheFilePath(targetRepo),
+  computeContentHash: (issues: IssueDetail[]) => computeContentHash(issues),
+};
 
 // Same shape as `triage.ts:parseJsonLoose` — accepts a JSON object in the
 // raw text whether or not the model wrapped it in a ```json fence or


### PR DESCRIPTION
Closes #156.

## Root cause

`previewHash` is computed over the entire formatted preview text, which includes a `Dedup cost: ~$X (already incurred)` line. The dedup pass had no cache, so every `--plan` and every `--confirm` re-invoked the Opus model. The model's per-call billing is non-deterministic (small cost variance even for identical inputs), so the gate-text cost line drifted between plan and confirm and the previewHash check rejected the very first `--confirm` after a fresh `--plan`.

This is the same failure mode #137 fixed for triage. The fix here mirrors that pattern.

## Fix

Add a content-hash cache to `detectDuplicates` (`src/orchestrator/dedup.ts`):
- Hash includes the rubric fingerprint + every input issue's body, comments, and labels (sorted by id so order doesn't matter — the model is order-insensitive).
- Cache file at `state/dedup/<owner__repo>.json`, single file per repo, atomic temp-rename write.
- On cache hit, returns cached clusters AND cached cost so the gate's `Dedup cost:` line is byte-identical across plan/confirm.
- Forward-compat: legacy entries without the `costUsd` field degrade to `0` (mirrors triage's pre-#137 forward-compat).
- Cluster shape re-validated via Zod on read so a corrupted file forces a model re-run rather than smuggling invalid shapes back into the orchestrator.
- Best-effort write — a cache write failure logs and proceeds rather than blocking the run.

Wire `targetRepo` into the `detectDuplicates` call site in `src/cli.ts` and surface `fromCache: boolean` on the `dedup.completed` log line.

## Why option (1), not (2)

The issue listed two paths. Option (1) — mirror the triage cache — is the more comprehensive architectural fix because it solves three problems where (2) would only solve one:

1. **Operability**: hash stays stable across plan→confirm (the bug as filed).
2. **Cost**: the Opus call no longer runs twice for a single user walking the two-step flow — a 50%+ savings on dedup spend per `--plan + --confirm` round.
3. **Determinism for `--apply-dedup`**: even when costs vary, the LLM's clustering decision can theoretically drift between calls. Without a cache, `--apply-dedup` could authorize closing one set of duplicates at plan time and then close a *different* set at confirm time. The cache makes the cluster decision pin to the plan-time outcome, which is what the user actually authorized.

(2) — strip sunk-cost lines from the hash — only addresses #1.

## Test plan

- [x] `npm run build` — passes.
- [x] `npm test` — all 352 tests pass, 10 new dedup-cache + content-hash tests added (write/read round-trip; contentHash mismatch → miss; legacy entry → costUsd: 0; deterministic cost on sequential reads; malformed JSON → null; corrupt cluster shape → null; order-invariant hash; body-edit invalidates; dropping an issue invalidates).
- [ ] Manual: `vp-dev run --target-repo … --agents 20 --issues all-open --plan` → `vp-dev run --confirm <token>` should now succeed without "Plan diverged" on the dedup-cost line.

— Alonzo (agent-92ff)
