### PR TITLE
fix(orchestrator): branch overload-warning text on splitter eligibility

### DIFF
--- a/src/agent/split.ts
+++ b/src/agent/split.ts
@@ -18,6 +18,15 @@ export const SPLIT_THRESHOLD_ISSUES = 20;
 export const SPLIT_THRESHOLD_TAGS = 50;
 export const SPLIT_THRESHOLD_BYTES = 30 * 1024;
 
+// Hard floor for the clusterer: with fewer than 4 attributable sections
+// (`<!-- run:... -->`-prefixed blocks) there isn't enough signal to
+// produce 2-3 coherent clusters. Crossed in `proposeSplit` and
+// surfaced via `OverloadVerdict.attributableSections` so the
+// pre-dispatch warning text can branch on splitter eligibility instead
+// of pointing the user at `vp-dev agents split` for an agent the
+// splitter will refuse (issue #161).
+export const SPLIT_MIN_SECTIONS = 4;
+
 // Resolved at module load from `models.ts` (env-overridable). See
 // `src/orchestrator/models.ts` for tier rationale and override env vars.
 const PROPOSAL_MODEL = ORCHESTRATOR_MODEL_SPLIT;
@@ -27,13 +36,22 @@ export interface OverloadVerdict {
   agentId: string;
   reasons: string[];
   claudeMdBytes: number;
+  /**
+   * Count of `<!-- run:... -->`-prefixed sections in the agent's
+   * CLAUDE.md — i.e. summarizer-attributable lessons. Surfaced so
+   * pre-dispatch warning text can distinguish "overloaded AND
+   * splittable" from "overloaded but section-floor blocks the
+   * splitter" (issue #161).
+   */
+  attributableSections: number;
 }
 
 export function detectOverload(
   agent: AgentRecord,
-  claudeMdBytes: number,
+  claudeMd: string,
 ): OverloadVerdict | null {
   const reasons: string[] = [];
+  const claudeMdBytes = Buffer.byteLength(claudeMd, "utf-8");
   if (agent.issuesHandled >= SPLIT_THRESHOLD_ISSUES) {
     reasons.push(`issuesHandled=${agent.issuesHandled} >= ${SPLIT_THRESHOLD_ISSUES}`);
   }
@@ -46,7 +64,12 @@ export function detectOverload(
     );
   }
   if (reasons.length === 0) return null;
