### PR TITLE
fix(compactClaudeMd): bump HEADING_MAX 100→160 for thesis-summary headings

### DIFF
--- a/src/agent/compactClaudeMd.test.ts
+++ b/src/agent/compactClaudeMd.test.ts
@@ -723,7 +723,7 @@ test("clampClusterFields: still trims cluster body / heading / rationale alongsi
     clusters: Array<{ proposedHeading: string; proposedBody: string; rationale: string }>;
     notes: string;
   };
-  assert.ok(out.clusters[0].proposedHeading.length <= 100);
+  assert.ok(out.clusters[0].proposedHeading.length <= 160);
   assert.ok(out.clusters[0].proposedBody.length <= 6000);
   assert.ok(out.clusters[0].rationale.length <= 800);
   assert.ok(out.notes.length <= 500);

--- a/src/agent/compactClaudeMd.ts
+++ b/src/agent/compactClaudeMd.ts
@@ -42,7 +42,12 @@ export const DEFAULT_MIN_CLUSTER_SIZE = 3;
 // be larger than per-section bodies (it's a synthesis), but a generous
 // ceiling prevents the model from emitting essay-length merges that defeat
 // the purpose of compaction.
-const HEADING_MAX = 100;
+// Phase A appendBlock headings are short rule titles; 100 chars is fine.
+// Compaction-via-merge headings are *thesis-summary* headings describing
+// what 3-6 source rules have in common — the model wants 110-145 chars,
+// and a 100-char clamp truncates them with a literal `...` (issue #167).
+// 160 covers observed natural lengths without admitting essay-length headings.
+const HEADING_MAX = 160;
 const BODY_MAX = 6000;
 const RATIONALE_MAX = 800;
 // Top-level model-side `notes` field. Pre-clamp ceiling matches
@@ -364,7 +369,7 @@ Output rules:
 - Each cluster must merge ${minClusterSize}+ sectionIds.
 - Each cluster needs:
   - sectionIds: the section IDs being merged (≥${minClusterSize}).
-  - proposedHeading: a short canonical heading (<= 100 chars). Capture the shared thesis.
+  - proposedHeading: a canonical thesis-summary heading (<= 160 chars). Capture what every source section in the cluster has in common.
   - proposedBody: synthesized body containing every load-bearing detail from the sources. Bullets > prose. Cite every past-incident date verbatim.
   - rationale: 1-3 sentences on why these sections share a thesis.
 - unclusteredSectionIds: sections that don't share a thesis with ${minClusterSize - 1}+ others. Better to leave them than force a weak cluster.


### PR DESCRIPTION
Closes #167

## Summary

Bump `HEADING_MAX` from 100 → 160 in `src/agent/compactClaudeMd.ts`. The first production-data run of compaction Phase A+B truncated all three merged blocks with a literal `...` because the model's natural thesis-summary headings (observed range ~105–145 chars) overshot the 100-char clamp.

## Why 160

100 chars is fine for Phase A `appendBlock` headings (one rule → one short title) but too tight for compaction headings, which describe what 3–6 source rules have in common. 160 covers the model's observed natural length without admitting essay-length headings. The cap flows through a single const that's referenced by `ClusterSchema.proposedHeading.max(...)`, the `clampClusterFields` clamp, and the system-prompt instruction, so the bump is single-source-of-truth.

## Files

- `src/agent/compactClaudeMd.ts` — bump const + matching prompt language (`<= 100 chars` → `<= 160 chars`).
- `src/agent/compactClaudeMd.test.ts` — `assert.ok(...length <= 100)` → `<= 160` for the clamp test.

## Out of scope

- Phase A appendBlock cap unchanged (different concept, different file).
- Splitter `NAME_MAX = 60` unchanged (cluster proposed-name, not section heading).

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 379/379 pass

— Advisory Scope Boundary (agent-916a)
