### PR TITLE
feat(cli): add Phase A `vp-dev agents compact-claude-md` (#158)

### DIFF
--- a/src/agent/compactClaudeMd.test.ts
+++ b/src/agent/compactClaudeMd.test.ts
@@ -1,0 +1,231 @@
+// Phase A (issue #158) tests: schema-validator boundary cases, the
+// collapsed-distinct-rules validator, and the dry-run formatter shape.
+// No LLM is called — `proposeCompaction` is exercised end-to-end only
+// indirectly via its pure helpers, since the live network/SDK call is the
+// expensive part and adds nothing to per-PR coverage.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_MIN_CLUSTER_SIZE,
+  extractDistinctDates,
+  findDroppedIncidentDates,
+  formatCompactionProposal,
+  type CompactionProposal,
+} from "./compactClaudeMd.js";
+import { parseClaudeMdSections } from "./split.js";
+
+function fakeMd(sections: Array<{ run: string; issue: number; heading: string; body: string }>): string {
+  return sections
+    .map(
+      (s) =>
+        `<!-- run:${s.run} issue:#${s.issue} outcome:implement ts:2026-05-05T12:00:00.000Z -->\n## ${s.heading}\n\n${s.body}\n`,
+    )
+    .join("\n");
+}
+
+test("extractDistinctDates: pulls ISO-style dates, ignores version numbers", () => {
+  const dates = extractDistinctDates(
+    "Past incident 2026-05-05: thing happened. Version 1.2.345 and 12-34-56 do not count. Also 2026-04-28 cited.",
+  );
+  assert.deepEqual([...dates].sort(), ["2026-04-28", "2026-05-05"]);
+});
+
+test("extractDistinctDates: returns empty set for body with no dates", () => {
+  const dates = extractDistinctDates("No incidents cited here.");
+  assert.equal(dates.size, 0);
+});
+
+test("findDroppedIncidentDates: flags cluster where merged body drops a source date", () => {
+  const md = fakeMd([
+    { run: "run-A", issue: 100, heading: "Rule A", body: "Past incident 2026-04-28: foo." },
+    { run: "run-B", issue: 101, heading: "Rule B", body: "Past incident 2026-05-05: bar." },
+    { run: "run-C", issue: 102, heading: "Rule C", body: "Past incident 2026-05-05: also bar." },
+  ]);
+  const sections = parseClaudeMdSections(md);
+  assert.equal(sections.length, 3);
+
+  const warnings = findDroppedIncidentDates(
+    {
+      clusters: [
+        {
+          sectionIds: ["s0", "s1", "s2"],
+          proposedHeading: "Merged",
+          // Drops 2026-04-28 entirely; mentions 2026-05-05 only.
+          proposedBody: "Combined: see 2026-05-05 incident.",
+          rationale: "merged",
+          sourceProvenance: [],
+        },
+      ],
+    },
+    sections,
+  );
+
+  assert.equal(warnings.length, 1);
+  assert.equal(warnings[0].kind, "dropped-incident-date");
+  assert.deepEqual(warnings[0].missingDates, ["2026-04-28"]);
+  assert.deepEqual(warnings[0].fromSectionIds, ["s0"]);
+});
+
+test("findDroppedIncidentDates: clean merge with all source dates preserved -> no warning", () => {
+  const md = fakeMd([
+    { run: "run-A", issue: 100, heading: "Rule A", body: "Past incident 2026-04-28: foo." },
+    { run: "run-B", issue: 101, heading: "Rule B", body: "Past incident 2026-05-05: bar." },
+    { run: "run-C", issue: 102, heading: "Rule C", body: "Past incident 2026-04-29: baz." },
+  ]);
+  const sections = parseClaudeMdSections(md);
+  const warnings = findDroppedIncidentDates(
+    {
+      clusters: [
+        {
+          sectionIds: ["s0", "s1", "s2"],
+          proposedHeading: "Merged",
+          proposedBody:
+            "Combined rule. Past incidents: 2026-04-28 (foo), 2026-04-29 (baz), 2026-05-05 (bar).",
+          rationale: "merged",
+          sourceProvenance: [],
+        },
+      ],
+    },
+    sections,
+  );
+  assert.equal(warnings.length, 0);
+});
+
+test("findDroppedIncidentDates: ignores clusters whose source sections cite no dates", () => {
+  const md = fakeMd([
+    { run: "run-A", issue: 100, heading: "Rule A", body: "No dates here." },
+    { run: "run-B", issue: 101, heading: "Rule B", body: "Or here." },
+  ]);
+  const sections = parseClaudeMdSections(md);
+  const warnings = findDroppedIncidentDates(
+    {
+      clusters: [
+        {
+          sectionIds: ["s0", "s1"],
+          proposedHeading: "Merged",
+          proposedBody: "Combined rule, no dates.",
+          rationale: "merged",
+          sourceProvenance: [],
+        },
+      ],
+    },
+    sections,
+  );
+  assert.equal(warnings.length, 0);
+});
+
+test("findDroppedIncidentDates: clusterIndex matches the position in the input array", () => {
+  const md = fakeMd([
+    { run: "run-A", issue: 100, heading: "A", body: "2026-01-01 thing" },
+    { run: "run-B", issue: 101, heading: "B", body: "2026-02-02 thing" },
+    { run: "run-C", issue: 102, heading: "C", body: "2026-03-03 thing" },
+    { run: "run-D", issue: 103, heading: "D", body: "2026-04-04 thing" },
+  ]);
+  const sections = parseClaudeMdSections(md);
+  const warnings = findDroppedIncidentDates(
+    {
+      clusters: [
+        {
+          sectionIds: ["s0", "s1"],
+          proposedHeading: "Clean",
+          proposedBody: "Cites 2026-01-01 and 2026-02-02.",
+          rationale: "ok",
+          sourceProvenance: [],
+        },
+        {
+          sectionIds: ["s2", "s3"],
+          proposedHeading: "Drops one",
+          proposedBody: "Cites only 2026-03-03.",
+          rationale: "lossy",
+          sourceProvenance: [],
+        },
+      ],
+    },
+    sections,
+  );
+  assert.equal(warnings.length, 1);
+  assert.equal(warnings[0].clusterIndex, 1);
+  assert.deepEqual(warnings[0].missingDates, ["2026-04-04"]);
+});
+
+test("formatCompactionProposal: zero-cluster proposal renders the no-op note", () => {
+  const proposal: CompactionProposal = {
+    agentId: "agent-test",
+    clusters: [],
+    unclusteredSectionIds: ["s0", "s1"],
+    estimatedBytesSaved: 0,
+    inputBytes: 4096,
+    sectionCount: 2,
+    notes: "Too few attributable sections (2) to compact at min-cluster-size=3.",
+    warnings: [],
+  };
+  const out = formatCompactionProposal(proposal);
+  assert.match(out, /Compaction proposal for agent-test/);
+  assert.match(out, /no merge clusters proposed/);
+  assert.match(out, /Too few attributable sections/);
+});
+
+test("formatCompactionProposal: surfaces dropped-date warnings inline per cluster", () => {
+  const proposal: CompactionProposal = {
+    agentId: "agent-test",
+    clusters: [
+      {
+        sectionIds: ["s0", "s1", "s2"],
+        proposedHeading: "Merged rule",
+        proposedBody: "body",
+        rationale: "shared thesis",
+        sourceProvenance: [
+          { runId: "run-A", issueId: 100 },
+          { runId: "run-B", issueId: 101 },
+        ],
+      },
+    ],
+    unclusteredSectionIds: ["s3"],
+    estimatedBytesSaved: 2048,
+    inputBytes: 10240,
+    sectionCount: 4,
+    warnings: [
+      {
+        kind: "dropped-incident-date",
+        clusterIndex: 0,
+        missingDates: ["2026-04-28"],
+        fromSectionIds: ["s0"],
+      },
+    ],
+  };
+  const out = formatCompactionProposal(proposal);
+  assert.match(out, /Merged rule/);
+  assert.match(out, /merging 3 sections/);
+  assert.match(out, /provenance: #100, #101/);
+  assert.match(out, /DROPPED DATES: 2026-04-28/);
+  assert.match(out, /1 cluster\(s\) flagged/);
+  assert.match(out, /Unclustered \(1\): s3/);
+});
+
+test("formatCompactionProposal: clean proposal advertises Phase A advisory note", () => {
+  const proposal: CompactionProposal = {
+    agentId: "agent-test",
+    clusters: [
+      {
+        sectionIds: ["s0", "s1", "s2"],
+        proposedHeading: "Merged",
+        proposedBody: "body",
+        rationale: "ok",
+        sourceProvenance: [],
+      },
+    ],
+    unclusteredSectionIds: [],
+    estimatedBytesSaved: 1024,
+    inputBytes: 8192,
+    sectionCount: 3,
+    warnings: [],
+  };
+  const out = formatCompactionProposal(proposal);
+  assert.match(out, /No validator warnings/);
+  assert.match(out, /#162/);
+});
+
+test("DEFAULT_MIN_CLUSTER_SIZE: documented default is 3 (per issue #158 — 2 too aggressive)", () => {
+  assert.equal(DEFAULT_MIN_CLUSTER_SIZE, 3);
+});

--- a/src/agent/compactClaudeMd.ts
+++ b/src/agent/compactClaudeMd.ts
@@ -1,0 +1,444 @@
+// Phase A (issue #158) — advisory-only compaction-via-merge for an agent's
+// CLAUDE.md when growth is in section *depth* rather than section *count*.
+//
+// The splitter (src/agent/split.ts) addresses a different overload shape:
+// an agent has accumulated multiple distinct sub-specialties that should
+// be partitioned into sibling agents. When growth is concentrated in
+// few-but-large coherent sections, splitting fragments the same specialty
+// across siblings; the right tool is to merge near-duplicate lessons in
+// place, preserving the specialty.
+//
+// This module is purely advisory: it parses sections, asks an opus model
+// to propose merge clusters, validates the proposal (Zod schema + a
+// collapsed-distinct-rules guard), and emits a dry-run report. No file
+// mutation. The destructive `--apply` path is deferred to issue #162.
+//
+// Usage: `vp-dev agents compact-claude-md <agentId> [--json] [--min-cluster-size N]`.
+
+import { z } from "zod";
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { claudeBinPath } from "./sdkBinary.js";
+import { parseClaudeMdSections, type ParsedSection } from "./split.js";
+import { parseJsonEnvelope } from "../util/parseJsonEnvelope.js";
+import { ORCHESTRATOR_MODEL_SPLIT } from "../orchestrator/models.js";
+import type { AgentRecord } from "../types.js";
+
+// Shares the splitter's tier (opus) — the prompts are similar shape (full
+// CLAUDE.md → structured proposal), and merge-quality matters more than
+// per-call cost. Env override flows through `models.ts`.
+const COMPACT_MODEL = ORCHESTRATOR_MODEL_SPLIT;
+
+// Minimum merged-cluster size below which the model is told to leave
+// sections alone. Default 3 (per issue #158: 2 is too aggressive, any
+// near-duplicate gets merged and loses nuance). Operator-tunable from CLI.
+export const DEFAULT_MIN_CLUSTER_SIZE = 3;
+
+// Per-field caps on the LLM proposal payload. `proposedBody` can legitimately
+// be larger than per-section bodies (it's a synthesis), but a generous
+// ceiling prevents the model from emitting essay-length merges that defeat
+// the purpose of compaction.
+const HEADING_MAX = 100;
+const BODY_MAX = 6000;
+const RATIONALE_MAX = 800;
+
+export interface CompactionCluster {
+  /** ≥2 sectionIds from parseClaudeMdSections, all to be merged into one. */
+  sectionIds: string[];
+  /** Heading proposed for the merged section (replaces all source headings). */
+  proposedHeading: string;
+  /** Synthesized body covering every load-bearing detail from source bodies. */
+  proposedBody: string;
+  /** 1-3 sentences on why these sections share a thesis. */
+  rationale: string;
+  /** Provenance preserved from source sections — surfaces which past
+   *  runs/issues contributed lessons to the merge. */
+  sourceProvenance: Array<{ runId: string; issueId: number }>;
+}
+
+export interface CompactionProposal {
+  agentId: string;
+  clusters: CompactionCluster[];
+  /** sectionIds the model declined to cluster. Better to leave nuanced
+   *  one-offs alone than to force them into a weak cluster. */
+  unclusteredSectionIds: string[];
+  /** Sum of (source-bytes - merged-bytes) across all clusters; advisory. */
+  estimatedBytesSaved: number;
+  inputBytes: number;
+  sectionCount: number;
+  /** Optional model-side note on proposal quality / caveats. */
+  notes?: string;
+  /** Per-cluster validator findings (e.g., dropped-date warnings). Empty
+   *  array on a clean proposal. Phase A surfaces them as advisories; the
+   *  destructive --apply path (#162) will treat them as hard rejections. */
+  warnings: CompactionWarning[];
+}
+
+export type CompactionWarning = {
+  kind: "dropped-incident-date";
+  clusterIndex: number;
+  /** Dates present in source section bodies but missing from the merged body. */
+  missingDates: string[];
+  /** sectionIds of the source sections whose dates were dropped. */
+  fromSectionIds: string[];
+};
+
+const ClusterSchema = z.object({
+  sectionIds: z.array(z.string().min(1)).min(2),
+  proposedHeading: z.string().min(1).max(HEADING_MAX),
+  proposedBody: z.string().min(1).max(BODY_MAX),
+  rationale: z.string().min(1).max(RATIONALE_MAX),
+});
+
+const ProposalPayloadSchema = z.object({
+  clusters: z.array(ClusterSchema).default([]),
+  unclusteredSectionIds: z.array(z.string()).default([]),
+  notes: z.string().max(500).optional(),
+});
+
+function clampClusterFields(json: unknown): unknown {
+  if (!json || typeof json !== "object") return json;
+  const obj = json as Record<string, unknown>;
+  const clusters = obj.clusters;
+  if (!Array.isArray(clusters)) return obj;
+  const next = clusters.map((c) => {
+    if (!c || typeof c !== "object") return c;
+    const cluster = c as Record<string, unknown>;
+    const out: Record<string, unknown> = { ...cluster };
+    if (typeof cluster.proposedHeading === "string" && cluster.proposedHeading.length > HEADING_MAX) {
+      out.proposedHeading = cluster.proposedHeading.slice(0, HEADING_MAX - 3) + "...";
+    }
+    if (typeof cluster.proposedBody === "string" && cluster.proposedBody.length > BODY_MAX) {
+      out.proposedBody = cluster.proposedBody.slice(0, BODY_MAX - 16) + "\n[…truncated]";
+    }
+    if (typeof cluster.rationale === "string" && cluster.rationale.length > RATIONALE_MAX) {
+      out.rationale = cluster.rationale.slice(0, RATIONALE_MAX - 16) + "\n[…truncated]";
+    }
+    return out;
+  });
+  return { ...obj, clusters: next };
+}
+
+// ISO-style date matcher: catches `2026-05-05`, `2026-04-28`, etc. Used by
+// the collapsed-distinct-rules validator. Deliberately strict on shape so
+// it doesn't false-positive on version numbers or arbitrary digit triples
+// that show up in code samples (`12.34.567`).
+const DATE_RE = /\b(20\d{2}-\d{2}-\d{2})\b/g;
+
+export function extractDistinctDates(body: string): Set<string> {
+  const out = new Set<string>();
+  for (const m of body.matchAll(DATE_RE)) out.add(m[1]);
+  return out;
+}
+
+/**
+ * Collapsed-distinct-rules validator (per issue #158).
+ *
+ * Checks every cluster: are all distinct ISO dates present in the source
+ * bodies also present in the merged body? If a date appears in any source
+ * but not in the merge, the model has dropped a load-bearing past-incident
+ * citation — flag the cluster as unsafe to apply.
+ *
+ * Cheap textual heuristic. Misses incidents cited by phrase-only ("the
+ * SunSwap rebase incident") rather than date, but those are the rarer
+ * shape; date-cited incidents dominate this codebase's lessons.
+ */
+export function findDroppedIncidentDates(
+  proposal: { clusters: CompactionCluster[] },
+  sections: ParsedSection[],
+): CompactionWarning[] {
+  const sectionById = new Map(sections.map((s) => [s.sectionId, s]));
+  const warnings: CompactionWarning[] = [];
+  proposal.clusters.forEach((cluster, idx) => {
+    const sourceDates = new Set<string>();
+    const datesByOrigin = new Map<string, string[]>(); // date -> sectionIds
+    for (const sid of cluster.sectionIds) {
+      const sec = sectionById.get(sid);
+      if (!sec) continue;
+      for (const d of extractDistinctDates(sec.body)) {
+        sourceDates.add(d);
+        const arr = datesByOrigin.get(d) ?? [];
+        if (!arr.includes(sid)) arr.push(sid);
+        datesByOrigin.set(d, arr);
+      }
+    }
+    const mergedDates = extractDistinctDates(cluster.proposedBody);
+    const missing: string[] = [];
+    const fromIds = new Set<string>();
+    for (const d of sourceDates) {
+      if (!mergedDates.has(d)) {
+        missing.push(d);
+        for (const sid of datesByOrigin.get(d) ?? []) fromIds.add(sid);
+      }
+    }
+    if (missing.length > 0) {
+      missing.sort();
+      warnings.push({
+        kind: "dropped-incident-date",
+        clusterIndex: idx,
+        missingDates: missing,
+        fromSectionIds: Array.from(fromIds).sort(),
+      });
+    }
+  });
+  return warnings;
+}
+
+export interface ProposeCompactionInput {
+  agent: AgentRecord;
+  /** Current CLAUDE.md content for the agent. */
+  claudeMd: string;
+  /** Minimum cluster size the model is asked to honour. Default 3. */
+  minClusterSize?: number;
+}
+
+export async function proposeCompaction(
+  input: ProposeCompactionInput,
+): Promise<CompactionProposal> {
+  const minClusterSize = input.minClusterSize ?? DEFAULT_MIN_CLUSTER_SIZE;
+  const sections = parseClaudeMdSections(input.claudeMd);
+  const inputBytes = Buffer.byteLength(input.claudeMd, "utf-8");
+  const baseProposal: Omit<CompactionProposal, "clusters" | "unclusteredSectionIds" | "estimatedBytesSaved" | "warnings" | "notes"> = {
+    agentId: input.agent.agentId,
+    inputBytes,
+    sectionCount: sections.length,
+  };
+
+  // Compaction needs at least minClusterSize attributable sections to
+  // produce a meaningful merge. Below that threshold, return a no-op
+  // proposal — same shape as the splitter's <4-section degenerate case.
+  if (sections.length < minClusterSize) {
+    return {
+      ...baseProposal,
+      clusters: [],
+      unclusteredSectionIds: sections.map((s) => s.sectionId),
+      estimatedBytesSaved: 0,
+      warnings: [],
+      notes: `Too few attributable sections (${sections.length}) to compact at min-cluster-size=${minClusterSize}.`,
+    };
+  }
+
+  const userPrompt = buildCompactionPrompt({
+    agent: input.agent,
+    sections,
+    minClusterSize,
+  });
+  let raw = "";
+  const stream = query({
+    prompt: userPrompt,
+    options: {
+      model: COMPACT_MODEL,
+      systemPrompt: buildCompactionSystemPrompt(minClusterSize),
+      tools: [],
+      permissionMode: "default",
+      env: process.env,
+      maxTurns: 1,
+      settingSources: [],
+      persistSession: false,
+      pathToClaudeCodeExecutable: claudeBinPath(),
+    },
+  });
+  for await (const msg of stream) {
+    if (msg.type === "result") {
+      if (msg.subtype === "success") raw = msg.result;
+      else throw new Error(`compactClaudeMd model failed: ${msg.subtype}`);
+    }
+  }
+
+  const extracted = parseJsonEnvelope(raw, z.unknown());
+  if (!extracted.ok) {
+    throw new Error(
+      `compactClaudeMd output not valid JSON: ${extracted.error ?? "no envelope"}`,
+    );
+  }
+  const clamped = clampClusterFields(extracted.value);
+  const parsed = ProposalPayloadSchema.safeParse(clamped);
+  if (!parsed.success) {
+    throw new Error(
+      `compactClaudeMd schema invalid: ${parsed.error.message.replace(/\s+/g, " ").slice(0, 400)}`,
+    );
+  }
+
+  const validIds = new Set(sections.map((s) => s.sectionId));
+  const sectionById = new Map(sections.map((s) => [s.sectionId, s]));
+  const seenIds = new Set<string>();
+  const clusters: CompactionCluster[] = [];
+  for (const c of parsed.data.clusters) {
+    // Drop clusters below the floor; still surface in unclustered list.
+    if (c.sectionIds.length < minClusterSize) continue;
+    for (const id of c.sectionIds) {
+      if (!validIds.has(id)) {
+        throw new Error(`compactClaudeMd cluster references unknown sectionId ${id}`);
+      }
+      if (seenIds.has(id)) {
+        throw new Error(
+          `compactClaudeMd cluster reuses sectionId ${id}; sections may belong to at most one cluster`,
+        );
+      }
+      seenIds.add(id);
+    }
+    const provenance: Array<{ runId: string; issueId: number }> = [];
+    for (const sid of c.sectionIds) {
+      const sec = sectionById.get(sid);
+      if (!sec || !sec.runId || sec.issueId == null) continue;
+      provenance.push({ runId: sec.runId, issueId: sec.issueId });
+    }
+    clusters.push({
+      sectionIds: c.sectionIds,
+      proposedHeading: c.proposedHeading,
+      proposedBody: c.proposedBody,
+      rationale: c.rationale,
+      sourceProvenance: provenance,
+    });
+  }
+
+  const unclusteredSectionIds = sections
+    .map((s) => s.sectionId)
+    .filter((id) => !seenIds.has(id));
+
+  const estimatedBytesSaved = computeEstimatedBytesSaved(clusters, sectionById);
+  const warnings = findDroppedIncidentDates({ clusters }, sections);
+
+  return {
+    ...baseProposal,
+    clusters,
+    unclusteredSectionIds,
+    estimatedBytesSaved,
+    warnings,
+    notes: parsed.data.notes,
+  };
+}
+
+function computeEstimatedBytesSaved(
+  clusters: CompactionCluster[],
+  sectionById: Map<string, ParsedSection>,
+): number {
+  let saved = 0;
+  for (const c of clusters) {
+    let sourceBytes = 0;
+    for (const sid of c.sectionIds) {
+      const sec = sectionById.get(sid);
+      if (!sec) continue;
+      // Approximate source size as heading + body + a fixed overhead for
+      // the provenance comment line. Close enough for an advisory metric.
+      sourceBytes +=
+        Buffer.byteLength(sec.heading, "utf-8") +
+        Buffer.byteLength(sec.body, "utf-8") +
+        80;
+    }
+    const mergedBytes =
+      Buffer.byteLength(c.proposedHeading, "utf-8") +
+      Buffer.byteLength(c.proposedBody, "utf-8") +
+      80;
+    saved += Math.max(0, sourceBytes - mergedBytes);
+  }
+  return saved;
+}
+
+export function buildCompactionSystemPrompt(minClusterSize: number): string {
+  return `You compact a coding agent's accumulated CLAUDE.md by merging near-duplicate lessons that share a single thesis.
+
+Input: a list of CLAUDE.md sections, each tagged with a sectionId, the issue it came from, the outcome, and the section heading + body. The agent's growth is in section depth — many sections share the same underlying rule with only minor variation. Your job is to find clusters of ${minClusterSize}+ sections that can be losslessly merged.
+
+CRITICAL: lossless means every load-bearing detail from every source section MUST appear in the merged body. In particular:
+- Every "Past incident YYYY-MM-DD" citation MUST be preserved (an automated validator checks this; missing dates flag the cluster as unsafe).
+- Every distinct mechanism, threshold, or numeric tunable MUST be preserved.
+- Every cross-reference (issue #N, PR #N, repo name) MUST be preserved.
+- "Tells" lists and "How to apply" steps from each source MUST be unioned, not picked.
+
+Output rules:
+- Each cluster must merge ${minClusterSize}+ sectionIds.
+- Each cluster needs:
+  - sectionIds: the section IDs being merged (≥${minClusterSize}).
+  - proposedHeading: a short canonical heading (<= 100 chars). Capture the shared thesis.
+  - proposedBody: synthesized body containing every load-bearing detail from the sources. Bullets > prose. Cite every past-incident date verbatim.
+  - rationale: 1-3 sentences on why these sections share a thesis.
+- unclusteredSectionIds: sections that don't share a thesis with ${minClusterSize - 1}+ others. Better to leave them than force a weak cluster.
+- notes: optional 1-2 sentences on caveats.
+- A section may belong to AT MOST one cluster.
+
+Output: a single JSON object, no fences, no prose:
+  {"clusters": [{"sectionIds": ["s0","s3","s7"], "proposedHeading": "...", "proposedBody": "...", "rationale": "..."}], "unclusteredSectionIds": ["s1","s2"], "notes": "..."}
+
+Returning {"clusters": [], "unclusteredSectionIds": ["s0","s1",...]} is acceptable when no clean merge exists.`;
+}
+
+export function buildCompactionPrompt(opts: {
+  agent: AgentRecord;
+  sections: ParsedSection[];
+  minClusterSize: number;
+}): string {
+  const sectionLines = opts.sections.map((s) => {
+    const head = `[${s.sectionId}] issue=#${s.issueId ?? "?"} outcome=${s.outcome ?? "?"} run=${s.runId ?? "?"}`;
+    return `${head}\n  heading: ${s.heading}\n  body:\n${indent(s.body, "    ")}`;
+  });
+
+  return `Agent ${opts.agent.agentId} has accumulated ${opts.sections.length} attributable sections across ${opts.agent.tags.length} tags. Identify clusters of ${opts.minClusterSize}+ sections that share a single thesis and can be merged losslessly.
+
+Parent tags (${opts.agent.tags.length}):
+${JSON.stringify(opts.agent.tags)}
+
+Sections:
+${sectionLines.join("\n\n")}
+
+Emit the JSON object now. min-cluster-size is ${opts.minClusterSize}.`;
+}
+
+function indent(s: string, prefix: string): string {
+  return s.split("\n").map((line) => prefix + line).join("\n");
+}
+
+export function formatCompactionProposal(p: CompactionProposal): string {
+  const lines: string[] = [];
+  const heading = `Compaction proposal for ${p.agentId}`;
+  lines.push(heading);
+  lines.push("=".repeat(heading.length));
+  lines.push(`  CLAUDE.md size:     ${(p.inputBytes / 1024).toFixed(1)}KB`);
+  lines.push(`  Sections analyzed:  ${p.sectionCount}`);
+  lines.push(`  Clusters proposed:  ${p.clusters.length}`);
+  lines.push(
+    `  Estimated savings:  ${(p.estimatedBytesSaved / 1024).toFixed(1)}KB`,
+  );
+  lines.push("");
+  if (p.clusters.length === 0) {
+    lines.push("  (no merge clusters proposed)");
+    if (p.notes) lines.push(`  ${p.notes}`);
+    return lines.join("\n");
+  }
+
+  p.clusters.forEach((c, idx) => {
+    lines.push(`  -> [${idx}] ${c.proposedHeading}  (merging ${c.sectionIds.length} sections)`);
+    lines.push(`     sections: ${c.sectionIds.join(", ")}`);
+    lines.push(`     why:      ${c.rationale}`);
+    if (c.sourceProvenance.length > 0) {
+      const prov = c.sourceProvenance
+        .map((p) => `#${p.issueId}`)
+        .join(", ");
+      lines.push(`     provenance: ${prov}`);
+    }
+    const myWarnings = p.warnings.filter((w) => w.clusterIndex === idx);
+    for (const w of myWarnings) {
+      if (w.kind === "dropped-incident-date") {
+        lines.push(
+          `     ⚠ DROPPED DATES: ${w.missingDates.join(", ")} (from ${w.fromSectionIds.join(", ")})`,
+        );
+      }
+    }
+    lines.push("");
+  });
+
+  if (p.unclusteredSectionIds.length > 0) {
+    lines.push(`  Unclustered (${p.unclusteredSectionIds.length}): ${p.unclusteredSectionIds.join(", ")}`);
+  }
+  if (p.notes) lines.push(`  Notes: ${p.notes}`);
+  lines.push("");
+  if (p.warnings.length > 0) {
+    lines.push(
+      `⚠ ${p.warnings.length} cluster(s) flagged by the collapsed-distinct-rules validator — review carefully before any --apply path.`,
+    );
+  } else {
+    lines.push(
+      "No validator warnings. (Phase A is advisory only; --apply is tracked at #162.)",
+    );
+  }
+  return lines.join("\n");
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -78,6 +78,11 @@ import {
   readAgentClaudeMdBytes,
 } from "./agent/split.js";
 import {
+  DEFAULT_MIN_CLUSTER_SIZE,
+  formatCompactionProposal,
+  proposeCompaction,
+} from "./agent/compactClaudeMd.js";
+import {
   applyPruneProposal,
   detectPruneCandidates,
   formatPruneProposals,
@@ -285,6 +290,23 @@ export function buildCli(): Command {
         .option("--yes", "Skip the apply confirmation prompt (required for non-TTY environments).")
         .action(async (opts) => {
           await cmdAgentsPrune(opts);
+        }),
+    )
+    .addCommand(
+      new Command("compact-claude-md")
+        .description(
+          "Phase A (#158): propose merge clusters for an agent's CLAUDE.md when growth is in section depth (few large sections). Advisory only — no file mutation. --apply is tracked at #162.",
+        )
+        .argument("<agentId>", "Agent to inspect (e.g. agent-916a)")
+        .option("--json", "Print machine-readable JSON")
+        .option(
+          "--min-cluster-size <n>",
+          "Minimum sections per merge cluster (default 3; 2 is too aggressive per issue #158)",
+          parsePositive,
+          DEFAULT_MIN_CLUSTER_SIZE,
+        )
+        .action(async (agentId, opts) => {
+          await cmdAgentsCompactClaudeMd(agentId, opts);
         }),
     )
     .addCommand(
@@ -1897,6 +1919,51 @@ async function confirmApply(input: {
   } finally {
     rl.close();
   }
+}
+
+interface AgentsCompactClaudeMdOpts {
+  json?: boolean;
+  minClusterSize: number;
+}
+
+async function cmdAgentsCompactClaudeMd(
+  agentId: string,
+  opts: AgentsCompactClaudeMdOpts,
+): Promise<void> {
+  const reg = await loadRegistry();
+  const agent = reg.agents.find((a) => a.agentId === agentId);
+  if (!agent) {
+    process.stderr.write(`ERROR: agent '${agentId}' not found in registry.\n`);
+    process.exit(2);
+  }
+  if (agent.archived) {
+    process.stderr.write(
+      `ERROR: agent '${agentId}' is already archived; compaction is for active agents.\n`,
+    );
+    process.exit(2);
+  }
+  const { md, bytes } = await readAgentClaudeMdBytes(agentId);
+  if (bytes === 0) {
+    process.stderr.write(
+      `ERROR: agent '${agentId}' has no CLAUDE.md on disk yet — nothing to compact.\n`,
+    );
+    process.exit(2);
+  }
+
+  process.stdout.write(
+    `Generating compaction proposal for ${agentId} (min-cluster-size=${opts.minClusterSize})...\n`,
+  );
+  const proposal = await proposeCompaction({
+    agent,
+    claudeMd: md,
+    minClusterSize: opts.minClusterSize,
+  });
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify({ agentId, proposal }, null, 2) + "\n");
+    return;
+  }
+  process.stdout.write(formatCompactionProposal(proposal) + "\n");
 }
 
 interface AgentsPruneOpts {


### PR DESCRIPTION
Closes #158.

Phase A of the [crystallized issue](https://github.com/szhygulin/vaultpilot-development-agents/issues/158) — narrowed to compaction-via-merge, advisory only, after the [layer-chain audit](https://github.com/szhygulin/vaultpilot-development-agents/issues/158#issuecomment-4382742723) flagged the original three-mechanism scope as out-of-budget. Phase B (`--apply`) is tracked at [#162](https://github.com/szhygulin/vaultpilot-development-agents/issues/162); the threshold-mismatch UX gap is tracked at [#161](https://github.com/szhygulin/vaultpilot-development-agents/issues/161).

## Summary

- **`vp-dev agents compact-claude-md <agentId> [--json] [--min-cluster-size N]`** — detects clusters of ≥3 near-duplicate CLAUDE.md sections that share a single thesis, asks the opus split-tier model to propose lossless merges, validates the output, and prints a dry-run report. No file mutation.
- **Collapsed-distinct-rules validator** runs in Phase A (not deferred). For every proposed cluster, every ISO-style date present in source-section bodies must also appear in the merged body; missing dates surface as `⚠ DROPPED DATES` warnings inline per cluster. This is the most common merge-failure mode (model collapsing distinct past-incident citations). The destructive `--apply` path (#162) will treat these warnings as hard rejections; Phase A surfaces them so the human reviewer's eyeball-pass is honest about which proposals would be safe to apply.
- **Tunable `--min-cluster-size` (default 3).** 2 is too aggressive per the issue body; 3 starts safer. Operator can lower per-agent if Phase A output justifies it.

## Files (3, within calibration)

| File | Change |
|---|---|
| `src/agent/compactClaudeMd.ts` (new) | Detection + LLM call + Zod schema + validator + dry-run formatter |
| `src/agent/compactClaudeMd.test.ts` (new) | 10 unit tests: date extraction, validator boundary cases, formatter shape, default invariant |
| `src/cli.ts` | `agents compact-claude-md` subcommand + handler |

The model resolves to `ORCHESTRATOR_MODEL_SPLIT` (opus) — same tier as the splitter, same env-override surface (`VP_DEV_SPLIT_MODEL`). Reused since the input shape (full CLAUDE.md → structured proposal) and the merge-quality-matters bias are aligned with the splitter's call site.

## Boundary preservation

- **Per-section provenance preserved on every cluster.** `sourceProvenance: Array<{ runId, issueId }>` carries forward the originating run/issue for every merged section, so Phase B's `--apply` writer can re-emit a single sentinel comment listing all contributing runs (the `appendBlock` format in `specialization.ts` already supports this shape).
- **Sections may belong to at most one cluster.** Validated in `proposeCompaction` after schema parse; throws on collision before reaching the formatter.
- **Per-field caps with clamp + Zod.** Same belt-and-suspenders pattern as the splitter (`clampClusterFields` trims overshoots before `safeParse`), so a slightly-verbose rationale doesn't discard the entire proposal.

## Test plan

- [x] `npm run build` passes cleanly.
- [x] `npm test` — 362 tests pass (10 new in `compactClaudeMd.test.ts`).
- [x] `node dist/bin/vp-dev.js agents --help` shows the new subcommand.
- [x] `node dist/bin/vp-dev.js agents compact-claude-md --help` shows args + `--min-cluster-size` default of 3.
- [ ] (Manual, post-merge) Run `vp-dev agents compact-claude-md agent-916a` and confirm Phase A success metric: dry-run output proposes ≥1 within-section merge cluster bringing projected post-merge size below `SPLIT_THRESHOLD_BYTES` (30KB) without dropping any past-incident date that has a unique citation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Advisory Scope Boundary (agent-916a)
