### PR TITLE
fix(compact-claude-md): SECTION_RE accepts tagged sentinels + clamp notes

### DIFF
--- a/src/agent/compactClaudeMd.test.ts
+++ b/src/agent/compactClaudeMd.test.ts
@@ -654,3 +654,77 @@ test("computeProposalHash: stable across calls on identical inputs, drifts on fi
 // AGENTS_ROOT usage in the test suite is informational — not asserted, but
 // surfaced here so a future reader sees how the tmp-agent dir is computed.
 void AGENTS_ROOT;
+
+// ---------------------------------------------------------------------------
+// Regressions surfaced by running Phase A on production agent CLAUDE.md
+// files post-#165 merge. Both bugs blocked the entire feature on any agent
+// that had received a #142+ summarizer pass — i.e. nearly every active one.
+// ---------------------------------------------------------------------------
+
+import { clampClusterFields } from "./compactClaudeMd.js";
+
+test("parseClaudeMdSections: matches sentinels with the optional `tags:` suffix (#142+ shape)", () => {
+  // Pre-fix, SECTION_RE required `ts:\S+\s*-->`, so any sentinel emitted by
+  // appendBlock with a tags fingerprint was silently skipped — Phase A saw
+  // 3/12 sections in agent-92ff, 3/18 in agent-916a. The fix mirrors the
+  // same allowance already in `SENTINEL_RE` (src/util/sentinels.ts).
+  const md =
+    "<!-- run:run-A issue:#100 outcome:implement ts:2026-05-05T00:00:00.000Z tags:cli-gate,phase-split -->\n" +
+    "## Tagged section\n\nbody-A\n" +
+    "<!-- run:run-B issue:#101 outcome:implement ts:2026-05-05T00:01:00.000Z -->\n" +
+    "## Untagged section\n\nbody-B\n";
+  const sections = parseClaudeMdSections(md);
+  assert.equal(sections.length, 2);
+  assert.equal(sections[0].issueId, 100);
+  assert.equal(sections[0].heading, "Tagged section");
+  assert.equal(sections[1].issueId, 101);
+  assert.equal(sections[1].heading, "Untagged section");
+});
+
+test("clampClusterFields: trims top-level `notes` past the 500-char cap", () => {
+  // Pre-fix, `notes` was schema-capped at 500 chars but never clamped, so a
+  // verbose model commentary tripped Zod and the entire proposal hard-failed
+  // (observed crash on agent-9a77 with a 500+ char notes value).
+  const longNotes = "x".repeat(2000);
+  const clamped = clampClusterFields({
+    clusters: [],
+    unclusteredSectionIds: [],
+    notes: longNotes,
+  }) as { notes: string };
+  assert.ok(
+    clamped.notes.length <= 500,
+    `clamped notes must fit the 500-char cap (got ${clamped.notes.length})`,
+  );
+  assert.match(clamped.notes, /\[…truncated\]$/);
+});
+
+test("clampClusterFields: leaves short notes untouched", () => {
+  const out = clampClusterFields({
+    clusters: [],
+    unclusteredSectionIds: [],
+    notes: "short note",
+  }) as { notes: string };
+  assert.equal(out.notes, "short note");
+});
+
+test("clampClusterFields: still trims cluster body / heading / rationale alongside notes", () => {
+  const out = clampClusterFields({
+    clusters: [
+      {
+        sectionIds: ["s0", "s1", "s2"],
+        proposedHeading: "x".repeat(200),
+        proposedBody: "y".repeat(8000),
+        rationale: "z".repeat(1200),
+      },
+    ],
+    unclusteredSectionIds: [],
+    notes: "n".repeat(700),
+  }) as {
+    clusters: Array<{ proposedHeading: string; proposedBody: string; rationale: string }>;
+    notes: string;
+  };
+  assert.ok(out.clusters[0].proposedHeading.length <= 100);
+  assert.ok(out.clusters[0].proposedBody.length <= 6000);
+  assert.ok(out.clusters[0].rationale.length <= 800);
+  assert.ok(out.notes.length <= 500);
+});

--- a/src/agent/compactClaudeMd.ts
+++ b/src/agent/compactClaudeMd.ts
@@ -45,6 +45,11 @@ export const DEFAULT_MIN_CLUSTER_SIZE = 3;
 const HEADING_MAX = 100;
 const BODY_MAX = 6000;
 const RATIONALE_MAX = 800;
+// Top-level model-side `notes` field. Pre-clamp ceiling matches
+// `ProposalPayloadSchema.notes.max(500)`; verbose model commentary used to
+// hard-fail the entire proposal at Zod parse time, which is the wrong
+// failure mode for a cosmetic field that's already advisory.
+const NOTES_MAX = 500;
 
 export interface CompactionCluster {
   /** ≥2 sectionIds from parseClaudeMdSections, all to be merged into one. */
@@ -100,27 +105,32 @@ const ProposalPayloadSchema = z.object({
   notes: z.string().max(500).optional(),
 });
 
-function clampClusterFields(json: unknown): unknown {
+export function clampClusterFields(json: unknown): unknown {
   if (!json || typeof json !== "object") return json;
   const obj = json as Record<string, unknown>;
   const clusters = obj.clusters;
-  if (!Array.isArray(clusters)) return obj;
-  const next = clusters.map((c) => {
-    if (!c || typeof c !== "object") return c;
-    const cluster = c as Record<string, unknown>;
-    const out: Record<string, unknown> = { ...cluster };
-    if (typeof cluster.proposedHeading === "string" && cluster.proposedHeading.length > HEADING_MAX) {
-      out.proposedHeading = cluster.proposedHeading.slice(0, HEADING_MAX - 3) + "...";
-    }
-    if (typeof cluster.proposedBody === "string" && cluster.proposedBody.length > BODY_MAX) {
-      out.proposedBody = cluster.proposedBody.slice(0, BODY_MAX - 16) + "\n[…truncated]";
-    }
-    if (typeof cluster.rationale === "string" && cluster.rationale.length > RATIONALE_MAX) {
-      out.rationale = cluster.rationale.slice(0, RATIONALE_MAX - 16) + "\n[…truncated]";
-    }
-    return out;
-  });
-  return { ...obj, clusters: next };
+  const out: Record<string, unknown> = { ...obj };
+  if (Array.isArray(clusters)) {
+    out.clusters = clusters.map((c) => {
+      if (!c || typeof c !== "object") return c;
+      const cluster = c as Record<string, unknown>;
+      const cOut: Record<string, unknown> = { ...cluster };
+      if (typeof cluster.proposedHeading === "string" && cluster.proposedHeading.length > HEADING_MAX) {
+        cOut.proposedHeading = cluster.proposedHeading.slice(0, HEADING_MAX - 3) + "...";
+      }
+      if (typeof cluster.proposedBody === "string" && cluster.proposedBody.length > BODY_MAX) {
+        cOut.proposedBody = cluster.proposedBody.slice(0, BODY_MAX - 16) + "\n[…truncated]";
+      }
+      if (typeof cluster.rationale === "string" && cluster.rationale.length > RATIONALE_MAX) {
+        cOut.rationale = cluster.rationale.slice(0, RATIONALE_MAX - 16) + "\n[…truncated]";
+      }
+      return cOut;
+    });
+  }
+  if (typeof obj.notes === "string" && (obj.notes as string).length > NOTES_MAX) {
+    out.notes = (obj.notes as string).slice(0, NOTES_MAX - 16) + "\n[…truncated]";
+  }
+  return out;
 }
 
 // ISO-style date matcher: catches `2026-05-05`, `2026-04-28`, etc. Used by
@@ -628,8 +638,13 @@ interface SectionWithOffset extends ParsedSection {
   fileEnd: number;
 }
 
+// Mirrors `SECTION_RE` in split.ts including the optional `tags:` suffix
+// (#142+ summarizer shape). Splicer correctness depends on this matching the
+// same set of sections `parseClaudeMdSections` returns — divergence would
+// mean `cluster.sectionIds` (numbered against split.ts's parse) wouldn't
+// line up with the offsets here.
 const SECTION_RE_WITH_OFFSETS =
-  /<!--\s*run:(\S+)\s+issue:#(\d+(?:\+#\d+)*)\s+outcome:(\S+)\s+ts:\S+\s*-->\s*\n##\s+(.+?)\n([\s\S]*?)(?=\n<!--\s*run:|$)/g;
+  /<!--\s*run:(\S+)\s+issue:#(\d+(?:\+#\d+)*)\s+outcome:(\S+)\s+ts:\S+(?:\s+tags:\S+)?\s*-->\s*\n##\s+(.+?)\n([\s\S]*?)(?=\n<!--\s*run:|$)/g;
 
 function parseClaudeMdSectionsWithOffsets(md: string): SectionWithOffset[] {
   const out: SectionWithOffset[] = [];

--- a/src/agent/split.ts
+++ b/src/agent/split.ts
@@ -103,8 +103,14 @@ export interface ParsedSection {
 // `outcome:compacted` blocks) so re-running parsing on a post-merge file
 // surfaces every compacted block as one section carrying every source ID.
 // Single-issue blocks (`issue:#42`) match the same group with one element.
+//
+// `(?:\s+tags:\S+)?` accepts the optional `tags:t1,t2,...` suffix that
+// `appendBlock` started emitting in #142. Without this, every modern
+// summarizer-emitted sentinel is silently skipped and `parseClaudeMdSections`
+// reports a section count well below the agent's actual lesson count.
+// Mirrors the same allowance already in `SENTINEL_RE` (src/util/sentinels.ts).
 const SECTION_RE =
-  /<!--\s*run:(\S+)\s+issue:#(\d+(?:\+#\d+)*)\s+outcome:(\S+)\s+ts:\S+\s*-->\s*\n##\s+(.+?)\n([\s\S]*?)(?=\n<!--\s*run:|$)/g;
+  /<!--\s*run:(\S+)\s+issue:#(\d+(?:\+#\d+)*)\s+outcome:(\S+)\s+ts:\S+(?:\s+tags:\S+)?\s*-->\s*\n##\s+(.+?)\n([\s\S]*?)(?=\n<!--\s*run:|$)/g;
 
 export function parseIssueIdsFromCapture(raw: string): number[] {
   // Split `100+#101+#102` → ["100", "#101", "#102"] → [100, 101, 102].


### PR DESCRIPTION
## Summary

Two Phase A defects surfaced post-#165 merge when running `vp-dev agents compact-claude-md` on production agent CLAUDE.md files:

**Bug 1 — `SECTION_RE` rejects tagged sentinels.** Since [#142](https://github.com/szhygulin/vaultpilot-development-agents/pull/142) every summarizer-emitted sentinel carries a `tags:t1,t2,...` suffix, but the parser regex required `ts:\S+\s*-->` and silently skipped them. Across the 20 oversized agents the parser saw a small fraction of the actual lessons:

| agent | size | current → fixed |
|---|---|---|
| agent-916a | 56KB | 3 → 18 sections |
| agent-92ff | 42KB | 3 → 12 sections |
| agent-fe90 | 38KB | 2 → 9 sections |
| agent-9a77 | 34KB | 3 → 7 sections |

If `--apply` had run on agent-916a, Phase B would have compacted the 3 visible sections and left the other 15 — actively making the file worse. Fix mirrors the same `(?:\s+tags:\S+)?` allowance already in `SENTINEL_RE` (`src/util/sentinels.ts`).

**Bug 2 — `clampClusterFields` doesn't trim the top-level `notes` field.** `notes: z.string().max(500).optional()` is enforced at parse time, but the clamp only ran over cluster-level fields. Result: a verbose model commentary hard-failed the entire proposal — observed crash on agent-9a77.

## Closing the loop on #162

Issue #162's body said *"Do not dispatch this until Phase A has run on production CLAUDE.md files."* That preflight didn't happen before Phase B shipped; the user's "use the feature now" follow-up is what surfaced both defects post-merge. This PR is the late preflight + the resulting fixes. Re-running Phase A on the heavy four can resume after this lands.

## Files

- `src/agent/split.ts` — `SECTION_RE` adds `(?:\s+tags:\S+)?`
- `src/agent/compactClaudeMd.ts` — `SECTION_RE_WITH_OFFSETS` mirrors; `clampClusterFields` exported, gains `notes` branch; `NOTES_MAX = 500` constant
- `src/agent/compactClaudeMd.test.ts` — 4 regression tests: tagged-sentinel parse, `notes` clamp at boundary, short-notes pass-through, multi-field clamp coexistence

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` (379/379 passing, 4 new regressions)

— hand-implemented by operator (no agent dispatched)