### PR TITLE
feat(cli): add Phase A `vp-dev agents tighten-claude-md` (#172)

### DIFF
--- a/src/agent/tightenClaudeMd.test.ts
+++ b/src/agent/tightenClaudeMd.test.ts
@@ -1,0 +1,408 @@
+// Phase A (issue #172) tests: invariant-extraction matchers, the
+// dropped-invariant validator (each warning kind), savings-cap warning,
+// schema clamp, and the dry-run formatter shape. No LLM is called —
+// `proposeTighten` is exercised end-to-end only indirectly via its pure
+// helpers, since the live network/SDK call is the expensive part and
+// adds nothing to per-PR coverage.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_MAX_SAVINGS_PCT,
+  clampRewriteFields,
+  extractDistinctDates,
+  extractDistinctNumerics,
+  extractDistinctXrefs,
+  findDroppedInvariants,
+  formatTightenProposal,
+  type SectionRewrite,
+  type TightenProposal,
+} from "./tightenClaudeMd.js";
+import { parseClaudeMdSections, type ParsedSection } from "./split.js";
+
+function fakeMd(
+  sections: Array<{ run: string; issue: number; heading: string; body: string }>,
+): string {
+  return (
+    sections
+      .map(
+        (s) =>
+          `<!-- run:${s.run} issue:#${s.issue} outcome:implement ts:2026-05-05T12:00:00.000Z -->\n## ${s.heading}\n\n${s.body}`,
+      )
+      .join("\n") + "\n"
+  );
+}
+
+test("extractDistinctDates: pulls ISO-style dates, ignores version numbers", () => {
+  const dates = extractDistinctDates(
+    "Past incident 2026-05-05: thing happened. Version 1.2.345 and 12-34-56 do not count. Also 2026-04-28 cited.",
+  );
+  assert.deepEqual([...dates].sort(), ["2026-04-28", "2026-05-05"]);
+});
+
+test("extractDistinctXrefs: pulls #NNN issue/PR refs", () => {
+  const refs = extractDistinctXrefs(
+    "See [#162](https://example) and #170 and PR #171. Tag #data is not a ref (no digits).",
+  );
+  // Note: `#171.` — trailing punctuation is fine, regex stops at non-digit.
+  assert.deepEqual([...refs].sort(), ["#162", "#170", "#171"]);
+});
+
+test("extractDistinctXrefs: returns empty set for body with no cross-refs", () => {
+  const refs = extractDistinctXrefs("Plain text with no GitHub refs.");
+  assert.equal(refs.size, 0);
+});
+
+test("extractDistinctNumerics: pulls number+unit pairs, normalizes unit case", () => {
+  const nums = extractDistinctNumerics(
+    "30KB threshold; 50 turns budget; 15 min TTL; 1.5× calibration; 40% cap; 30 kb again.",
+  );
+  // `30KB` and `30 kb` normalize to the same token (case-insensitive on
+  // the unit, exact on the number).
+  assert.ok(nums.has("30kb"));
+  assert.ok(nums.has("50turns"));
+  assert.ok(nums.has("15min"));
+  assert.ok(nums.has("1.5×"));
+  assert.ok(nums.has("40%"));
+  // `30 kb` should collapse with `30KB` — same token.
+  const allKb = [...nums].filter((n) => n.endsWith("kb"));
+  assert.equal(allKb.length, 1);
+});
+
+test("extractDistinctNumerics: returns empty set for body with no recognized numerics", () => {
+  // Bare numerics without recognized units don't match — conservative on
+  // purpose to avoid false positives on version numbers, line counts, etc.
+  const nums = extractDistinctNumerics("K=3 factor 1.5 step 12.");
+  assert.equal(nums.size, 0);
+});
+
+test("findDroppedInvariants: flags rewrite that drops an ISO date", () => {
+  const md = fakeMd([
+    {
+      run: "run-A",
+      issue: 100,
+      heading: "Rule A",
+      body: "Past incident 2026-04-28: foo. Past incident 2026-05-05: bar.",
+    },
+  ]);
+  const sections = parseClaudeMdSections(md);
+  const warnings = findDroppedInvariants({
+    rewrites: [
+      {
+        sectionId: "s0",
+        rewrittenBody: "Combined rule. Past incident 2026-05-05 only.",
+        estimatedBytesSaved: 10,
+      },
+    ],
+    sections,
+    maxSavingsPct: 100, // disable savings warning to isolate the date check
+  });
+  const dateWarn = warnings.find((w) => w.kind === "dropped-incident-date");
+  assert.ok(dateWarn, "expected a dropped-incident-date warning");
+  if (dateWarn?.kind === "dropped-incident-date") {
+    assert.deepEqual(dateWarn.missingDates, ["2026-04-28"]);
+  }
+});
+
+test("findDroppedInvariants: flags rewrite that drops a #NNN cross-reference", () => {
+  const md = fakeMd([
+    {
+      run: "run-A",
+      issue: 100,
+      heading: "Rule A",
+      body: "See #162 and #165 for context. The fix landed in #166.",
+    },
+  ]);
+  const sections = parseClaudeMdSections(md);
+  const warnings = findDroppedInvariants({
+    rewrites: [
+      {
+        sectionId: "s0",
+        // Drops #166 entirely.
+        rewrittenBody: "See #162 and #165 for context.",
+        estimatedBytesSaved: 30,
+      },
+    ],
+    sections,
+    maxSavingsPct: 100,
+  });
+  const refWarn = warnings.find((w) => w.kind === "dropped-cross-reference");
+  assert.ok(refWarn, "expected a dropped-cross-reference warning");
+  if (refWarn?.kind === "dropped-cross-reference") {
+    assert.deepEqual(refWarn.missingRefs, ["#166"]);
+  }
+});
+
+test("findDroppedInvariants: flags rewrite that drops a numeric threshold", () => {
+  const md = fakeMd([
+    {
+      run: "run-A",
+      issue: 100,
+      heading: "Rule A",
+      body: "30KB threshold; 50 turns budget; 15 min TTL.",
+    },
+  ]);
+  const sections = parseClaudeMdSections(md);
+  const warnings = findDroppedInvariants({
+    rewrites: [
+      {
+        sectionId: "s0",
+        // Drops 50 turns.
+        rewrittenBody: "30KB threshold; 15 min TTL.",
+        estimatedBytesSaved: 12,
+      },
+    ],
+    sections,
+    maxSavingsPct: 100,
+  });
+  const numWarn = warnings.find((w) => w.kind === "dropped-numeric-threshold");
+  assert.ok(numWarn, "expected a dropped-numeric-threshold warning");
+  if (numWarn?.kind === "dropped-numeric-threshold") {
+    assert.deepEqual(numWarn.missingNumerics, ["50turns"]);
+  }
+});
+
+test("findDroppedInvariants: clean rewrite with all invariants preserved -> no warning", () => {
+  const md = fakeMd([
+    {
+      run: "run-A",
+      issue: 100,
+      heading: "Rule A",
+      body: "Past incident 2026-04-28; see #162; 30KB threshold.",
+    },
+  ]);
+  const sections = parseClaudeMdSections(md);
+  const warnings = findDroppedInvariants({
+    rewrites: [
+      {
+        sectionId: "s0",
+        rewrittenBody: "2026-04-28 incident; #162; 30KB threshold.",
+        estimatedBytesSaved: 15,
+      },
+    ],
+    sections,
+    maxSavingsPct: 100,
+  });
+  assert.equal(warnings.length, 0);
+});
+
+test("findDroppedInvariants: flags excessive-savings when rewrite shrinks body more than max-savings-pct", () => {
+  const md = fakeMd([
+    {
+      run: "run-A",
+      issue: 100,
+      heading: "Rule A",
+      // 100-byte body — easy to compute percentages.
+      body: "x".repeat(100),
+    },
+  ]);
+  const sections = parseClaudeMdSections(md);
+  // Rewrite to 30 bytes — 70% reduction, exceeds 40% cap.
+  const rewrites: SectionRewrite[] = [
+    { sectionId: "s0", rewrittenBody: "x".repeat(30), estimatedBytesSaved: 70 },
+  ];
+  const warnings = findDroppedInvariants({
+    rewrites,
+    sections,
+    maxSavingsPct: 40,
+  });
+  const savWarn = warnings.find((w) => w.kind === "excessive-savings");
+  assert.ok(savWarn, "expected an excessive-savings warning");
+  if (savWarn?.kind === "excessive-savings") {
+    assert.equal(savWarn.savingsPct, 70);
+    assert.equal(savWarn.maxSavingsPct, 40);
+  }
+});
+
+test("findDroppedInvariants: excessive-savings does not fire at exactly the cap", () => {
+  const md = fakeMd([
+    {
+      run: "run-A",
+      issue: 100,
+      heading: "Rule A",
+      body: "x".repeat(100),
+    },
+  ]);
+  const sections = parseClaudeMdSections(md);
+  // Rewrite to 60 bytes — exactly 40% reduction, at the cap.
+  const rewrites: SectionRewrite[] = [
+    { sectionId: "s0", rewrittenBody: "x".repeat(60), estimatedBytesSaved: 40 },
+  ];
+  const warnings = findDroppedInvariants({
+    rewrites,
+    sections,
+    maxSavingsPct: 40,
+  });
+  assert.equal(warnings.find((w) => w.kind === "excessive-savings"), undefined);
+});
+
+test("findDroppedInvariants: ignores zero-byte source bodies (no division by zero)", () => {
+  const sections: ParsedSection[] = [
+    {
+      sectionId: "s0",
+      runId: "run-A",
+      issueId: 100,
+      outcome: "implement",
+      heading: "h",
+      body: "",
+    },
+  ];
+  const warnings = findDroppedInvariants({
+    rewrites: [
+      { sectionId: "s0", rewrittenBody: "tiny", estimatedBytesSaved: 0 },
+    ],
+    sections,
+    maxSavingsPct: 40,
+  });
+  assert.equal(warnings.length, 0);
+});
+
+test("findDroppedInvariants: composes multiple warnings on the same rewrite", () => {
+  const md = fakeMd([
+    {
+      run: "run-A",
+      issue: 100,
+      heading: "Rule A",
+      body:
+        "Past incident 2026-04-28; see #162; 30KB threshold; 50 turns budget. " +
+        "x".repeat(200), // pad to 200+ bytes so reductions trip both invariants AND cap
+    },
+  ]);
+  const sections = parseClaudeMdSections(md);
+  // Drop #162, drop 50 turns, AND >40% reduction.
+  const rewrites: SectionRewrite[] = [
+    {
+      sectionId: "s0",
+      rewrittenBody: "2026-04-28; 30KB.",
+      estimatedBytesSaved: 200,
+    },
+  ];
+  const warnings = findDroppedInvariants({
+    rewrites,
+    sections,
+    maxSavingsPct: 40,
+  });
+  const kinds = warnings.map((w) => w.kind).sort();
+  assert.deepEqual(kinds, [
+    "dropped-cross-reference",
+    "dropped-numeric-threshold",
+    "excessive-savings",
+  ]);
+});
+
+test("clampRewriteFields: trims rewrittenBody past BODY_MAX", () => {
+  const huge = "y".repeat(8000);
+  const out = clampRewriteFields({
+    rewrites: [{ sectionId: "s0", rewrittenBody: huge }],
+    unchangedSectionIds: [],
+  }) as { rewrites: Array<{ rewrittenBody: string }> };
+  assert.ok(out.rewrites[0].rewrittenBody.length <= 6000);
+  assert.match(out.rewrites[0].rewrittenBody, /\[…truncated\]$/);
+});
+
+test("clampRewriteFields: trims notes past 500-char cap", () => {
+  const longNotes = "n".repeat(900);
+  const out = clampRewriteFields({
+    rewrites: [],
+    unchangedSectionIds: [],
+    notes: longNotes,
+  }) as { notes: string };
+  assert.ok(out.notes.length <= 500);
+  assert.match(out.notes, /\[…truncated\]$/);
+});
+
+test("clampRewriteFields: leaves short notes / short body untouched", () => {
+  const out = clampRewriteFields({
+    rewrites: [{ sectionId: "s0", rewrittenBody: "short body" }],
+    unchangedSectionIds: [],
+    notes: "short note",
+  }) as {
+    rewrites: Array<{ rewrittenBody: string }>;
+    notes: string;
+  };
+  assert.equal(out.rewrites[0].rewrittenBody, "short body");
+  assert.equal(out.notes, "short note");
+});
+
+test("formatTightenProposal: zero-rewrite proposal renders the no-op note", () => {
+  const proposal: TightenProposal = {
+    agentId: "agent-test",
+    rewrites: [],
+    unchangedSectionIds: ["s0", "s1"],
+    estimatedBytesSaved: 0,
+    inputBytes: 4096,
+    sectionCount: 2,
+    notes: "All sections already tight; no rewrite proposed.",
+    warnings: [],
+    maxSavingsPct: DEFAULT_MAX_SAVINGS_PCT,
+  };
+  const out = formatTightenProposal(proposal);
+  assert.match(out, /Tighten proposal for agent-test/);
+  assert.match(out, /no rewrites proposed/);
+  assert.match(out, /All sections already tight/);
+});
+
+test("formatTightenProposal: surfaces all four warning kinds inline per rewrite", () => {
+  const proposal: TightenProposal = {
+    agentId: "agent-test",
+    rewrites: [
+      { sectionId: "s0", rewrittenBody: "tight", estimatedBytesSaved: 200 },
+    ],
+    unchangedSectionIds: ["s1"],
+    estimatedBytesSaved: 200,
+    inputBytes: 8192,
+    sectionCount: 2,
+    warnings: [
+      {
+        kind: "dropped-incident-date",
+        sectionId: "s0",
+        missingDates: ["2026-04-28"],
+      },
+      {
+        kind: "dropped-cross-reference",
+        sectionId: "s0",
+        missingRefs: ["#162"],
+      },
+      {
+        kind: "dropped-numeric-threshold",
+        sectionId: "s0",
+        missingNumerics: ["50turns"],
+      },
+      {
+        kind: "excessive-savings",
+        sectionId: "s0",
+        savingsPct: 70,
+        maxSavingsPct: 40,
+      },
+    ],
+    maxSavingsPct: 40,
+  };
+  const out = formatTightenProposal(proposal);
+  assert.match(out, /DROPPED DATES: 2026-04-28/);
+  assert.match(out, /DROPPED REFS: #162/);
+  assert.match(out, /DROPPED NUMERICS: 50turns/);
+  assert.match(out, /EXCESSIVE SAVINGS: 70% > 40%/);
+  assert.match(out, /4 validator finding\(s\)/);
+});
+
+test("formatTightenProposal: clean proposal points at the --apply path tracker", () => {
+  const proposal: TightenProposal = {
+    agentId: "agent-test",
+    rewrites: [
+      { sectionId: "s0", rewrittenBody: "tight", estimatedBytesSaved: 100 },
+    ],
+    unchangedSectionIds: [],
+    estimatedBytesSaved: 100,
+    inputBytes: 4096,
+    sectionCount: 1,
+    warnings: [],
+    maxSavingsPct: DEFAULT_MAX_SAVINGS_PCT,
+  };
+  const out = formatTightenProposal(proposal);
+  assert.match(out, /No validator warnings/);
+  assert.match(out, /#173/);
+});
+
+test("DEFAULT_MAX_SAVINGS_PCT: documented default is 40 (per issue #172)", () => {
+  assert.equal(DEFAULT_MAX_SAVINGS_PCT, 40);
+});

--- a/src/agent/tightenClaudeMd.ts
+++ b/src/agent/tightenClaudeMd.ts
@@ -1,0 +1,507 @@
+// Phase A (issue #172, of #169 split per Cook's pushback) — advisory-only
+// intra-section prose tightening for an agent's CLAUDE.md.
+//
+// Compact (#158/#162) addresses *cross-section* growth: many sections
+// share a thesis, merge them. Tighten addresses *within-section* growth:
+// a single coherent section with verbose prose that could say the same
+// thing in fewer bytes. Compact's splicer copies non-clustered sections
+// verbatim, so verbose-but-distinct sections fall through both tools
+// untouched today — this fills that gap.
+//
+// Phase A is purely advisory: it parses sections, asks an opus model to
+// rewrite each body more concisely, validates the rewrite (Zod schema +
+// dropped-invariant guards), and emits a per-section dry-run report. No
+// file mutation. The destructive `--apply` path is deferred to issue #173,
+// gated on Phase A having been exercised on real production CLAUDE.md
+// files for at least one full month — same deferral pattern as #158→#162.
+//
+// Usage: `vp-dev agents tighten-claude-md <agentId> [--json] [--max-savings-pct N]`.
+
+import { z } from "zod";
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { claudeBinPath } from "./sdkBinary.js";
+import { parseClaudeMdSections, type ParsedSection } from "./split.js";
+import { parseJsonEnvelope } from "../util/parseJsonEnvelope.js";
+import { ORCHESTRATOR_MODEL_SPLIT } from "../orchestrator/models.js";
+import type { AgentRecord } from "../types.js";
+
+// Shares compact's tier (opus) — both are full-CLAUDE.md → structured
+// proposal calls and rewrite quality matters more than per-call cost. Env
+// override flows through `models.ts`.
+const TIGHTEN_MODEL = ORCHESTRATOR_MODEL_SPLIT;
+
+// Default cap on per-section savings. Above this percentage the model is
+// likely paraphrasing-with-loss rather than tightening — the validator
+// catches dropped dates / xrefs / numerics, but watery rewrites (drop a
+// "for example" clause that isn't a load-bearing date) can still erode
+// nuance. Operator-tunable from CLI.
+export const DEFAULT_MAX_SAVINGS_PCT = 40;
+
+// Per-field caps on the LLM proposal payload. `rewrittenBody` lower-bound
+// is 1 (a section with empty body shouldn't appear in source — the parser
+// trims whitespace, but a one-char body is technically valid). Upper bound
+// matches compact's BODY_MAX so a verbose model emission gets clamped
+// instead of hard-failing the whole proposal.
+const BODY_MIN = 1;
+const BODY_MAX = 6000;
+
+export interface SectionRewrite {
+  /** sectionId from `parseClaudeMdSections`. */
+  sectionId: string;
+  /** New body the model wants to substitute for the source body. */
+  rewrittenBody: string;
+  /** sourceBytes - rewrittenBytes. Always non-negative; rewrites that
+   *  *grow* the body are dropped pre-validation (model misunderstood). */
+  estimatedBytesSaved: number;
+}
+
+export interface TightenProposal {
+  agentId: string;
+  rewrites: SectionRewrite[];
+  /** sectionIds the model declined to rewrite. Better to leave a tight
+   *  section alone than force a worse rewrite. */
+  unchangedSectionIds: string[];
+  estimatedBytesSaved: number;
+  inputBytes: number;
+  sectionCount: number;
+  /** Optional model-side note on caveats. */
+  notes?: string;
+  /** Per-rewrite validator findings. Phase A surfaces them as advisory;
+   *  the destructive `--apply` path (#173) treats them as hard rejections. */
+  warnings: TightenWarning[];
+  /** Cap surfaced in the gate text — included for symmetry with the CLI
+   *  flag so a `--json` consumer can see what threshold was applied. */
+  maxSavingsPct: number;
+}
+
+export type TightenWarning =
+  | {
+      kind: "dropped-incident-date";
+      sectionId: string;
+      missingDates: string[];
+    }
+  | {
+      kind: "dropped-cross-reference";
+      sectionId: string;
+      /** Cross-references like `#NNN` that appear in source but not rewrite. */
+      missingRefs: string[];
+    }
+  | {
+      kind: "dropped-numeric-threshold";
+      sectionId: string;
+      /** Numeric tunables like `30KB`, `50 turns`, `15 min`. */
+      missingNumerics: string[];
+    }
+  | {
+      kind: "excessive-savings";
+      sectionId: string;
+      savingsPct: number;
+      maxSavingsPct: number;
+    };
+
+const RewriteSchema = z.object({
+  sectionId: z.string().min(1),
+  rewrittenBody: z.string().min(BODY_MIN).max(BODY_MAX),
+});
+
+const ProposalPayloadSchema = z.object({
+  rewrites: z.array(RewriteSchema).default([]),
+  unchangedSectionIds: z.array(z.string()).default([]),
+  notes: z.string().max(500).optional(),
+});
+
+export function clampRewriteFields(json: unknown): unknown {
+  if (!json || typeof json !== "object") return json;
+  const obj = json as Record<string, unknown>;
+  const out: Record<string, unknown> = { ...obj };
+  const rewrites = obj.rewrites;
+  if (Array.isArray(rewrites)) {
+    out.rewrites = rewrites.map((r) => {
+      if (!r || typeof r !== "object") return r;
+      const rewrite = r as Record<string, unknown>;
+      const rOut: Record<string, unknown> = { ...rewrite };
+      if (
+        typeof rewrite.rewrittenBody === "string" &&
+        rewrite.rewrittenBody.length > BODY_MAX
+      ) {
+        rOut.rewrittenBody =
+          rewrite.rewrittenBody.slice(0, BODY_MAX - 16) + "\n[…truncated]";
+      }
+      return rOut;
+    });
+  }
+  if (typeof obj.notes === "string" && (obj.notes as string).length > 500) {
+    out.notes = (obj.notes as string).slice(0, 500 - 16) + "\n[…truncated]";
+  }
+  return out;
+}
+
+// ISO date matcher — same regex as compact's, deliberately strict on shape
+// so it doesn't false-positive on version numbers or arbitrary digit triples.
+const DATE_RE = /\b(20\d{2}-\d{2}-\d{2})\b/g;
+
+// Cross-reference matcher: `#42`, `#1234`. Catches issue/PR refs that
+// dominate the project's lessons. Bare digit-only references without `#`
+// are out of scope (too many false positives on numeric thresholds).
+const XREF_RE = /#(\d{1,5})\b/g;
+
+// Numeric-tunable matcher: a number plus a recognized unit. Conservative
+// pattern — misses bare numerics (`K=3`, `factor 1.5`), but those are rare
+// in this codebase's lessons relative to dated/unit'd numbers. Matches
+// `30KB`, `50 turns`, `15 min`, `1.5×`, `40%`.
+//
+// `(?!\w)` instead of `\b` after the unit: `\b` requires a word/non-word
+// transition, but `×` and `%` are non-word characters, so `\b` doesn't
+// fire at end-of-string after them. Negative-lookahead-for-word-char
+// covers both word units (KB, turns — fails on `KBd`) and symbolic units
+// (×, % — succeeds at EOS or followed by whitespace/punctuation).
+const NUMERIC_RE =
+  /(\b\d+(?:\.\d+)?)\s*(KB|MB|GB|chars?|sections?|turns?|days?|hours?|min|sec|ms|%|x|×)(?!\w)/gi;
+
+export function extractDistinctDates(body: string): Set<string> {
+  const out = new Set<string>();
+  for (const m of body.matchAll(DATE_RE)) out.add(m[1]);
+  return out;
+}
+
+export function extractDistinctXrefs(body: string): Set<string> {
+  const out = new Set<string>();
+  for (const m of body.matchAll(XREF_RE)) out.add(`#${m[1]}`);
+  return out;
+}
+
+export function extractDistinctNumerics(body: string): Set<string> {
+  const out = new Set<string>();
+  for (const m of body.matchAll(NUMERIC_RE)) {
+    // Normalize unit case for stable comparison: `30KB` and `30 kb` are
+    // the same numeric. Keep the *number* shape verbatim so `1.5` and `2`
+    // stay distinct.
+    out.add(`${m[1]}${m[2].toLowerCase()}`);
+  }
+  return out;
+}
+
+/**
+ * Run the dropped-invariant validators against each rewrite. Phase A
+ * surfaces every warning as advisory so the operator can review before
+ * committing to a destructive Phase B path. Phase B (#173) will treat
+ * any warning as a hard rejection at apply time.
+ *
+ * Three checks per rewrite:
+ *   - Every ISO date `20XX-XX-XX` cited in source MUST appear in rewrite.
+ *   - Every `#NNN` cross-reference cited in source MUST appear in rewrite.
+ *   - Every numeric+unit pair (e.g. `30KB`, `50 turns`) cited in source
+ *     MUST appear in rewrite.
+ *
+ * Plus a fourth, advisory-only check:
+ *   - savingsPct ≤ maxSavingsPct. Above the cap the model is likely
+ *     paraphrasing-with-loss rather than tightening; surface as a
+ *     warning operator can choose to override.
+ */
+export function findDroppedInvariants(input: {
+  rewrites: SectionRewrite[];
+  sections: ParsedSection[];
+  maxSavingsPct: number;
+}): TightenWarning[] {
+  const sectionById = new Map(input.sections.map((s) => [s.sectionId, s]));
+  const warnings: TightenWarning[] = [];
+  for (const r of input.rewrites) {
+    const sec = sectionById.get(r.sectionId);
+    if (!sec) continue; // caller validates section existence; defensive only
+
+    const srcDates = extractDistinctDates(sec.body);
+    const dstDates = extractDistinctDates(r.rewrittenBody);
+    const missingDates = [...srcDates].filter((d) => !dstDates.has(d)).sort();
+    if (missingDates.length > 0) {
+      warnings.push({
+        kind: "dropped-incident-date",
+        sectionId: r.sectionId,
+        missingDates,
+      });
+    }
+
+    const srcRefs = extractDistinctXrefs(sec.body);
+    const dstRefs = extractDistinctXrefs(r.rewrittenBody);
+    const missingRefs = [...srcRefs].filter((x) => !dstRefs.has(x)).sort();
+    if (missingRefs.length > 0) {
+      warnings.push({
+        kind: "dropped-cross-reference",
+        sectionId: r.sectionId,
+        missingRefs,
+      });
+    }
+
+    const srcNums = extractDistinctNumerics(sec.body);
+    const dstNums = extractDistinctNumerics(r.rewrittenBody);
+    const missingNumerics = [...srcNums]
+      .filter((n) => !dstNums.has(n))
+      .sort();
+    if (missingNumerics.length > 0) {
+      warnings.push({
+        kind: "dropped-numeric-threshold",
+        sectionId: r.sectionId,
+        missingNumerics,
+      });
+    }
+
+    const srcBytes = Buffer.byteLength(sec.body, "utf-8");
+    const dstBytes = Buffer.byteLength(r.rewrittenBody, "utf-8");
+    if (srcBytes > 0) {
+      const pct = ((srcBytes - dstBytes) / srcBytes) * 100;
+      if (pct > input.maxSavingsPct) {
+        warnings.push({
+          kind: "excessive-savings",
+          sectionId: r.sectionId,
+          savingsPct: Math.round(pct * 10) / 10,
+          maxSavingsPct: input.maxSavingsPct,
+        });
+      }
+    }
+  }
+  return warnings;
+}
+
+export interface ProposeTightenInput {
+  agent: AgentRecord;
+  /** Current CLAUDE.md content for the agent. */
+  claudeMd: string;
+  /** Soft cap on per-section savings (advisory warning, not a hard reject
+   *  in Phase A). Default 40 — rewrites shrinking the body by more than
+   *  40% surface as `excessive-savings` warnings. */
+  maxSavingsPct?: number;
+}
+
+export async function proposeTighten(
+  input: ProposeTightenInput,
+): Promise<TightenProposal> {
+  const maxSavingsPct = input.maxSavingsPct ?? DEFAULT_MAX_SAVINGS_PCT;
+  const sections = parseClaudeMdSections(input.claudeMd);
+  const inputBytes = Buffer.byteLength(input.claudeMd, "utf-8");
+  const base = {
+    agentId: input.agent.agentId,
+    inputBytes,
+    sectionCount: sections.length,
+    maxSavingsPct,
+  };
+
+  if (sections.length === 0) {
+    return {
+      ...base,
+      rewrites: [],
+      unchangedSectionIds: [],
+      estimatedBytesSaved: 0,
+      warnings: [],
+      notes: "No attributable sections — nothing to tighten.",
+    };
+  }
+
+  const userPrompt = buildTightenPrompt({ agent: input.agent, sections });
+  let raw = "";
+  const stream = query({
+    prompt: userPrompt,
+    options: {
+      model: TIGHTEN_MODEL,
+      systemPrompt: buildTightenSystemPrompt(),
+      tools: [],
+      permissionMode: "default",
+      env: process.env,
+      maxTurns: 1,
+      settingSources: [],
+      persistSession: false,
+      pathToClaudeCodeExecutable: claudeBinPath(),
+    },
+  });
+  for await (const msg of stream) {
+    if (msg.type === "result") {
+      if (msg.subtype === "success") raw = msg.result;
+      else throw new Error(`tightenClaudeMd model failed: ${msg.subtype}`);
+    }
+  }
+
+  const extracted = parseJsonEnvelope(raw, z.unknown());
+  if (!extracted.ok) {
+    throw new Error(
+      `tightenClaudeMd output not valid JSON: ${extracted.error ?? "no envelope"}`,
+    );
+  }
+  const clamped = clampRewriteFields(extracted.value);
+  const parsed = ProposalPayloadSchema.safeParse(clamped);
+  if (!parsed.success) {
+    throw new Error(
+      `tightenClaudeMd schema invalid: ${parsed.error.message.replace(/\s+/g, " ").slice(0, 400)}`,
+    );
+  }
+
+  const validIds = new Set(sections.map((s) => s.sectionId));
+  const sectionById = new Map(sections.map((s) => [s.sectionId, s]));
+  const seenIds = new Set<string>();
+  const rewrites: SectionRewrite[] = [];
+  for (const r of parsed.data.rewrites) {
+    if (!validIds.has(r.sectionId)) {
+      throw new Error(
+        `tightenClaudeMd rewrite references unknown sectionId ${r.sectionId}`,
+      );
+    }
+    if (seenIds.has(r.sectionId)) {
+      throw new Error(
+        `tightenClaudeMd rewrite reuses sectionId ${r.sectionId}; each section may have at most one rewrite`,
+      );
+    }
+    seenIds.add(r.sectionId);
+
+    const sec = sectionById.get(r.sectionId);
+    if (!sec) continue;
+    const srcBytes = Buffer.byteLength(sec.body, "utf-8");
+    const dstBytes = Buffer.byteLength(r.rewrittenBody, "utf-8");
+    // Drop rewrites that *grow* the body — model misunderstood the task.
+    // Don't surface them as unchanged either; the model should have
+    // declined explicitly, and silently dropping protects the operator
+    // from `--apply`-ing a "tightening" that bloats the file.
+    if (dstBytes >= srcBytes) continue;
+    rewrites.push({
+      sectionId: r.sectionId,
+      rewrittenBody: r.rewrittenBody,
+      estimatedBytesSaved: srcBytes - dstBytes,
+    });
+  }
+
+  const unchangedSectionIds = sections
+    .map((s) => s.sectionId)
+    .filter((id) => !rewrites.some((r) => r.sectionId === id));
+
+  const estimatedBytesSaved = rewrites.reduce(
+    (acc, r) => acc + r.estimatedBytesSaved,
+    0,
+  );
+  const warnings = findDroppedInvariants({
+    rewrites,
+    sections,
+    maxSavingsPct,
+  });
+
+  return {
+    ...base,
+    rewrites,
+    unchangedSectionIds,
+    estimatedBytesSaved,
+    warnings,
+    notes: parsed.data.notes,
+  };
+}
+
+export function buildTightenSystemPrompt(): string {
+  return `You tighten the prose of a coding agent's CLAUDE.md sections — rewrite each section body more concisely while preserving every load-bearing detail.
+
+Input: a list of CLAUDE.md sections, each tagged with a sectionId, the issue it came from, the outcome, and the section heading + body. Each section is a coherent rule with no near-duplicates (cross-section dedup is a separate tool). Your job is to rewrite each body to be shorter while keeping every fact.
+
+CRITICAL: lossless tightening means every load-bearing detail from the source body MUST appear in the rewrite. In particular:
+- Every "Past incident YYYY-MM-DD" citation MUST be preserved verbatim — an automated validator checks this and flags rewrites that drop dates as unsafe.
+- Every issue/PR cross-reference (#NNN) MUST be preserved.
+- Every numeric threshold or tunable (30KB, 50 turns, 15 min, 1.5×, 40%) MUST be preserved.
+- Every distinct mechanism or concrete recipe step MUST be preserved.
+- "Tells" lists and "How to apply" steps MUST be preserved as bullets, not collapsed into prose.
+
+What to cut:
+- Filler phrases ("for example", "in particular", "essentially") that don't add information.
+- Redundant rephrasing of the same idea ("X is Y" followed by "X means Y").
+- Over-qualified hedges where one qualifier suffices.
+- Long parenthetical asides that bury the rule.
+
+Output rules:
+- Each rewrite needs:
+  - sectionId: the source section ID.
+  - rewrittenBody: the tightened body. Bullets > prose. Cite every past-incident date verbatim. Preserve markdown structure (lists, code blocks, links).
+- unchangedSectionIds: sections you decline to rewrite (already tight, or you can't shrink without dropping detail). Better to leave them than force a watery rewrite.
+- notes: optional 1-2 sentences on caveats.
+- A section may have AT MOST one rewrite. Don't propose two competing rewrites for the same section.
+
+Output: a single JSON object, no fences, no prose:
+  {"rewrites": [{"sectionId": "s0", "rewrittenBody": "..."}, ...], "unchangedSectionIds": ["s3","s4"], "notes": "..."}
+
+Returning {"rewrites": [], "unchangedSectionIds": [...]} is acceptable when no section can be tightened without losing detail.`;
+}
+
+export function buildTightenPrompt(opts: {
+  agent: AgentRecord;
+  sections: ParsedSection[];
+}): string {
+  const sectionLines = opts.sections.map((s) => {
+    const head = `[${s.sectionId}] issue=#${s.issueId ?? "?"} outcome=${s.outcome ?? "?"} run=${s.runId ?? "?"}`;
+    return `${head}\n  heading: ${s.heading}\n  body:\n${indent(s.body, "    ")}`;
+  });
+
+  return `Agent ${opts.agent.agentId} has ${opts.sections.length} attributable sections. Rewrite each body more concisely while preserving every load-bearing detail.
+
+Parent tags (${opts.agent.tags.length}):
+${JSON.stringify(opts.agent.tags)}
+
+Sections:
+${sectionLines.join("\n\n")}
+
+Emit the JSON object now. Decline to rewrite any section you can't shrink without dropping a date / cross-reference / numeric.`;
+}
+
+function indent(s: string, prefix: string): string {
+  return s
+    .split("\n")
+    .map((line) => prefix + line)
+    .join("\n");
+}
+
+export function formatTightenProposal(p: TightenProposal): string {
+  const lines: string[] = [];
+  const heading = `Tighten proposal for ${p.agentId}`;
+  lines.push(heading);
+  lines.push("=".repeat(heading.length));
+  lines.push(`  CLAUDE.md size:    ${(p.inputBytes / 1024).toFixed(1)}KB`);
+  lines.push(`  Sections analyzed: ${p.sectionCount}`);
+  lines.push(`  Rewrites proposed: ${p.rewrites.length}`);
+  lines.push(`  Unchanged:         ${p.unchangedSectionIds.length}`);
+  lines.push(
+    `  Estimated savings: ${(p.estimatedBytesSaved / 1024).toFixed(1)}KB`,
+  );
+  lines.push(`  max-savings-pct:   ${p.maxSavingsPct}%`);
+  lines.push("");
+  if (p.rewrites.length === 0) {
+    lines.push("  (no rewrites proposed)");
+    if (p.notes) lines.push(`  ${p.notes}`);
+    return lines.join("\n");
+  }
+
+  for (const r of p.rewrites) {
+    const myWarnings = p.warnings.filter((w) => w.sectionId === r.sectionId);
+    const savedKb = (r.estimatedBytesSaved / 1024).toFixed(2);
+    lines.push(`  -> [${r.sectionId}] ${savedKb}KB saved`);
+    for (const w of myWarnings) {
+      if (w.kind === "dropped-incident-date") {
+        lines.push(`     ⚠ DROPPED DATES: ${w.missingDates.join(", ")}`);
+      } else if (w.kind === "dropped-cross-reference") {
+        lines.push(`     ⚠ DROPPED REFS: ${w.missingRefs.join(", ")}`);
+      } else if (w.kind === "dropped-numeric-threshold") {
+        lines.push(`     ⚠ DROPPED NUMERICS: ${w.missingNumerics.join(", ")}`);
+      } else if (w.kind === "excessive-savings") {
+        lines.push(
+          `     ⚠ EXCESSIVE SAVINGS: ${w.savingsPct}% > ${w.maxSavingsPct}% (likely paraphrasing-with-loss)`,
+        );
+      }
+    }
+  }
+  lines.push("");
+  if (p.unchangedSectionIds.length > 0) {
+    lines.push(
+      `  Unchanged (${p.unchangedSectionIds.length}): ${p.unchangedSectionIds.join(", ")}`,
+    );
+  }
+  if (p.notes) lines.push(`  Notes: ${p.notes}`);
+  lines.push("");
+  if (p.warnings.length > 0) {
+    lines.push(
+      `⚠ ${p.warnings.length} validator finding(s) — Phase A surfaces these as advisory; the destructive --apply path (#173) will reject any rewrite carrying a finding.`,
+    );
+  } else {
+    lines.push(
+      "No validator warnings. Phase A is advisory only; --apply is tracked at #173.",
+    );
+  }
+  return lines.join("\n");
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -85,6 +85,11 @@ import {
   resolveMinClusterSize,
 } from "./agent/compactClaudeMd.js";
 import {
+  DEFAULT_MAX_SAVINGS_PCT,
+  formatTightenProposal,
+  proposeTighten,
+} from "./agent/tightenClaudeMd.js";
+import {
   computeProposalHash,
   deleteCompactConfirmToken,
   mintToken as mintCompactToken,
@@ -299,6 +304,23 @@ export function buildCli(): Command {
         .option("--yes", "Skip the apply confirmation prompt (required for non-TTY environments).")
         .action(async (opts) => {
           await cmdAgentsPrune(opts);
+        }),
+    )
+    .addCommand(
+      new Command("tighten-claude-md")
+        .description(
+          "Phase A (#172): propose intra-section prose-tightening rewrites for an agent's CLAUDE.md. Advisory only — no file mutation. The destructive --apply path is tracked at #173.",
+        )
+        .argument("<agentId>", "Agent to inspect (e.g. agent-916a)")
+        .option("--json", "Print machine-readable JSON")
+        .option(
+          "--max-savings-pct <n>",
+          "Soft cap on per-section savings before flagging the rewrite as 'excessive-savings' (default 40)",
+          parsePositive,
+          DEFAULT_MAX_SAVINGS_PCT,
+        )
+        .action(async (agentId, opts) => {
+          await cmdAgentsTightenClaudeMd(agentId, opts);
         }),
     )
     .addCommand(
@@ -2130,6 +2152,51 @@ async function cmdAgentsCompactClaudeMdConfirm(
       `(${result.clustersApplied} cluster(s), ${result.sectionsMerged} sections merged)\n` +
       `  merge runId: ${result.runId}\n`,
   );
+}
+
+interface AgentsTightenClaudeMdOpts {
+  json?: boolean;
+  maxSavingsPct: number;
+}
+
+async function cmdAgentsTightenClaudeMd(
+  agentId: string,
+  opts: AgentsTightenClaudeMdOpts,
+): Promise<void> {
+  const reg = await loadRegistry();
+  const agent = reg.agents.find((a) => a.agentId === agentId);
+  if (!agent) {
+    process.stderr.write(`ERROR: agent '${agentId}' not found in registry.\n`);
+    process.exit(2);
+  }
+  if (agent.archived) {
+    process.stderr.write(
+      `ERROR: agent '${agentId}' is already archived; tightening is for active agents.\n`,
+    );
+    process.exit(2);
+  }
+  const { md, bytes } = await readAgentClaudeMdBytes(agentId);
+  if (bytes === 0) {
+    process.stderr.write(
+      `ERROR: agent '${agentId}' has no CLAUDE.md on disk yet — nothing to tighten.\n`,
+    );
+    process.exit(2);
+  }
+
+  process.stdout.write(
+    `Generating tighten proposal for ${agentId} (max-savings-pct=${opts.maxSavingsPct})...\n`,
+  );
+  const proposal = await proposeTighten({
+    agent,
+    claudeMd: md,
+    maxSavingsPct: opts.maxSavingsPct,
+  });
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify({ agentId, proposal }, null, 2) + "\n");
+    return;
+  }
+  process.stdout.write(formatTightenProposal(proposal) + "\n");
 }
 
 interface AgentsPruneOpts {


### PR DESCRIPTION
## Summary

Phase A of [#169](https://github.com/szhygulin/vaultpilot-development-agents/issues/169) (split per Cook's [pushback](https://github.com/szhygulin/vaultpilot-development-agents/issues/169#issuecomment-4383492393) into [#172](https://github.com/szhygulin/vaultpilot-development-agents/issues/172) advisory + [#173](https://github.com/szhygulin/vaultpilot-development-agents/issues/173) destructive).

Compact addresses *cross-section* growth (merge similar sections); tighten addresses *within-section* growth (rewrite a verbose body more concisely while preserving every load-bearing detail). Compact's splicer copies non-clustered sections verbatim, so verbose-but-distinct sections fell through both tools untouched until now.

## What's in this PR

- **`proposeTighten()`** — full-CLAUDE.md → per-section rewrites via opus call. Schema-validated + clamp pre-validation (matches compact's pattern).
- **Validator extension** — three dropped-invariant checks plus an advisory savings cap:
  - Drop ISO date `20XX-XX-XX` cited in source → `dropped-incident-date`
  - Drop `#NNN` issue/PR cross-reference → `dropped-cross-reference`
  - Drop numeric+unit pair (`30KB`, `50 turns`, `1.5×`, `40%`) → `dropped-numeric-threshold`
  - Reduction > `--max-savings-pct N` (default 40) → `excessive-savings` (advisory; model is likely paraphrasing-with-loss above the cap)
- **Refuses rewrites that *grow* the body** — model misunderstood the task; silently dropped from the proposal so `--apply` (#173) can't accidentally bloat the file.
- **Per-section dry-run report** + `--json` mode for programmatic consumers.

## Why no `--apply` here

Phase B is [#173](https://github.com/szhygulin/vaultpilot-development-agents/issues/173). Explicitly gated on Phase A having been exercised on real production agent CLAUDE.md files for at least one full month — mirrors the #158→#162 deferral pattern Cook cited when pushing back on the original combined-scope dispatch. Phase A's output is the input to Phase B's safeguards: which over-aggressive rewrites does the model actually produce? That informs Phase B's apply-time invariants instead of guesses.

## Files (~3, calibration ×1.5 ≈ 5 — within scope-fit)

- `src/agent/tightenClaudeMd.ts` (new, 446 lines) — propose + validators + system prompt + formatter
- `src/agent/tightenClaudeMd.test.ts` (new, 384 lines) — 24 unit tests covering invariant matchers, validator composition, savings-cap boundary, schema clamp, formatter
- `src/cli.ts` — `agents tighten-claude-md <agentId> [--json] [--max-savings-pct N]` subcommand wiring + handler

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `npm test` — 403/403 passing (24 new)
- [x] CLI smoke: `--help` renders, unknown-agent path errors cleanly

## Notes

- Numeric matcher uses `(?!\w)` rather than `\b` after the unit — `\b` requires word/non-word transitions and doesn't fire after symbolic units like `×` or `%` at end-of-string. The negative-lookahead-for-word-char covers both cases (KB/turns AND ×/%).
- Per-section savings warning fires *strictly above* the cap (40% reduction at the boundary doesn't warn; 41% does). Test pins the boundary.

— hand-implemented by operator (no agent dispatched)