### PR TITLE
feat(cli): Phase B `compact-claude-md --apply` / `--confirm <token>` (#162)

### DIFF
--- a/src/agent/compactClaudeMd.test.ts
+++ b/src/agent/compactClaudeMd.test.ts
@@ -203,7 +203,7 @@ test("formatCompactionProposal: surfaces dropped-date warnings inline per cluste
   assert.match(out, /Unclustered \(1\): s3/);
 });
 
-test("formatCompactionProposal: clean proposal advertises Phase A advisory note", () => {
+test("formatCompactionProposal: clean proposal points at the --apply / --confirm flow", () => {
   const proposal: CompactionProposal = {
     agentId: "agent-test",
     clusters: [
@@ -223,9 +223,434 @@ test("formatCompactionProposal: clean proposal advertises Phase A advisory note"
   };
   const out = formatCompactionProposal(proposal);
   assert.match(out, /No validator warnings/);
-  assert.match(out, /#162/);
+  assert.match(out, /--apply/);
+  assert.match(out, /--confirm/);
 });
 
 test("DEFAULT_MIN_CLUSTER_SIZE: documented default is 3 (per issue #158 — 2 too aggressive)", () => {
   assert.equal(DEFAULT_MIN_CLUSTER_SIZE, 3);
 });
+
+// ---------------------------------------------------------------------------
+// Phase B (issue #162) tests: splicer + applyCompaction drift rejections.
+// Splicer is exercised pure; applyCompaction is exercised end-to-end against
+// a tmp agents-root via process.chdir, since AGENTS_ROOT is `process.cwd() +
+// "/agents"` and there's no override hook by design (matches appendBlock).
+// ---------------------------------------------------------------------------
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import {
+  applyCompaction,
+  renderMergedBlock,
+  type CompactionCluster,
+} from "./compactClaudeMd.js";
+import {
+  computeProposalHash,
+  hashFile,
+} from "../state/compactConfirm.js";
+import { parseSentinelHeader } from "../util/sentinels.js";
+
+function fakeMdContent(
+  sections: Array<{ run: string; issue: number; heading: string; body: string }>,
+): string {
+  // Match the on-disk shape `appendBlock` produces: one `\n` separating
+  // blocks, no leading whitespace before the first sentinel.
+  return sections
+    .map(
+      (s) =>
+        `<!-- run:${s.run} issue:#${s.issue} outcome:implement ts:2026-05-05T12:00:00.000Z -->\n## ${s.heading}\n\n${s.body}`,
+    )
+    .join("\n") + "\n";
+}
+
+test("spliceCompactedSections: replaces 3-section cluster with one merged block", () => {
+  const md = fakeMdContent([
+    { run: "run-a", issue: 100, heading: "Rule A", body: "Past incident 2026-04-28: foo." },
+    { run: "run-b", issue: 101, heading: "Rule B", body: "Past incident 2026-04-29: bar." },
+    { run: "run-c", issue: 102, heading: "Rule C", body: "Past incident 2026-04-30: baz." },
+  ]);
+  // Re-parse with offsets via the exported wrapper. Build sections manually
+  // mirroring what parseClaudeMdSectionsWithOffsets returns; here we cheat
+  // by using parseClaudeMdSections + inferring offsets from match.
+  const parsed = parseClaudeMdSections(md);
+  assert.equal(parsed.length, 3);
+
+  const cluster: CompactionCluster = {
+    sectionIds: ["s0", "s1", "s2"],
+    proposedHeading: "Merged AB+C",
+    proposedBody:
+      "Combined rule. Past incidents: 2026-04-28 (foo), 2026-04-29 (bar), 2026-04-30 (baz).",
+    rationale: "shared thesis",
+    sourceProvenance: [
+      { runId: "run-a", issueId: 100 },
+      { runId: "run-b", issueId: 101 },
+      { runId: "run-c", issueId: 102 },
+    ],
+  };
+
+  // We don't expose parseClaudeMdSectionsWithOffsets externally — the
+  // splicer is exercised through applyCompaction in the chdir-based test
+  // below. Test renderMergedBlock here (the only piece we can poke at
+  // without re-parsing offsets).
+  const block = renderMergedBlock(cluster, "merge-test", "2026-05-06T00:00:00.000Z");
+  assert.match(block, /run:merge-test/);
+  assert.match(block, /issue:#100\+#101\+#102/);
+  assert.match(block, /outcome:compacted/);
+  assert.match(block, /## Merged AB\+C/);
+  assert.match(block, /2026-04-28/);
+  assert.match(block, /2026-04-29/);
+  assert.match(block, /2026-04-30/);
+});
+
+test("renderMergedBlock: dedups + sorts source issue IDs", () => {
+  const cluster: CompactionCluster = {
+    sectionIds: ["s0", "s1", "s2"],
+    proposedHeading: "h",
+    proposedBody: "b",
+    rationale: "r",
+    sourceProvenance: [
+      { runId: "r-c", issueId: 102 },
+      { runId: "r-a", issueId: 100 },
+      // Duplicate issueId across two source runs — token should appear once.
+      { runId: "r-a-dup", issueId: 100 },
+      { runId: "r-b", issueId: 101 },
+    ],
+  };
+  const block = renderMergedBlock(cluster, "merge-x", "2026-05-06T00:00:00.000Z");
+  assert.match(block, /issue:#100\+#101\+#102/);
+});
+
+test("compound issue:#100+#101+#102 sentinel parses back via parseClaudeMdSections", () => {
+  const cluster: CompactionCluster = {
+    sectionIds: ["s0", "s1"],
+    proposedHeading: "Merged",
+    proposedBody: "body content",
+    rationale: "shared thesis",
+    sourceProvenance: [
+      { runId: "run-a", issueId: 100 },
+      { runId: "run-b", issueId: 101 },
+    ],
+  };
+  const block = renderMergedBlock(cluster, "merge-1", "2026-05-06T00:00:00.000Z");
+  // The block needs a trailing newline so parseClaudeMdSections's lookahead
+  // for `\n<!--` or end-of-string can terminate the body.
+  const reParsed = parseClaudeMdSections(block + "\n");
+  assert.equal(reParsed.length, 1);
+  assert.equal(reParsed[0].issueId, 100);
+  assert.deepEqual(reParsed[0].issueIds, [100, 101]);
+  assert.equal(reParsed[0].outcome, "compacted");
+});
+
+test("compound issue:#100+#101+#102 sentinel parses back via parseSentinelHeader", () => {
+  // The single-line parser used by the expiry walker (locateSentinels in
+  // sentinels.ts) must also accept compound IDs — otherwise compacted
+  // blocks become invisible to the walker and get absorbed as part of a
+  // previous block's body, with collateral expiry on the previous block's
+  // drop.
+  const line =
+    "<!-- run:merge-1 issue:#100+#101+#102 outcome:compacted ts:2026-05-06T00:00:00.000Z -->";
+  const h = parseSentinelHeader(line);
+  assert.notEqual(h, null);
+  if (!h) return;
+  assert.equal(h.outcome, "compacted");
+  assert.equal(h.issueId, 100);
+  assert.deepEqual(h.issueIds, [100, 101, 102]);
+});
+
+// applyCompaction tests — these chdir into a temp dir so AGENTS_ROOT
+// (computed from process.cwd at module import) resolves to the tmp tree.
+// Since AGENTS_ROOT is captured at module-load time via path.resolve,
+// process.chdir does NOT relocate it. To work around: we'd need to reset
+// the module — but importing once is fine because `agentClaudeMdPath`
+// recomputes from AGENTS_ROOT. Let me re-read… see specialization.ts:
+//   AGENTS_ROOT = path.resolve(process.cwd(), "agents")
+// Captured once. So chdir post-import doesn't help.
+//
+// Workaround: write the file at the path AGENTS_ROOT already points to
+// (i.e. <repo>/agents/<test-id>/CLAUDE.md), use a unique agentId per
+// test, and clean up afterwards. The repo's `agents/` dir is gitignored,
+// so this is safe. Same approach `appendBlock` would need if it had
+// tests.
+
+import { agentClaudeMdPath, AGENTS_ROOT } from "./specialization.js";
+
+async function withTempAgentDir(
+  fn: (agentId: string, filePath: string) => Promise<void>,
+): Promise<void> {
+  const agentId = `test-compact-${Math.random().toString(16).slice(2, 10)}`;
+  const filePath = agentClaudeMdPath(agentId);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  try {
+    await fn(agentId, filePath);
+  } finally {
+    // Best-effort cleanup of the per-test agent dir. Don't blow up if
+    // the file was renamed mid-test or the dir already gone.
+    await fs.rm(path.dirname(filePath), { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+test("applyCompaction: rewrites file under lock + collapses 3 sections to 1 merged block", async () => {
+  await withTempAgentDir(async (agentId, filePath) => {
+    const md = fakeMdContent([
+      { run: "run-a", issue: 100, heading: "Rule A", body: "Past incident 2026-04-28: foo." },
+      { run: "run-b", issue: 101, heading: "Rule B", body: "Past incident 2026-04-29: bar." },
+      { run: "run-c", issue: 102, heading: "Rule C", body: "Past incident 2026-04-30: baz." },
+    ]);
+    await fs.writeFile(filePath, md);
+
+    const proposal: CompactionProposal = {
+      agentId,
+      clusters: [
+        {
+          sectionIds: ["s0", "s1", "s2"],
+          proposedHeading: "Merged ABC",
+          proposedBody:
+            "Combined. Past incidents 2026-04-28, 2026-04-29, 2026-04-30.",
+          rationale: "shared thesis",
+          sourceProvenance: [
+            { runId: "run-a", issueId: 100 },
+            { runId: "run-b", issueId: 101 },
+            { runId: "run-c", issueId: 102 },
+          ],
+        },
+      ],
+      unclusteredSectionIds: [],
+      estimatedBytesSaved: 200,
+      inputBytes: Buffer.byteLength(md, "utf-8"),
+      sectionCount: 3,
+      warnings: [],
+    };
+    const expectedHash = computeProposalHash(proposal, md);
+    const result = await applyCompaction({
+      agentId,
+      proposal,
+      expectedProposalHash: expectedHash,
+      computeProposalHash,
+      runId: "merge-test-1",
+      now: () => "2026-05-06T00:00:00.000Z",
+    });
+    assert.equal(result.kind, "applied");
+    if (result.kind !== "applied") return;
+    assert.equal(result.clustersApplied, 1);
+    assert.equal(result.sectionsMerged, 3);
+
+    const after = await fs.readFile(filePath, "utf-8");
+    const reparsed = parseClaudeMdSections(after);
+    assert.equal(reparsed.length, 1, "compacted file should hold exactly one section");
+    assert.equal(reparsed[0].outcome, "compacted");
+    assert.deepEqual(reparsed[0].issueIds, [100, 101, 102]);
+    assert.match(reparsed[0].body, /2026-04-28/);
+    assert.match(reparsed[0].body, /2026-04-29/);
+    assert.match(reparsed[0].body, /2026-04-30/);
+  });
+});
+
+test("applyCompaction: rejects with proposal-hash drift when file changed between plan and confirm", async () => {
+  await withTempAgentDir(async (agentId, filePath) => {
+    const planMd = fakeMdContent([
+      { run: "run-a", issue: 100, heading: "Rule A", body: "2026-04-28 foo" },
+      { run: "run-b", issue: 101, heading: "Rule B", body: "2026-04-29 bar" },
+      { run: "run-c", issue: 102, heading: "Rule C", body: "2026-04-30 baz" },
+    ]);
+    await fs.writeFile(filePath, planMd);
+
+    const proposal: CompactionProposal = {
+      agentId,
+      clusters: [
+        {
+          sectionIds: ["s0", "s1", "s2"],
+          proposedHeading: "Merged",
+          proposedBody: "Combined 2026-04-28, 2026-04-29, 2026-04-30",
+          rationale: "shared thesis",
+          sourceProvenance: [
+            { runId: "run-a", issueId: 100 },
+            { runId: "run-b", issueId: 101 },
+            { runId: "run-c", issueId: 102 },
+          ],
+        },
+      ],
+      unclusteredSectionIds: [],
+      estimatedBytesSaved: 100,
+      inputBytes: Buffer.byteLength(planMd, "utf-8"),
+      sectionCount: 3,
+      warnings: [],
+    };
+    const planHash = computeProposalHash(proposal, planMd);
+
+    // Drift: append another summarizer block before confirm.
+    const driftMd = planMd + "\n<!-- run:run-d issue:#103 outcome:implement ts:2026-05-06T00:00:00.000Z -->\n## Rule D\n\nNew lesson.\n";
+    await fs.writeFile(filePath, driftMd);
+
+    const result = await applyCompaction({
+      agentId,
+      proposal,
+      expectedProposalHash: planHash,
+      computeProposalHash,
+    });
+    assert.equal(result.kind, "drift-rejected");
+    if (result.kind !== "drift-rejected") return;
+    assert.equal(result.reason, "proposal-hash");
+
+    // File untouched (still drift content).
+    const after = await fs.readFile(filePath, "utf-8");
+    assert.equal(after, driftMd);
+  });
+});
+
+test("applyCompaction: rejects with warnings-present when validator flags a dropped past-incident date", async () => {
+  await withTempAgentDir(async (agentId, filePath) => {
+    const md = fakeMdContent([
+      { run: "run-a", issue: 100, heading: "Rule A", body: "Past incident 2026-04-28: foo." },
+      { run: "run-b", issue: 101, heading: "Rule B", body: "Past incident 2026-04-29: bar." },
+      { run: "run-c", issue: 102, heading: "Rule C", body: "Past incident 2026-04-30: baz." },
+    ]);
+    await fs.writeFile(filePath, md);
+
+    // Lossy proposal: cites only 2026-04-28 in the merged body.
+    const proposal: CompactionProposal = {
+      agentId,
+      clusters: [
+        {
+          sectionIds: ["s0", "s1", "s2"],
+          proposedHeading: "Merged (lossy)",
+          proposedBody: "Combined rule. See 2026-04-28 incident only.",
+          rationale: "shared thesis",
+          sourceProvenance: [
+            { runId: "run-a", issueId: 100 },
+            { runId: "run-b", issueId: 101 },
+            { runId: "run-c", issueId: 102 },
+          ],
+        },
+      ],
+      unclusteredSectionIds: [],
+      estimatedBytesSaved: 50,
+      inputBytes: Buffer.byteLength(md, "utf-8"),
+      sectionCount: 3,
+      warnings: [],
+    };
+    const hash = computeProposalHash(proposal, md);
+    const result = await applyCompaction({
+      agentId,
+      proposal,
+      expectedProposalHash: hash,
+      computeProposalHash,
+    });
+    assert.equal(result.kind, "drift-rejected");
+    if (result.kind !== "drift-rejected") return;
+    assert.equal(result.reason, "warnings-present");
+    assert.match(result.details, /2026-04-29/);
+
+    const after = await fs.readFile(filePath, "utf-8");
+    assert.equal(after, md, "file must not be mutated when validator rejects");
+  });
+});
+
+test("applyCompaction: preserves non-clustered sections verbatim, replaces only the clustered ones", async () => {
+  await withTempAgentDir(async (agentId, filePath) => {
+    const md = fakeMdContent([
+      { run: "run-a", issue: 100, heading: "Rule A", body: "Past incident 2026-04-28 foo" },
+      { run: "run-b", issue: 101, heading: "Rule B", body: "Past incident 2026-04-29 bar" },
+      { run: "run-c", issue: 102, heading: "Rule C", body: "Past incident 2026-04-30 baz" },
+      { run: "run-d", issue: 200, heading: "Distinct rule", body: "Unrelated lesson 2026-05-01" },
+    ]);
+    await fs.writeFile(filePath, md);
+
+    const proposal: CompactionProposal = {
+      agentId,
+      clusters: [
+        {
+          sectionIds: ["s0", "s1", "s2"],
+          proposedHeading: "Merged ABC",
+          proposedBody: "Combined 2026-04-28, 2026-04-29, 2026-04-30",
+          rationale: "shared",
+          sourceProvenance: [
+            { runId: "run-a", issueId: 100 },
+            { runId: "run-b", issueId: 101 },
+            { runId: "run-c", issueId: 102 },
+          ],
+        },
+      ],
+      unclusteredSectionIds: ["s3"],
+      estimatedBytesSaved: 100,
+      inputBytes: Buffer.byteLength(md, "utf-8"),
+      sectionCount: 4,
+      warnings: [],
+    };
+    const hash = computeProposalHash(proposal, md);
+    const result = await applyCompaction({
+      agentId,
+      proposal,
+      expectedProposalHash: hash,
+      computeProposalHash,
+      runId: "merge-test-keep",
+      now: () => "2026-05-06T00:00:00.000Z",
+    });
+    assert.equal(result.kind, "applied");
+
+    const after = await fs.readFile(filePath, "utf-8");
+    const sections = parseClaudeMdSections(after);
+    assert.equal(sections.length, 2);
+    // Order preserved: merged block at the position of s0; distinct rule
+    // (originally s3) follows.
+    assert.equal(sections[0].outcome, "compacted");
+    assert.equal(sections[1].outcome, "implement");
+    assert.equal(sections[1].issueId, 200);
+    assert.match(sections[1].body, /Unrelated lesson 2026-05-01/);
+  });
+});
+
+test("applyCompaction: rejects no-clusters proposal without touching the file", async () => {
+  await withTempAgentDir(async (agentId, filePath) => {
+    const md = fakeMdContent([
+      { run: "run-a", issue: 100, heading: "Rule A", body: "alpha" },
+    ]);
+    await fs.writeFile(filePath, md);
+    const proposal: CompactionProposal = {
+      agentId,
+      clusters: [],
+      unclusteredSectionIds: ["s0"],
+      estimatedBytesSaved: 0,
+      inputBytes: Buffer.byteLength(md, "utf-8"),
+      sectionCount: 1,
+      warnings: [],
+    };
+    const hash = computeProposalHash(proposal, md);
+    const result = await applyCompaction({
+      agentId,
+      proposal,
+      expectedProposalHash: hash,
+      computeProposalHash,
+    });
+    assert.equal(result.kind, "drift-rejected");
+    if (result.kind !== "drift-rejected") return;
+    assert.equal(result.reason, "no-clusters");
+    const after = await fs.readFile(filePath, "utf-8");
+    assert.equal(after, md);
+  });
+});
+
+test("computeProposalHash: stable across calls on identical inputs, drifts on file change", () => {
+  const proposal: CompactionProposal = {
+    agentId: "agent-x",
+    clusters: [],
+    unclusteredSectionIds: [],
+    estimatedBytesSaved: 0,
+    inputBytes: 0,
+    sectionCount: 0,
+    warnings: [],
+  };
+  const file = "alpha";
+  const h1 = computeProposalHash(proposal, file);
+  const h2 = computeProposalHash(proposal, file);
+  assert.equal(h1, h2);
+  const h3 = computeProposalHash(proposal, file + " ");
+  assert.notEqual(h1, h3);
+  assert.equal(typeof h1, "string");
+  assert.match(h1, /^[a-f0-9]{64}$/);
+  assert.match(hashFile(file), /^[a-f0-9]{64}$/);
+});
+
+// AGENTS_ROOT usage in the test suite is informational — not asserted, but
+// surfaced here so a future reader sees how the tmp-agent dir is computed.
+void AGENTS_ROOT;

--- a/src/agent/compactClaudeMd.ts
+++ b/src/agent/compactClaudeMd.ts
@@ -1,5 +1,9 @@
 // Phase A (issue #158) — advisory-only compaction-via-merge for an agent's
 // CLAUDE.md when growth is in section *depth* rather than section *count*.
+// Phase B (issue #162) — destructive `applyCompaction` rewrite under the
+// same per-file lock used by `appendBlock` / `expireSentinels`, gated by a
+// proposalHash drift check and the validator's hard rejection on dropped
+// past-incident dates.
 //
 // The splitter (src/agent/split.ts) addresses a different overload shape:
 // an agent has accumulated multiple distinct sub-specialties that should
@@ -8,17 +12,18 @@
 // across siblings; the right tool is to merge near-duplicate lessons in
 // place, preserving the specialty.
 //
-// This module is purely advisory: it parses sections, asks an opus model
-// to propose merge clusters, validates the proposal (Zod schema + a
-// collapsed-distinct-rules guard), and emits a dry-run report. No file
-// mutation. The destructive `--apply` path is deferred to issue #162.
-//
-// Usage: `vp-dev agents compact-claude-md <agentId> [--json] [--min-cluster-size N]`.
+// Usage:
+//   vp-dev agents compact-claude-md <agentId> [--json] [--min-cluster-size N]
+//   vp-dev agents compact-claude-md <agentId> --apply
+//   vp-dev agents compact-claude-md <agentId> --confirm <token>
 
+import { promises as fs } from "node:fs";
 import { z } from "zod";
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import { claudeBinPath } from "./sdkBinary.js";
 import { parseClaudeMdSections, type ParsedSection } from "./split.js";
+import { agentClaudeMdPath } from "./specialization.js";
+import { withFileLock } from "../state/locks.js";
 import { parseJsonEnvelope } from "../util/parseJsonEnvelope.js";
 import { ORCHESTRATOR_MODEL_SPLIT } from "../orchestrator/models.js";
 import type { AgentRecord } from "../types.js";
@@ -433,12 +438,328 @@ export function formatCompactionProposal(p: CompactionProposal): string {
   lines.push("");
   if (p.warnings.length > 0) {
     lines.push(
-      `⚠ ${p.warnings.length} cluster(s) flagged by the collapsed-distinct-rules validator — review carefully before any --apply path.`,
+      `⚠ ${p.warnings.length} cluster(s) flagged by the collapsed-distinct-rules validator — --apply will reject this proposal until re-run produces a clean output.`,
     );
   } else {
     lines.push(
-      "No validator warnings. (Phase A is advisory only; --apply is tracked at #162.)",
+      "No validator warnings. Pass --apply to mint a confirm token; --confirm <token> to perform the rewrite.",
     );
   }
   return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Phase B (issue #162): destructive applyCompaction
+// ---------------------------------------------------------------------------
+
+export interface ApplyCompactionInput {
+  agentId: string;
+  /** Proposal recorded in the confirm token at plan time. */
+  proposal: CompactionProposal;
+  /** Hash recorded in the confirm token: sha256(JSON.stringify(proposal) + sha256(file@plan)). */
+  expectedProposalHash: string;
+  /** Compute proposalHash from the live file (re-imported here to avoid a cyclical import). */
+  computeProposalHash: (proposal: CompactionProposal, file: string) => string;
+  /** Synthetic runId stamped into the merged sentinels. Defaults to `merge-<ISO>`. */
+  runId?: string;
+  /** Override `Date.now`/timestamp for deterministic tests. Defaults to `new Date().toISOString()`. */
+  now?: () => string;
+}
+
+export type ApplyCompactionResult =
+  | {
+      kind: "applied";
+      bytesBefore: number;
+      bytesAfter: number;
+      clustersApplied: number;
+      sectionsMerged: number;
+      runId: string;
+    }
+  | {
+      kind: "drift-rejected";
+      reason:
+        | "proposal-hash"
+        | "missing-section"
+        | "warnings-present"
+        | "no-clusters"
+        | "missing-file";
+      details: string;
+    };
+
+/**
+ * Apply a Phase A proposal to the agent's CLAUDE.md.
+ *
+ * Steps (all under `withFileLock(filePath)` so the read/validate/rewrite/
+ * rename sequence is atomic against `appendBlock` / `expireSentinels`):
+ *
+ *  1. Re-read the file. Reject if the proposalHash recomputed against the
+ *     current bytes doesn't match the stored hash (file drifted between
+ *     plan and confirm — re-propose required).
+ *  2. Re-parse sections. Reject if any cluster references a sectionId that
+ *     no longer exists.
+ *  3. Re-run the collapsed-distinct-rules validator against the live
+ *     parse. Phase A treats warnings as advisory; Phase B treats them as
+ *     hard rejections (per #162: "if two source sections cite different
+ *     past-incident dates and the merged body cites only one, reject").
+ *  4. Splice the file: keep the prelude + every non-clustered section
+ *     verbatim, replace each cluster's first source section with one
+ *     synthesized merged block, drop the rest. Emit via tmp + atomic
+ *     rename (same write pattern as `appendBlock`).
+ *
+ * The synthesized sentinel uses the issue spec shape:
+ *   <!-- run:merge-<runId> issue:#<N1>+#<N2>+#<N3> outcome:compacted ts:<ISO> -->
+ * `parseClaudeMdSections` and `parseSentinelHeader` accept this compound ID
+ * shape (see `SECTION_RE` in split.ts and `SENTINEL_RE` in sentinels.ts), so
+ * a compacted block re-parses as a single section carrying every source ID.
+ */
+export async function applyCompaction(
+  input: ApplyCompactionInput,
+): Promise<ApplyCompactionResult> {
+  if (input.proposal.clusters.length === 0) {
+    return {
+      kind: "drift-rejected",
+      reason: "no-clusters",
+      details: "Proposal has zero clusters; nothing to apply.",
+    };
+  }
+  const filePath = agentClaudeMdPath(input.agentId);
+  return withFileLock(filePath, async () => {
+    let currentFile: string;
+    try {
+      currentFile = await fs.readFile(filePath, "utf-8");
+    } catch {
+      return {
+        kind: "drift-rejected",
+        reason: "missing-file",
+        details: `agents/${input.agentId}/CLAUDE.md no longer exists; nothing to compact.`,
+      };
+    }
+
+    const computedHash = input.computeProposalHash(input.proposal, currentFile);
+    if (computedHash !== input.expectedProposalHash) {
+      return {
+        kind: "drift-rejected",
+        reason: "proposal-hash",
+        details:
+          "CLAUDE.md content changed between --apply and --confirm. Re-run --apply to generate a fresh proposal + token.",
+      };
+    }
+
+    const sections = parseClaudeMdSectionsWithOffsets(currentFile);
+    const sectionById = new Map(sections.map((s) => [s.sectionId, s]));
+    for (const c of input.proposal.clusters) {
+      for (const sid of c.sectionIds) {
+        if (!sectionById.has(sid)) {
+          return {
+            kind: "drift-rejected",
+            reason: "missing-section",
+            details: `Cluster references sectionId ${sid} which is not present in the current parse.`,
+          };
+        }
+      }
+    }
+
+    const warnings = findDroppedIncidentDates(
+      { clusters: input.proposal.clusters },
+      sections,
+    );
+    if (warnings.length > 0) {
+      const summary = warnings
+        .map(
+          (w) =>
+            `cluster[${w.clusterIndex}] dropped ${w.missingDates.join(",")}`,
+        )
+        .join("; ");
+      return {
+        kind: "drift-rejected",
+        reason: "warnings-present",
+        details: `Collapsed-distinct-rules validator flagged the proposal at apply time: ${summary}. Re-run --apply.`,
+      };
+    }
+
+    const runId = input.runId ?? defaultMergeRunId(input.now);
+    const ts = input.now?.() ?? new Date().toISOString();
+    const rewritten = spliceCompactedSections({
+      currentFile,
+      sections,
+      clusters: input.proposal.clusters,
+      runId,
+      ts,
+    });
+
+    const tmp = `${filePath}.tmp.${process.pid}`;
+    await fs.writeFile(tmp, rewritten);
+    await fs.rename(tmp, filePath);
+
+    const sectionsMerged = input.proposal.clusters.reduce(
+      (acc, c) => acc + c.sectionIds.length,
+      0,
+    );
+    return {
+      kind: "applied",
+      bytesBefore: Buffer.byteLength(currentFile, "utf-8"),
+      bytesAfter: Buffer.byteLength(rewritten, "utf-8"),
+      clustersApplied: input.proposal.clusters.length,
+      sectionsMerged,
+      runId,
+    };
+  });
+}
+
+function defaultMergeRunId(now?: () => string): string {
+  const iso = now?.() ?? new Date().toISOString();
+  // Match the makeRunId() shape (`run-<ISO with : and . replaced by ->`)
+  // so the runId is filesystem-safe and lex-sorts chronologically. Prefix
+  // with `merge-` so a future audit (`grep run:merge- agents/...`) can
+  // identify compaction-emitted blocks.
+  const safe = iso.replace(/[:.]/g, "-");
+  return `merge-${safe}`;
+}
+
+// Position-aware section parser used by Phase B's splicer. Same regex as
+// `parseClaudeMdSections` (re-imported from split.ts so the shape stays
+// in sync) but capture offsets too. Parallel sectionId numbering matches
+// what `parseClaudeMdSections` produces, so cluster.sectionIds bind
+// stable across both views.
+interface SectionWithOffset extends ParsedSection {
+  /** Char offset of the first char of `<!--` in the section's sentinel. */
+  fileStart: number;
+  /** Char offset just past the section's body (lookahead position). */
+  fileEnd: number;
+}
+
+const SECTION_RE_WITH_OFFSETS =
+  /<!--\s*run:(\S+)\s+issue:#(\d+(?:\+#\d+)*)\s+outcome:(\S+)\s+ts:\S+\s*-->\s*\n##\s+(.+?)\n([\s\S]*?)(?=\n<!--\s*run:|$)/g;
+
+function parseClaudeMdSectionsWithOffsets(md: string): SectionWithOffset[] {
+  const out: SectionWithOffset[] = [];
+  let i = 0;
+  for (const m of md.matchAll(SECTION_RE_WITH_OFFSETS)) {
+    const start = m.index ?? 0;
+    const end = start + m[0].length;
+    const issueIds = m[2]
+      .split("+")
+      .map((tok) => Number(tok.replace(/^#/, "")));
+    const section: SectionWithOffset = {
+      sectionId: `s${i++}`,
+      runId: m[1],
+      issueId: issueIds[0],
+      outcome: m[3],
+      heading: m[4].trim(),
+      body: m[5].trim(),
+      fileStart: start,
+      fileEnd: end,
+    };
+    if (issueIds.length > 1) section.issueIds = issueIds;
+    out.push(section);
+  }
+  return out;
+}
+
+interface SpliceInput {
+  currentFile: string;
+  sections: SectionWithOffset[];
+  clusters: CompactionCluster[];
+  runId: string;
+  ts: string;
+}
+
+/**
+ * Walk sections in file order. For sections that aren't part of a cluster,
+ * emit their original bytes. For each cluster, emit the merged block once,
+ * at the position of its first source section in file order; drop the
+ * rest. Inter-block separators (the single `\n` between sentinels) follow
+ * the section they precede — when a section is dropped, its leading `\n`
+ * goes with it so the rewritten file stays well-formed.
+ */
+export function spliceCompactedSections(input: SpliceInput): string {
+  const sectionIdOrder = new Map<string, number>();
+  input.sections.forEach((s, idx) => sectionIdOrder.set(s.sectionId, idx));
+
+  // For each cluster, the canonical position is its earliest member in
+  // file order. The other members are dropped during the walk.
+  const clusterByCanonicalId = new Map<string, CompactionCluster>();
+  const skipSectionIds = new Set<string>();
+  for (const c of input.clusters) {
+    let canonicalIdx = Infinity;
+    let canonicalId = c.sectionIds[0];
+    for (const sid of c.sectionIds) {
+      const idx = sectionIdOrder.get(sid);
+      if (idx === undefined) continue;
+      if (idx < canonicalIdx) {
+        canonicalIdx = idx;
+        canonicalId = sid;
+      }
+    }
+    clusterByCanonicalId.set(canonicalId, c);
+    for (const sid of c.sectionIds) {
+      if (sid !== canonicalId) skipSectionIds.add(sid);
+    }
+  }
+
+  if (input.sections.length === 0) return input.currentFile;
+
+  // Prelude = everything before the first section's sentinel.
+  let out = input.currentFile.slice(0, input.sections[0].fileStart);
+
+  for (let i = 0; i < input.sections.length; i++) {
+    const sec = input.sections[i];
+    const isSkipped = skipSectionIds.has(sec.sectionId);
+    if (!isSkipped) {
+      const cluster = clusterByCanonicalId.get(sec.sectionId);
+      if (cluster) {
+        out += renderMergedBlock(cluster, input.runId, input.ts);
+      } else {
+        out += input.currentFile.slice(sec.fileStart, sec.fileEnd);
+      }
+    }
+    if (i < input.sections.length - 1) {
+      const sep = input.currentFile.slice(
+        sec.fileEnd,
+        input.sections[i + 1].fileStart,
+      );
+      // Each section "owns" the separator that follows it. If we dropped
+      // the section, drop the trailing separator too — otherwise we'd
+      // accumulate stray `\n`s where the merged block doesn't need them.
+      if (!isSkipped) out += sep;
+    } else if (!isSkipped) {
+      // Last section was kept — emit any trailing content (typically a
+      // trailing `\n` written by `appendBlock`).
+      out += input.currentFile.slice(sec.fileEnd);
+    } else {
+      // Last section was skipped — preserve trailing content of the file
+      // (the `appendBlock`-written trailing `\n`) so the file still ends
+      // with a newline.
+      out += input.currentFile.slice(sec.fileEnd);
+    }
+  }
+  return out;
+}
+
+/**
+ * Render a single merged block with the issue-#162 sentinel shape:
+ *
+ *   <!-- run:<runId> issue:#<N1>+#<N2>+#<N3> outcome:compacted ts:<ISO> -->
+ *   ## <heading>
+ *
+ *   <body>
+ *
+ * No trailing newline — the caller (splicer) emits inter-block separators.
+ */
+export function renderMergedBlock(
+  cluster: CompactionCluster,
+  runId: string,
+  ts: string,
+): string {
+  const ids = Array.from(
+    new Set(cluster.sourceProvenance.map((p) => p.issueId)),
+  ).sort((a, b) => a - b);
+  // Compound issue token: `#100+#101+#102`. The first `#` is in front of
+  // the literal in the regex (`issue:#(\d+...)`) so each tok includes its
+  // own `#` from index 1 onwards; here we prepend `#` to all and join.
+  const idToken = ids.length > 0 ? ids.map((n) => `#${n}`).join("+") : "#0";
+  const sentinel = `<!-- run:${runId} issue:${idToken} outcome:compacted ts:${ts} -->`;
+  const heading = `## ${cluster.proposedHeading.trim()}`;
+  const body = cluster.proposedBody.trim();
+  return `${sentinel}\n${heading}\n\n${body}`;
 }

--- a/src/agent/split.ts
+++ b/src/agent/split.ts
@@ -77,7 +77,11 @@ export interface ParsedSection {
   // partitions. Position-based, stable across calls on the same MD file.
   sectionId: string;
   runId?: string;
+  /** Canonical / first issue ID. For non-compacted blocks, the only ID. */
   issueId?: number;
+  /** Set on `outcome:compacted` blocks (issue #162) — the full list of
+   * source issue IDs the merge spans. Undefined for single-issue blocks. */
+  issueIds?: number[];
   outcome?: string;
   heading: string;
   body: string;
@@ -94,21 +98,36 @@ export interface ParsedSection {
 // so the terminator must look for the literal `-->` rather than excluding
 // hyphens. Section body terminates at the next provenance comment OR at
 // EOF — the summarizer always re-emits the comment per appended block.
+//
+// `issue:#N` accepts compound IDs of the shape `#N1+#N2+#N3` (issue #162's
+// `outcome:compacted` blocks) so re-running parsing on a post-merge file
+// surfaces every compacted block as one section carrying every source ID.
+// Single-issue blocks (`issue:#42`) match the same group with one element.
 const SECTION_RE =
-  /<!--\s*run:(\S+)\s+issue:#(\d+)\s+outcome:(\S+)\s+ts:\S+\s*-->\s*\n##\s+(.+?)\n([\s\S]*?)(?=\n<!--\s*run:|$)/g;
+  /<!--\s*run:(\S+)\s+issue:#(\d+(?:\+#\d+)*)\s+outcome:(\S+)\s+ts:\S+\s*-->\s*\n##\s+(.+?)\n([\s\S]*?)(?=\n<!--\s*run:|$)/g;
+
+export function parseIssueIdsFromCapture(raw: string): number[] {
+  // Split `100+#101+#102` → ["100", "#101", "#102"] → [100, 101, 102].
+  return raw.split("+").map((tok) => Number(tok.replace(/^#/, "")));
+}
 
 export function parseClaudeMdSections(md: string): ParsedSection[] {
   const out: ParsedSection[] = [];
   let i = 0;
   for (const m of md.matchAll(SECTION_RE)) {
-    out.push({
+    const issueIds = parseIssueIdsFromCapture(m[2]);
+    const section: ParsedSection = {
       sectionId: `s${i++}`,
       runId: m[1],
-      issueId: Number(m[2]),
+      issueId: issueIds[0],
       outcome: m[3],
       heading: m[4].trim(),
       body: m[5].trim(),
-    });
+    };
+    // Only set when the section encodes multiple IDs — single-ID
+    // sections stay deep-equal-comparable to the pre-#162 shape.
+    if (issueIds.length > 1) section.issueIds = issueIds;
+    out.push(section);
   }
   return out;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,9 +79,17 @@ import {
 } from "./agent/split.js";
 import {
   DEFAULT_MIN_CLUSTER_SIZE,
+  applyCompaction,
   formatCompactionProposal,
   proposeCompaction,
 } from "./agent/compactClaudeMd.js";
+import {
+  computeProposalHash,
+  deleteCompactConfirmToken,
+  mintToken as mintCompactToken,
+  readCompactConfirmToken,
+  writeCompactConfirmToken,
+} from "./state/compactConfirm.js";
 import {
   applyPruneProposal,
   detectPruneCandidates,
@@ -295,7 +303,7 @@ export function buildCli(): Command {
     .addCommand(
       new Command("compact-claude-md")
         .description(
-          "Phase A (#158): propose merge clusters for an agent's CLAUDE.md when growth is in section depth (few large sections). Advisory only — no file mutation. --apply is tracked at #162.",
+          "Propose merge clusters for an agent's CLAUDE.md (#158 Phase A). With --apply: emit a confirm token (15-min TTL); with --confirm <token>: rewrite the file under the per-file lock (#162 Phase B). Two-step is the human-in-the-loop checkpoint — no single-flag silent bypass.",
         )
         .argument("<agentId>", "Agent to inspect (e.g. agent-916a)")
         .option("--json", "Print machine-readable JSON")
@@ -304,6 +312,14 @@ export function buildCli(): Command {
           "Minimum sections per merge cluster (default 3; 2 is too aggressive per issue #158)",
           parsePositive,
           DEFAULT_MIN_CLUSTER_SIZE,
+        )
+        .option(
+          "--apply",
+          "Compute the proposal AND mint a confirm token under state/compact-confirm-<token>.json (15-min TTL). Re-invoke with --confirm <token> to perform the rewrite.",
+        )
+        .option(
+          "--confirm <token>",
+          "Apply the proposal recorded in the named token, after re-validating against the live file content.",
         )
         .action(async (agentId, opts) => {
           await cmdAgentsCompactClaudeMd(agentId, opts);
@@ -1924,12 +1940,26 @@ async function confirmApply(input: {
 interface AgentsCompactClaudeMdOpts {
   json?: boolean;
   minClusterSize: number;
+  apply?: boolean;
+  confirm?: string;
 }
 
 async function cmdAgentsCompactClaudeMd(
   agentId: string,
   opts: AgentsCompactClaudeMdOpts,
 ): Promise<void> {
+  if (opts.apply && opts.confirm) {
+    process.stderr.write(
+      "ERROR: --apply and --confirm are mutually exclusive. Use --apply first, then --confirm <token>.\n",
+    );
+    process.exit(2);
+  }
+
+  if (opts.confirm) {
+    await cmdAgentsCompactClaudeMdConfirm(agentId, opts);
+    return;
+  }
+
   const reg = await loadRegistry();
   const agent = reg.agents.find((a) => a.agentId === agentId);
   if (!agent) {
@@ -1959,11 +1989,134 @@ async function cmdAgentsCompactClaudeMd(
     minClusterSize: opts.minClusterSize,
   });
 
+  if (!opts.apply) {
+    if (opts.json) {
+      process.stdout.write(JSON.stringify({ agentId, proposal }, null, 2) + "\n");
+      return;
+    }
+    process.stdout.write(formatCompactionProposal(proposal) + "\n");
+    return;
+  }
+
+  // --apply path: refuse to mint a token if the proposal isn't safe to apply.
+  // Per #162, validator warnings are a hard rejection (Phase A surfaces them
+  // as advisory; Phase B treats them as the gate). Empty proposals are also
+  // rejected — there's nothing to confirm.
+  if (proposal.clusters.length === 0) {
+    if (opts.json) {
+      process.stdout.write(
+        JSON.stringify({ agentId, proposal, applyRefused: "no-clusters" }, null, 2) + "\n",
+      );
+      return;
+    }
+    process.stdout.write(formatCompactionProposal(proposal) + "\n");
+    process.stdout.write(
+      "\nERROR: --apply refused; proposal has zero merge clusters. Nothing to confirm.\n",
+    );
+    process.exit(2);
+  }
+  if (proposal.warnings.length > 0) {
+    if (opts.json) {
+      process.stdout.write(
+        JSON.stringify(
+          { agentId, proposal, applyRefused: "warnings-present" },
+          null,
+          2,
+        ) + "\n",
+      );
+      return;
+    }
+    process.stdout.write(formatCompactionProposal(proposal) + "\n");
+    process.stdout.write(
+      `\nERROR: --apply refused; ${proposal.warnings.length} cluster(s) flagged by collapsed-distinct-rules validator. Re-run after the model emits a clean proposal.\n`,
+    );
+    process.exit(2);
+  }
+
+  const token = mintCompactToken();
+  const proposalHash = computeProposalHash(proposal, md);
+  await writeCompactConfirmToken({ token, agentId, proposal, proposalHash });
+
   if (opts.json) {
-    process.stdout.write(JSON.stringify({ agentId, proposal }, null, 2) + "\n");
+    process.stdout.write(
+      JSON.stringify(
+        {
+          agentId,
+          proposal,
+          confirmToken: token,
+          proposalHash,
+          confirmCommand: `vp-dev agents compact-claude-md ${agentId} --confirm ${token}`,
+        },
+        null,
+        2,
+      ) + "\n",
+    );
     return;
   }
   process.stdout.write(formatCompactionProposal(proposal) + "\n");
+  process.stdout.write(
+    `\nConfirm token: ${token} (15-min TTL, written to state/compact-confirm-${token}.json)\n` +
+      `Apply with:    vp-dev agents compact-claude-md ${agentId} --confirm ${token}\n` +
+      `If the file changes between now and confirm, the token rejects and you'll need to re-run --apply.\n`,
+  );
+}
+
+async function cmdAgentsCompactClaudeMdConfirm(
+  agentId: string,
+  opts: AgentsCompactClaudeMdOpts,
+): Promise<void> {
+  const token = opts.confirm;
+  if (!token) {
+    process.stderr.write("ERROR: --confirm requires a token argument.\n");
+    process.exit(2);
+  }
+  const read = await readCompactConfirmToken(token);
+  if (!read.ok) {
+    process.stderr.write(`ERROR: ${read.message}\n`);
+    process.exit(2);
+  }
+  if (read.record.agentId !== agentId) {
+    process.stderr.write(
+      `ERROR: token ${token} was minted for agent '${read.record.agentId}', not '${agentId}'.\n`,
+    );
+    process.exit(2);
+  }
+
+  const result = await applyCompaction({
+    agentId,
+    proposal: read.record.proposal,
+    expectedProposalHash: read.record.proposalHash,
+    computeProposalHash,
+  });
+
+  if (result.kind === "drift-rejected") {
+    if (opts.json) {
+      process.stdout.write(
+        JSON.stringify({ agentId, token, result }, null, 2) + "\n",
+      );
+    } else {
+      process.stderr.write(
+        `ERROR: --confirm rejected (${result.reason}): ${result.details}\n`,
+      );
+    }
+    // Don't delete the token on drift — operator may want to re-inspect.
+    process.exit(2);
+  }
+
+  await deleteCompactConfirmToken(token);
+
+  if (opts.json) {
+    process.stdout.write(
+      JSON.stringify({ agentId, token, result }, null, 2) + "\n",
+    );
+    return;
+  }
+  process.stdout.write(
+    `Compacted ${agentId}/CLAUDE.md\n` +
+      `  ${(result.bytesBefore / 1024).toFixed(1)}KB -> ${(result.bytesAfter / 1024).toFixed(1)}KB ` +
+      `(${result.clustersApplied} cluster(s), ${result.sectionsMerged} sections merged)\n` +
+      `  merge runId: ${result.runId}\n`,
+  );
 }
 
 interface AgentsPruneOpts {

--- a/src/state/compactConfirm.ts
+++ b/src/state/compactConfirm.ts
@@ -1,0 +1,135 @@
+// Two-step approval token flow for `vp-dev agents compact-claude-md --apply`.
+//
+// Mirrors `runConfirm.ts` (the `vp-dev run --plan/--confirm` flow) but with a
+// per-agent CompactionProposal binding instead of a run-shape. Phase A's
+// `--apply` step prints the proposal and writes a token under
+// `state/compact-confirm-<token>.json` with a 15-min TTL; the operator
+// reviews the proposal, then re-invokes `--confirm <token>` which re-reads
+// the file, recomputes the proposal hash, and applies the rewrite under the
+// same per-file lock used by `appendBlock` / `expireSentinels`.
+//
+// The proposalHash binds the token to BOTH the proposal text AND the file
+// content at plan time:
+//   proposalHash = sha256(JSON.stringify(proposal) + sha256(currentFile))
+// At confirm time, we recompute with the stored proposal + the live file
+// content; any drift in the file invalidates the token and forces the
+// operator to re-run `--apply`. This is the safety story the destructive
+// path inherits from #133's dedup `--plan/--confirm` and #142's
+// `autoPhaseFollowup` round-trip.
+
+import { promises as fs } from "node:fs";
+import crypto from "node:crypto";
+import path from "node:path";
+import { STATE_DIR, atomicWriteJson } from "./runState.js";
+import type { CompactionProposal } from "../agent/compactClaudeMd.js";
+
+const TOKEN_TTL_MS = 15 * 60 * 1000;
+const TOKEN_FILE_PREFIX = "compact-confirm-";
+
+export interface CompactConfirmRecord {
+  token: string;
+  agentId: string;
+  /** sha256(JSON.stringify(proposal) + sha256(currentFileAtPlanTime)). */
+  proposalHash: string;
+  /** The proposal verbatim — re-used at confirm time without a fresh LLM call. */
+  proposal: CompactionProposal;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export function mintToken(): string {
+  return crypto.randomBytes(8).toString("hex");
+}
+
+export function hashFile(content: string): string {
+  return crypto.createHash("sha256").update(content).digest("hex");
+}
+
+/**
+ * Recipe per issue #162:
+ *   proposalHash = sha256(JSON.stringify(proposal) + sha256(currentFile))
+ * Stable across plan/confirm so long as the proposal object and file bytes
+ * don't change. JSON.stringify of object literals built by the same code
+ * path is order-stable in V8; that's the same assumption #142 makes.
+ */
+export function computeProposalHash(
+  proposal: CompactionProposal,
+  currentFile: string,
+): string {
+  const fileHash = hashFile(currentFile);
+  return crypto
+    .createHash("sha256")
+    .update(JSON.stringify(proposal))
+    .update(fileHash)
+    .digest("hex");
+}
+
+function tokenFilePath(token: string): string {
+  if (!/^[a-f0-9]+$/i.test(token)) {
+    throw new Error("Invalid token format: must be hex.");
+  }
+  return path.join(STATE_DIR, `${TOKEN_FILE_PREFIX}${token}.json`);
+}
+
+export async function writeCompactConfirmToken(input: {
+  token: string;
+  agentId: string;
+  proposal: CompactionProposal;
+  proposalHash: string;
+}): Promise<CompactConfirmRecord> {
+  const now = new Date();
+  const record: CompactConfirmRecord = {
+    token: input.token,
+    agentId: input.agentId,
+    proposalHash: input.proposalHash,
+    proposal: input.proposal,
+    createdAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + TOKEN_TTL_MS).toISOString(),
+  };
+  await atomicWriteJson(tokenFilePath(input.token), record);
+  return record;
+}
+
+export type ReadResult =
+  | { ok: true; record: CompactConfirmRecord }
+  | { ok: false; reason: "missing" | "expired" | "malformed"; message: string };
+
+export async function readCompactConfirmToken(token: string): Promise<ReadResult> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(tokenFilePath(token), "utf-8");
+  } catch {
+    return {
+      ok: false,
+      reason: "missing",
+      message: `No compact token found for ${token}. Re-run with --apply to generate a fresh one.`,
+    };
+  }
+  let record: CompactConfirmRecord;
+  try {
+    record = JSON.parse(raw) as CompactConfirmRecord;
+  } catch {
+    return {
+      ok: false,
+      reason: "malformed",
+      message: `Compact token ${token} is malformed. Re-run with --apply to generate a fresh one.`,
+    };
+  }
+  if (Date.now() > Date.parse(record.expiresAt)) {
+    await deleteCompactConfirmToken(token).catch(() => {});
+    return {
+      ok: false,
+      reason: "expired",
+      message: `Compact token ${token} expired at ${record.expiresAt}. Re-run with --apply to generate a fresh one.`,
+    };
+  }
+  return { ok: true, record };
+}
+
+export async function deleteCompactConfirmToken(token: string): Promise<void> {
+  try {
+    await fs.unlink(tokenFilePath(token));
+  } catch {
+    // already gone — fine
+  }
+}

--- a/src/util/sentinels.ts
+++ b/src/util/sentinels.ts
@@ -6,12 +6,22 @@
 // Pure functions only — file I/O lives in `specialization.ts`. Tested in
 // `sentinels.test.ts` (node --test glob picks up `dist/src/util/*.test.js`).
 
+// `issue:#(\d+(?:\+#\d+)*)` so `outcome:compacted` blocks (issue #162) —
+// which embed multiple source IDs as `issue:#100+#101+#102` — are still
+// located by the expiry walker. Without this, locateSentinels skips the
+// compacted line, the previous block silently absorbs the compacted
+// block's bytes as part of its body, and dropping the previous block on
+// expiry takes the compacted block out as collateral damage.
 const SENTINEL_RE =
-  /^<!--\s+run:(\S+)\s+issue:#(\d+)\s+outcome:([\w-]+)\s+ts:(\S+?)(?:\s+tags:(\S+))?\s+-->$/;
+  /^<!--\s+run:(\S+)\s+issue:#(\d+(?:\+#\d+)*)\s+outcome:([\w-]+)\s+ts:(\S+?)(?:\s+tags:(\S+))?\s+-->$/;
 
 export interface SentinelHeader {
   runId: string;
+  /** Canonical / first issue ID. For non-compacted blocks, the only ID. */
   issueId: number;
+  /** All source issue IDs for `outcome:compacted` blocks (issue #162).
+   * Undefined for single-issue blocks. */
+  issueIds?: number[];
   outcome: string;
   ts: string;
   tags: string[];
@@ -23,13 +33,18 @@ export function parseSentinelHeader(line: string): SentinelHeader | null {
   const tagsRaw = m[5];
   const tags =
     tagsRaw && tagsRaw.length > 0 ? tagsRaw.split(",").filter(Boolean) : [];
-  return {
+  const issueIds = m[2].split("+").map((tok) => Number(tok.replace(/^#/, "")));
+  const header: SentinelHeader = {
     runId: m[1],
-    issueId: Number(m[2]),
+    issueId: issueIds[0],
     outcome: m[3],
     ts: m[4],
     tags,
   };
+  // Only set when the sentinel encodes multiple IDs — keeps the
+  // single-ID shape deep-equal-comparable to the pre-#162 record shape.
+  if (issueIds.length > 1) header.issueIds = issueIds;
+  return header;
 }
 
 export function formatSentinelHeader(input: {


### PR DESCRIPTION
## Summary

Lands the destructive path of `vp-dev agents compact-claude-md`. Phase A
(merged in #164) ships detection + LLM proposal + dry-run output; this PR
ships the apply flow.

- `--apply` recomputes the proposal and refuses to mint a token if the
  validator flags any cluster (collapsed-distinct-rules) or the proposal is
  empty; otherwise writes `state/compact-confirm-<token>.json` (15-min TTL)
  binding `proposalHash = sha256(JSON.stringify(proposal) + sha256(currentFile))`
  per the issue spec.
- `--confirm <token>` re-reads the file under `withFileLock` (the per-file
  lock shared with `appendBlock` / `expireSentinels`), recomputes the hash
  (rejects on file drift), re-runs the validator (rejects on warnings),
  then splices the rewrite + atomic rename.
- Synthesized merged sentinels use the issue-spec shape `<!-- run:merge-<runId>
  issue:#<N1>+#<N2>+#<N3> outcome:compacted ts:<ISO> -->`. Both `SECTION_RE`
  in `split.ts` and `SENTINEL_RE` in `sentinels.ts` are extended to accept
  compound IDs, so compacted blocks remain locatable on subsequent compaction
  or expiry passes — without this, the expiry walker would miss the
  compacted block, the previous block would absorb its bytes as body, and a
  later `expireSentinels` drop on the previous block would take the compacted
  block out as collateral.

## Two-step is the gate

No `--apply --yes` silent bypass — matches the `vp-dev run --plan` / `--confirm`
contract documented in CLAUDE.md "Approval gate before launch". The token
file is the human-in-the-loop checkpoint between propose and rewrite, and
the proposalHash binding makes it impossible to confirm a token against a
file that's drifted since plan time.

## Files

- `src/agent/compactClaudeMd.ts` — `applyCompaction()`, `spliceCompactedSections()`, `renderMergedBlock()`, position-aware section parser
- `src/agent/compactClaudeMd.test.ts` — splicer, drift-reject paths, compound-ID round-trip
- `src/agent/split.ts` — extend `SECTION_RE` to accept compound IDs; add optional `issueIds` field on `ParsedSection`
- `src/util/sentinels.ts` — same extension to `SENTINEL_RE` so the expiry walker locates compacted blocks
- `src/cli.ts` — `--apply` / `--confirm <token>` wiring; mutex check; refusal on warnings or zero clusters
- `src/state/compactConfirm.ts` — token mint/read/delete + `computeProposalHash` recipe

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` (375/375 passing, including 10 new Phase B tests)
- [x] `node dist/bin/vp-dev.js agents compact-claude-md --help` (renders new flags)
- [x] Mutex check: `--apply --confirm <token>` exits 2 with the right error
- [x] Missing-token check: `--confirm deadbeef` exits 2 with re-run guidance

Closes #162.

— hand-implemented by operator (no agent dispatched)