-  return { agentId: agent.agentId, reasons, claudeMdBytes };
+  return {
+    agentId: agent.agentId,
+    reasons,
+    claudeMdBytes,
+    attributableSections: parseClaudeMdSections(claudeMd).length,
+  };
 }
 
 export interface ParsedSection {
@@ -160,10 +183,10 @@ export async function proposeSplit(
   input: ProposeSplitInput,
 ): Promise<SplitProposal> {
   const sections = parseClaudeMdSections(input.claudeMd);
-  if (sections.length < 4) {
-    // With <4 attributable sections there's not enough signal to split on
-    // — return a single-cluster "no-op" proposal callers can render as
-    // "not enough history yet to split meaningfully".
+  if (sections.length < SPLIT_MIN_SECTIONS) {
+    // With fewer than SPLIT_MIN_SECTIONS attributable sections there's not
+    // enough signal to split on — return a single-cluster "no-op" proposal
+    // callers can render as "not enough history yet to split meaningfully".
     return {
       agentId: input.agent.agentId,
       parentTags: input.agent.tags,
@@ -171,7 +194,7 @@ export async function proposeSplit(
       unclusteredSectionIds: sections.map((s) => s.sectionId),
       inputBytes: Buffer.byteLength(input.claudeMd, "utf-8"),
       sectionCount: sections.length,
-      notes: "Too few attributable sections (<4) to cluster meaningfully.",
+      notes: `Too few attributable sections (<${SPLIT_MIN_SECTIONS}) to cluster meaningfully.`,
     };
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1802,7 +1802,7 @@ async function cmdAgentsSplit(agentId: string, opts: AgentsSplitOpts): Promise<v
     process.exit(2);
   }
   const { md, bytes } = await readAgentClaudeMdBytes(agentId);
-  const verdict = detectOverload(agent, bytes);
+  const verdict = detectOverload(agent, md);
   if (!verdict && !opts.force) {
     if (opts.json) {
       process.stdout.write(JSON.stringify({ agentId, overloaded: false, claudeMdBytes: bytes }, null, 2) + "\n");

--- a/src/orchestrator/setup.test.ts
+++ b/src/orchestrator/setup.test.ts
@@ -2,6 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { formatSetupPreview, type SetupPreview } from "./setup.js";
 import type { DuplicateCluster } from "../types.js";
+import type { OverloadVerdict } from "../agent/split.js";
 
 // Issue #151 (Phase 2a-ii of #133): integration tests for the dedup
 // advisory block + dedup-cost line. Pure-function tests against
@@ -113,6 +114,71 @@ test("formatSetupPreview: dedupCostUsd 0 still renders the line", () => {
   // the pass actually executed.
   const text = formatSetupPreview(basePreview({ dedupCostUsd: 0 }));
   assert.match(text, /Dedup cost:\s+~\$0\.0000 \(already incurred\)/);
+});
+
+// Issue #161: pre-dispatch overload warning text must branch on whether
+// the splitter can actually produce a proposal. With fewer than 4
+// attributable sections, `vp-dev agents split <id>` returns "Too few
+// attributable sections (<4) to cluster meaningfully" — pointing the
+// user at it from the warning is a "you should split this → can't split
+// this" dead end. Verdict.attributableSections gates the text below.
+test("formatSetupPreview: overload warning with >=4 sections points at `vp-dev agents split`", () => {
+  const verdict: OverloadVerdict = {
+    agentId: "agent-1234",
+    reasons: ["CLAUDE.md=51.9KB >= 30KB", "tags=74 >= 50"],
+    claudeMdBytes: 51_900,
+    attributableSections: 12,
+  };
+  const text = formatSetupPreview(basePreview({ overloadWarnings: [verdict] }));
+  assert.match(text, /WARNING: agent-1234 crossed split threshold/);
+  assert.match(text, /CLAUDE\.md=51\.9KB >= 30KB/);
+  assert.match(text, /Run `vp-dev agents split agent-1234` to view a split proposal\./);
+  assert.doesNotMatch(text, /Splitter needs/);
+});
+
+test("formatSetupPreview: overload warning with <4 sections points at compaction path (#158), not the splitter", () => {
+  const verdict: OverloadVerdict = {
+    agentId: "agent-916a",
+    reasons: ["CLAUDE.md=51.9KB >= 30KB", "tags=74 >= 50"],
+    claudeMdBytes: 51_900,
+    attributableSections: 3,
+  };
+  const text = formatSetupPreview(basePreview({ overloadWarnings: [verdict] }));
+  assert.match(text, /WARNING: agent-916a crossed split threshold/);
+  assert.match(
+    text,
+    /Splitter needs >=4 attributable sections; agent-916a has 3\. See #158 for the compaction path\./,
+  );
+  // Critical: do NOT recommend `vp-dev agents split` for an agent the
+  // splitter will refuse — that's the dead-end UX the branch fixes.
+  assert.doesNotMatch(text, /Run `vp-dev agents split agent-916a`/);
+});
+
+test("formatSetupPreview: per-agent branching — splittable + un-splittable agents in same run get different remediation lines", () => {
+  // Mixed-overload run: agent-AAAA has lots of sections (post-summarizer
+  // history) so the splitter will work; agent-BBBB has tons of size /
+  // tag pressure but only 2 sections so the splitter would refuse. Each
+  // gets its own remediation line.
+  const verdicts: OverloadVerdict[] = [
+    {
+      agentId: "agent-AAAA",
+      reasons: ["issuesHandled=22 >= 20"],
+      claudeMdBytes: 20_000,
+      attributableSections: 18,
+    },
+    {
+      agentId: "agent-BBBB",
+      reasons: ["CLAUDE.md=37.0KB >= 30KB"],
+      claudeMdBytes: 37_888,
+      attributableSections: 2,
+    },
+  ];
+  const text = formatSetupPreview(basePreview({ overloadWarnings: verdicts }));
+  assert.match(text, /Run `vp-dev agents split agent-AAAA` to view a split proposal\./);
+  assert.match(
+    text,
+    /Splitter needs >=4 attributable sections; agent-BBBB has 2\. See #158 for the compaction path\./,
+  );
 });
 
 test("formatSetupPreview: cluster set + dedup cost are bound into the rendered text (previewHash coverage)", () => {

--- a/src/orchestrator/setup.ts
+++ b/src/orchestrator/setup.ts
@@ -4,6 +4,7 @@ import { pickAgents, type PickedAgent } from "./orchestrator.js";
 import {
   detectOverload,
   readAgentClaudeMdBytes,
+  SPLIT_MIN_SECTIONS,
   type OverloadVerdict,
 } from "../agent/split.js";
 import type { BudgetExceededSkipped } from "./costEstimator.js";
@@ -184,8 +185,8 @@ export async function buildSetupPreview(input: BuildPreviewInput): Promise<Setup
   // before the y/N gate, so the user can decide whether to split first.
   const overloadWarnings: OverloadVerdict[] = [];
   for (const r of pick.reusedAgents) {
-    const { bytes } = await readAgentClaudeMdBytes(r.agent.agentId);
-    const verdict = detectOverload(r.agent, bytes);
+    const { md } = await readAgentClaudeMdBytes(r.agent.agentId);
+    const verdict = detectOverload(r.agent, md);
     if (verdict) overloadWarnings.push(verdict);
   }
   return {
@@ -287,7 +288,19 @@ export function formatSetupPreview(p: SetupPreview): string {
     lines.push("Overload warnings:");
     for (const w of p.overloadWarnings) {
       lines.push(`  WARNING: ${w.agentId} crossed split threshold — ${w.reasons.join(", ")}`);
-      lines.push(`    Run \`vp-dev agents split ${w.agentId}\` to view a split proposal.`);
+      // Issue #161: branch remediation text on splitter eligibility. The
+      // splitter's clusterer requires at least SPLIT_MIN_SECTIONS
+      // summarizer-attributable sections; pointing the user at
+      // `vp-dev agents split` for an agent below that floor results in
+      // "Too few attributable sections (<4) to cluster meaningfully" —
+      // exactly the dead-end UX this branch avoids.
+      if (w.attributableSections >= SPLIT_MIN_SECTIONS) {
+        lines.push(`    Run \`vp-dev agents split ${w.agentId}\` to view a split proposal.`);
+      } else {
+        lines.push(
+          `    Splitter needs >=${SPLIT_MIN_SECTIONS} attributable sections; ${w.agentId} has ${w.attributableSections}. See #158 for the compaction path.`,
+        );
+      }
     }
     lines.push("");
   }


### PR DESCRIPTION
Closes #161.

## Symptom

Pre-dispatch overload warning told the operator to run `vp-dev agents split <id>`, but the splitter's clusterer refused with "Too few attributable sections (<4) to cluster meaningfully" because the overload threshold (size/tags/issuesHandled) and the clusterer's section floor (≥4) disagreed. 4 of 5 agents flagged in the 2026-05-05 vaultpilot-mcp run hit this dead-end UX (surfaced from #158).

## Fix

Branch the warning text in `formatSetupPreview` on splitter eligibility. Agents with ≥`SPLIT_MIN_SECTIONS` (4) summarizer-attributable sections get the original `vp-dev agents split` hint; agents below the floor get a different line that points at #158's compaction path:

```
WARNING: agent-916a crossed split threshold — CLAUDE.md=51.9KB >= 30KB, tags=74 >= 50
  Splitter needs >=4 attributable sections; agent-916a has 3. See #158 for the compaction path.
```

## Implementation

- Export `SPLIT_MIN_SECTIONS = 4` from `src/agent/split.ts`; use it inside `proposeSplit` so the threshold lives in one place.
- Extend `OverloadVerdict` with `attributableSections: number` so the preview formatter can branch without re-parsing the MD.
- Change `detectOverload(agent, claudeMd)` to take the MD string directly — single source of truth for both bytes and section count, and both call sites already had `md` available from `readAgentClaudeMdBytes`.
- Update `buildSetupPreview` (orchestrator preview) and `cmdAgentsSplit` (CLI) to pass `md` instead of `bytes`.
- Branch `formatSetupPreview`'s overload-warnings block on `verdict.attributableSections >= SPLIT_MIN_SECTIONS`.

## Tests

Three new tests in `src/orchestrator/setup.test.ts`:
- ≥4 sections → renders the `vp-dev agents split` hint, no compaction line.
- <4 sections → renders the compaction-path line citing #158, no `vp-dev agents split` hint.
- Mixed-overload run with one splittable + one un-splittable agent → each gets the correct per-agent remediation line.

All 355 tests pass; `npm run build` clean.

## Files

- `src/agent/split.ts` — `SPLIT_MIN_SECTIONS` const, `OverloadVerdict.attributableSections`, `detectOverload` signature change.
- `src/orchestrator/setup.ts` — pass `md` to `detectOverload`; branch warning text.
- `src/cli.ts` — pass `md` to `detectOverload`.
- `src/orchestrator/setup.test.ts` — three new branching tests.

— Alonzo (agent-92ff)
