### PR TITLE
feat(compact): add --allow-pair-clusters opt-in for clean 2-section near-duplicates

### DIFF
--- a/src/agent/compactClaudeMd.test.ts
+++ b/src/agent/compactClaudeMd.test.ts
@@ -8,9 +8,11 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   DEFAULT_MIN_CLUSTER_SIZE,
+  PAIR_CLUSTER_FLOOR,
   extractDistinctDates,
   findDroppedIncidentDates,
   formatCompactionProposal,
+  resolveMinClusterSize,
   type CompactionProposal,
 } from "./compactClaudeMd.js";
 import { parseClaudeMdSections } from "./split.js";
@@ -229,6 +231,46 @@ test("formatCompactionProposal: clean proposal points at the --apply / --confirm
 
 test("DEFAULT_MIN_CLUSTER_SIZE: documented default is 3 (per issue #158 — 2 too aggressive)", () => {
   assert.equal(DEFAULT_MIN_CLUSTER_SIZE, 3);
+});
+
+test("PAIR_CLUSTER_FLOOR: documented floor lowered by --allow-pair-clusters is 2 (per issue #168)", () => {
+  assert.equal(PAIR_CLUSTER_FLOOR, 2);
+});
+
+test("resolveMinClusterSize: default (no flag) keeps explicit minClusterSize unchanged", () => {
+  assert.equal(resolveMinClusterSize({ minClusterSize: 3 }), 3);
+  assert.equal(resolveMinClusterSize({ minClusterSize: 5 }), 5);
+  assert.equal(
+    resolveMinClusterSize({ minClusterSize: 3, allowPairClusters: false }),
+    3,
+  );
+});
+
+test("resolveMinClusterSize: --allow-pair-clusters lowers floor to 2 when minClusterSize > 2", () => {
+  assert.equal(
+    resolveMinClusterSize({ minClusterSize: 3, allowPairClusters: true }),
+    2,
+  );
+  assert.equal(
+    resolveMinClusterSize({ minClusterSize: DEFAULT_MIN_CLUSTER_SIZE, allowPairClusters: true }),
+    2,
+  );
+  assert.equal(
+    resolveMinClusterSize({ minClusterSize: 7, allowPairClusters: true }),
+    2,
+  );
+});
+
+test("resolveMinClusterSize: --allow-pair-clusters is a no-op when minClusterSize already at or below floor", () => {
+  assert.equal(
+    resolveMinClusterSize({ minClusterSize: 2, allowPairClusters: true }),
+    2,
+  );
+  // Explicit lower-than-floor choice wins — pair-clusters never raises.
+  assert.equal(
+    resolveMinClusterSize({ minClusterSize: 1, allowPairClusters: true }),
+    1,
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/src/agent/compactClaudeMd.ts
+++ b/src/agent/compactClaudeMd.ts
@@ -38,6 +38,30 @@ const COMPACT_MODEL = ORCHESTRATOR_MODEL_SPLIT;
 // near-duplicate gets merged and loses nuance). Operator-tunable from CLI.
 export const DEFAULT_MIN_CLUSTER_SIZE = 3;
 
+// Floor lowered by `--allow-pair-clusters` (issue #168). The default-3 floor
+// IS the safety story; pair clusters need a human deciding "yes, these two
+// are tight enough to merge" — which is exactly what the existing
+// `--apply` / `--confirm` two-step gate provides.
+export const PAIR_CLUSTER_FLOOR = 2;
+
+/**
+ * Resolve the effective `minClusterSize` for a compaction invocation.
+ *
+ * `--allow-pair-clusters` is sugar for "lower the floor to 2 if it would
+ * otherwise be higher" (issue #168). If the operator explicitly passed
+ * `--min-cluster-size <n>` with `n < 2`, that explicit choice wins —
+ * pair-clusters never raises the floor.
+ */
+export function resolveMinClusterSize(opts: {
+  minClusterSize: number;
+  allowPairClusters?: boolean;
+}): number {
+  if (opts.allowPairClusters && opts.minClusterSize > PAIR_CLUSTER_FLOOR) {
+    return PAIR_CLUSTER_FLOOR;
+  }
+  return opts.minClusterSize;
+}
+
 // Per-field caps on the LLM proposal payload. `proposedBody` can legitimately
 // be larger than per-section bodies (it's a synthesis), but a generous
 // ceiling prevents the model from emitting essay-length merges that defeat

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -82,6 +82,7 @@ import {
   applyCompaction,
   formatCompactionProposal,
   proposeCompaction,
+  resolveMinClusterSize,
 } from "./agent/compactClaudeMd.js";
 import {
   computeProposalHash,
@@ -312,6 +313,10 @@ export function buildCli(): Command {
           "Minimum sections per merge cluster (default 3; 2 is too aggressive per issue #158)",
           parsePositive,
           DEFAULT_MIN_CLUSTER_SIZE,
+        )
+        .option(
+          "--allow-pair-clusters",
+          "Lower the cluster-size floor to 2 for this invocation (sugar for --min-cluster-size 2). Surfaces clean 2-section near-duplicates the default-3 floor would orphan; the --apply/--confirm gate is the human-in-the-loop check (per issue #168).",
         )
         .option(
           "--apply",
@@ -1942,6 +1947,7 @@ interface AgentsCompactClaudeMdOpts {
   minClusterSize: number;
   apply?: boolean;
   confirm?: string;
+  allowPairClusters?: boolean;
 }
 
 async function cmdAgentsCompactClaudeMd(
@@ -1980,13 +1986,20 @@ async function cmdAgentsCompactClaudeMd(
     process.exit(2);
   }
 
+  const minClusterSize = resolveMinClusterSize({
+    minClusterSize: opts.minClusterSize,
+    allowPairClusters: opts.allowPairClusters,
+  });
+  const floorNote = opts.allowPairClusters && minClusterSize !== opts.minClusterSize
+    ? " (lowered by --allow-pair-clusters)"
+    : "";
   process.stdout.write(
-    `Generating compaction proposal for ${agentId} (min-cluster-size=${opts.minClusterSize})...\n`,
+    `Generating compaction proposal for ${agentId} (min-cluster-size=${minClusterSize}${floorNote})...\n`,
   );
   const proposal = await proposeCompaction({
     agent,
     claudeMd: md,
-    minClusterSize: opts.minClusterSize,
+    minClusterSize,
   });
 
   if (!opts.apply) {


### PR DESCRIPTION
Closes #168

## Summary

Adds `--allow-pair-clusters` to `vp-dev agents compact-claude-md`. Default `min-cluster-size=3` stays the safety story (per #158: 2 is too aggressive for unattended runs). The new opt-in flag lowers the floor to 2 *for the current invocation only*, surfacing clean 2-section near-duplicates that the default-3 floor otherwise orphans on overloaded agents.

The existing `--apply` / `--confirm` two-step gate is unchanged — it remains the human-in-the-loop checkpoint that decides "yes, these two are tight enough to merge". No single-flag silent bypass.

## What changed

- `src/agent/compactClaudeMd.ts`: new `PAIR_CLUSTER_FLOOR = 2` constant + exported `resolveMinClusterSize({minClusterSize, allowPairClusters})` helper. The helper centralizes the "lower the floor to 2 if it would otherwise be higher" rule; an explicit `--min-cluster-size 1` still wins over the flag (pair-clusters never raises).
- `src/cli.ts`: new `--allow-pair-clusters` flag on the `compact-claude-md` command; `cmdAgentsCompactClaudeMd` resolves the effective floor via the helper and surfaces the lowered value in the "Generating compaction proposal..." line so the operator sees the active floor.
- `src/agent/compactClaudeMd.test.ts`: 4 new unit tests covering the resolution table — default no-op, lowering when explicit `>2`, no-op when already `≤2`, and explicit `1` winning over the flag.

## Composition with existing flags

`--allow-pair-clusters` composes with `--min-cluster-size <n>`:
- `--allow-pair-clusters` alone (default min=3) → effective floor 2
- `--min-cluster-size 5 --allow-pair-clusters` → effective floor 2
- `--min-cluster-size 2` (no flag) → effective floor 2 (same effect, less ergonomic)
- `--min-cluster-size 1 --allow-pair-clusters` → effective floor 1 (explicit lower wins)

## Validator behavior

Unchanged. The collapsed-distinct-rules validator runs identically on pair clusters; pairs that drop a past-incident date still hard-reject at `--apply`.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm test` — 383 tests pass (4 new)
- [ ] Manual smoke: `vp-dev agents compact-claude-md agent-fe90 --allow-pair-clusters` returns the s0+s1 / s6+s7 pair clusters cited in #168

— Alonzo (agent-92ff)
