### PR TITLE
feat(tighten): show per-rewrite unified diffs in Phase A formatter

### DIFF
--- a/src/agent/tightenClaudeMd.test.ts
+++ b/src/agent/tightenClaudeMd.test.ts
@@ -8,13 +8,17 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
+  DEFAULT_MAX_DIFF_LINES,
   DEFAULT_MAX_SAVINGS_PCT,
+  MIN_DIFF_SAVINGS_BYTES,
   clampRewriteFields,
   extractDistinctDates,
   extractDistinctNumerics,
   extractDistinctXrefs,
   findDroppedInvariants,
+  formatRewriteDiff,
   formatTightenProposal,
+  lineDiff,
   type SectionRewrite,
   type TightenProposal,
 } from "./tightenClaudeMd.js";
@@ -405,4 +409,197 @@ test("formatTightenProposal: clean proposal points at the --apply path tracker",
 
 test("DEFAULT_MAX_SAVINGS_PCT: documented default is 40 (per issue #172)", () => {
   assert.equal(DEFAULT_MAX_SAVINGS_PCT, 40);
+});
+
+test("MIN_DIFF_SAVINGS_BYTES: documented default is 50 (per issue #176)", () => {
+  assert.equal(MIN_DIFF_SAVINGS_BYTES, 50);
+});
+
+test("DEFAULT_MAX_DIFF_LINES: documented default is 60 (per issue #176)", () => {
+  assert.equal(DEFAULT_MAX_DIFF_LINES, 60);
+});
+
+test("lineDiff: identical inputs yield only eq ops", () => {
+  const ops = lineDiff(["a", "b", "c"], ["a", "b", "c"]);
+  assert.deepEqual(
+    ops.map((o) => o.kind),
+    ["eq", "eq", "eq"],
+  );
+});
+
+test("lineDiff: pure replacement yields del+add ops", () => {
+  const ops = lineDiff(["old"], ["new"]);
+  assert.deepEqual(
+    ops.map((o) => `${o.kind}:${o.line}`).sort(),
+    ["add:new", "del:old"],
+  );
+});
+
+test("lineDiff: detects common context line between two changes", () => {
+  const ops = lineDiff(
+    ["context", "removed-line", "context2"],
+    ["context", "added-line", "context2"],
+  );
+  // Expected order from LCS walk: context (eq), removed (del),
+  // added (add), context2 (eq) — and the eq lines must surface as eq.
+  assert.equal(ops.filter((o) => o.kind === "eq").length, 2);
+  assert.ok(ops.some((o) => o.kind === "del" && o.line === "removed-line"));
+  assert.ok(ops.some((o) => o.kind === "add" && o.line === "added-line"));
+});
+
+test("formatRewriteDiff: emits unified-diff headers and prefixed body lines", () => {
+  const out = formatRewriteDiff({
+    sectionId: "s0",
+    sourceBody: "alpha\nbeta\ngamma",
+    rewrittenBody: "alpha\ndelta\ngamma",
+  });
+  const lines = out.split("\n");
+  assert.equal(lines[0], "--- s0 (source)");
+  assert.equal(lines[1], "+++ s0 (rewrite)");
+  assert.equal(lines[2], "@@ -1,3 +1,3 @@");
+  // alpha/gamma are common context (two-space prefix); beta→delta are -/+.
+  assert.ok(out.includes("  alpha"));
+  assert.ok(out.includes("- beta"));
+  assert.ok(out.includes("+ delta"));
+  assert.ok(out.includes("  gamma"));
+});
+
+test("formatRewriteDiff: caps body at maxLines and appends truncation marker", () => {
+  // Build a 100-line "all replaced" diff: every line differs, so 200 ops.
+  const src = Array.from({ length: 100 }, (_, i) => `src-line-${i}`).join("\n");
+  const dst = Array.from({ length: 100 }, (_, i) => `dst-line-${i}`).join("\n");
+  const out = formatRewriteDiff({
+    sectionId: "s0",
+    sourceBody: src,
+    rewrittenBody: dst,
+    maxLines: 10,
+  });
+  const lines = out.split("\n");
+  // 3 header lines + 10 body lines + 1 truncation marker = 14.
+  assert.equal(lines.length, 3 + 10 + 1);
+  assert.match(lines[lines.length - 1], /^… \(\d+ more lines truncated\)$/);
+});
+
+test("formatTightenProposal: emits inline diff for rewrite ≥ 50 bytes when sources provided", () => {
+  const sourceBody =
+    "Past incident 2026-04-28: thing happened in elaborate detail.\n" +
+    "More background that the rewrite trims.\n" +
+    "Final point #162 preserved.";
+  const rewrittenBody =
+    "Past incident 2026-04-28: thing happened.\nFinal point #162 preserved.";
+  const proposal: TightenProposal = {
+    agentId: "agent-test",
+    rewrites: [
+      {
+        sectionId: "s0",
+        rewrittenBody,
+        estimatedBytesSaved:
+          Buffer.byteLength(sourceBody, "utf-8") -
+          Buffer.byteLength(rewrittenBody, "utf-8"),
+      },
+    ],
+    unchangedSectionIds: [],
+    estimatedBytesSaved: 60,
+    inputBytes: 4096,
+    sectionCount: 1,
+    warnings: [],
+    maxSavingsPct: DEFAULT_MAX_SAVINGS_PCT,
+  };
+  const sources = new Map([["s0", sourceBody]]);
+  const out = formatTightenProposal(proposal, { sources });
+  assert.match(out, /diff:/);
+  assert.match(out, /--- s0 \(source\)/);
+  assert.match(out, /\+\+\+ s0 \(rewrite\)/);
+});
+
+test("formatTightenProposal: omits diff for sub-50-byte savings (low signal)", () => {
+  const sourceBody = "Tiny rewrite. Drop one filler.";
+  const rewrittenBody = "Tiny rewrite.";
+  const saved =
+    Buffer.byteLength(sourceBody, "utf-8") -
+    Buffer.byteLength(rewrittenBody, "utf-8");
+  assert.ok(saved < MIN_DIFF_SAVINGS_BYTES, "fixture must be sub-50B");
+  const proposal: TightenProposal = {
+    agentId: "agent-test",
+    rewrites: [
+      {
+        sectionId: "s0",
+        rewrittenBody,
+        estimatedBytesSaved: saved,
+      },
+    ],
+    unchangedSectionIds: [],
+    estimatedBytesSaved: saved,
+    inputBytes: 1024,
+    sectionCount: 1,
+    warnings: [],
+    maxSavingsPct: DEFAULT_MAX_SAVINGS_PCT,
+  };
+  const sources = new Map([["s0", sourceBody]]);
+  const out = formatTightenProposal(proposal, { sources });
+  // No diff block should appear; the savings-only summary stays.
+  assert.doesNotMatch(out, /diff:/);
+  assert.doesNotMatch(out, /--- s0 \(source\)/);
+  assert.match(out, /\[s0\]/);
+});
+
+test("formatTightenProposal: --no-diff (showDiffs:false) suppresses diffs even for big rewrites", () => {
+  const sourceBody = "x".repeat(1000);
+  const rewrittenBody = "y".repeat(500);
+  const proposal: TightenProposal = {
+    agentId: "agent-test",
+    rewrites: [
+      { sectionId: "s0", rewrittenBody, estimatedBytesSaved: 500 },
+    ],
+    unchangedSectionIds: [],
+    estimatedBytesSaved: 500,
+    inputBytes: 4096,
+    sectionCount: 1,
+    warnings: [],
+    maxSavingsPct: 100,
+  };
+  const sources = new Map([["s0", sourceBody]]);
+  const out = formatTightenProposal(proposal, { showDiffs: false, sources });
+  assert.doesNotMatch(out, /diff:/);
+  assert.doesNotMatch(out, /--- s0 \(source\)/);
+});
+
+test("formatTightenProposal: gracefully omits diff when sources lack the sectionId", () => {
+  const proposal: TightenProposal = {
+    agentId: "agent-test",
+    rewrites: [
+      { sectionId: "s0", rewrittenBody: "tight", estimatedBytesSaved: 200 },
+    ],
+    unchangedSectionIds: [],
+    estimatedBytesSaved: 200,
+    inputBytes: 4096,
+    sectionCount: 1,
+    warnings: [],
+    maxSavingsPct: DEFAULT_MAX_SAVINGS_PCT,
+  };
+  // showDiffs default true, but sources empty: formatter must NOT throw
+  // and must still render the savings-only line.
+  const out = formatTightenProposal(proposal, { sources: new Map() });
+  assert.doesNotMatch(out, /diff:/);
+  assert.match(out, /\[s0\] 0\.20KB saved/);
+});
+
+test("formatTightenProposal: omits diff entirely when no opts arg provided (back-compat)", () => {
+  const proposal: TightenProposal = {
+    agentId: "agent-test",
+    rewrites: [
+      { sectionId: "s0", rewrittenBody: "tight", estimatedBytesSaved: 200 },
+    ],
+    unchangedSectionIds: [],
+    estimatedBytesSaved: 200,
+    inputBytes: 4096,
+    sectionCount: 1,
+    warnings: [],
+    maxSavingsPct: DEFAULT_MAX_SAVINGS_PCT,
+  };
+  // Legacy single-arg call (existing tests + JSON path) must keep working
+  // and produce no diff (no sources to diff against).
+  const out = formatTightenProposal(proposal);
+  assert.doesNotMatch(out, /diff:/);
+  assert.match(out, /\[s0\] 0\.20KB saved/);
 });

--- a/src/agent/tightenClaudeMd.ts
+++ b/src/agent/tightenClaudeMd.ts
@@ -37,6 +37,20 @@ const TIGHTEN_MODEL = ORCHESTRATOR_MODEL_SPLIT;
 // nuance. Operator-tunable from CLI.
 export const DEFAULT_MAX_SAVINGS_PCT = 40;
 
+// Below this byte-savings floor the per-rewrite diff is low signal — a
+// trivial trim that doesn't merit a wall-of-diff. Falls back to the
+// single-line `[sN] X.YYKB saved` summary instead. Picked at 50 bytes
+// per issue #176: catches "drop one filler phrase" (~30-50B) but lets
+// substantive rewrites surface their diff.
+export const MIN_DIFF_SAVINGS_BYTES = 50;
+
+// Cap on per-rewrite diff body lines. 60 keeps the largest rewrite
+// readable in a terminal scrollback without becoming a wall-of-text on
+// near-total rewrites. Beyond the cap, the formatter appends a
+// `… (N more lines truncated)` marker. Operator can re-run with `--json`
+// (which carries `rewrittenBody` in full) to see the untruncated body.
+export const DEFAULT_MAX_DIFF_LINES = 60;
+
 // Per-field caps on the LLM proposal payload. `rewrittenBody` lower-bound
 // is 1 (a section with empty body shouldn't appear in source — the parser
 // trims whitespace, but a one-char body is technically valid). Upper bound
@@ -448,7 +462,109 @@ function indent(s: string, prefix: string): string {
     .join("\n");
 }
 
-export function formatTightenProposal(p: TightenProposal): string {
+/**
+ * Line-level LCS diff. Returns an edit script of `eq` (line in both
+ * source and rewrite, in order), `del` (source only), and `add` (rewrite
+ * only) ops. O(M·N) time and memory; bounded by `BODY_MAX = 6000` chars
+ * per body so worst case is a few hundred lines × few hundred lines —
+ * trivial.
+ */
+type DiffOp = { kind: "eq" | "del" | "add"; line: string };
+
+export function lineDiff(srcLines: string[], dstLines: string[]): DiffOp[] {
+  const m = srcLines.length;
+  const n = dstLines.length;
+  const lcs: number[][] = Array.from({ length: m + 1 }, () =>
+    new Array<number>(n + 1).fill(0),
+  );
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (srcLines[i - 1] === dstLines[j - 1]) {
+        lcs[i][j] = lcs[i - 1][j - 1] + 1;
+      } else {
+        lcs[i][j] = Math.max(lcs[i - 1][j], lcs[i][j - 1]);
+      }
+    }
+  }
+  const ops: DiffOp[] = [];
+  let i = m;
+  let j = n;
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && srcLines[i - 1] === dstLines[j - 1]) {
+      ops.push({ kind: "eq", line: srcLines[i - 1] });
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || lcs[i][j - 1] >= lcs[i - 1][j])) {
+      ops.push({ kind: "add", line: dstLines[j - 1] });
+      j--;
+    } else {
+      ops.push({ kind: "del", line: srcLines[i - 1] });
+      i--;
+    }
+  }
+  return ops.reverse();
+}
+
+/**
+ * Render a unified diff for a single section rewrite. Headers are
+ * `--- <sectionId> (source)` / `+++ <sectionId> (rewrite)`, followed by
+ * a single hunk header `@@ -1,M +1,N @@` and the prefixed edit script.
+ * Output is capped at `maxLines` body lines (excluding the three header
+ * lines); on overflow a `… (N more lines truncated)` marker is appended.
+ */
+export function formatRewriteDiff(opts: {
+  sectionId: string;
+  sourceBody: string;
+  rewrittenBody: string;
+  maxLines?: number;
+}): string {
+  const maxLines = opts.maxLines ?? DEFAULT_MAX_DIFF_LINES;
+  const srcLines = opts.sourceBody.split("\n");
+  const dstLines = opts.rewrittenBody.split("\n");
+  const ops = lineDiff(srcLines, dstLines);
+  const out: string[] = [];
+  out.push(`--- ${opts.sectionId} (source)`);
+  out.push(`+++ ${opts.sectionId} (rewrite)`);
+  out.push(`@@ -1,${srcLines.length} +1,${dstLines.length} @@`);
+  let body: string[] = [];
+  for (const op of ops) {
+    const prefix = op.kind === "eq" ? "  " : op.kind === "del" ? "- " : "+ ";
+    body.push(prefix + op.line);
+  }
+  if (body.length > maxLines) {
+    const remaining = body.length - maxLines;
+    body = body.slice(0, maxLines);
+    body.push(`… (${remaining} more lines truncated)`);
+  }
+  return [...out, ...body].join("\n");
+}
+
+export interface FormatTightenProposalOpts {
+  /** When true (default), each rewrite with savings ≥ `MIN_DIFF_SAVINGS_BYTES`
+   *  is followed by an inline unified diff against its source body. CLI
+   *  exposes the inverse as `--no-diff` for batch / wall-of-rewrites runs.
+   *  When false, falls back to the prior savings-only summary. */
+  showDiffs?: boolean;
+  /** Cap on diff body lines per rewrite. Default `DEFAULT_MAX_DIFF_LINES`. */
+  maxDiffLines?: number;
+  /** Per-section source bodies, keyed by `sectionId`. Required for diff
+   *  rendering; if a sectionId is absent from the map, the formatter
+   *  silently falls back to the savings-only line for that rewrite (the
+   *  proposal is still complete; the operator just loses the diff for
+   *  that one section). The caller (CLI / tests) builds this from
+   *  `parseClaudeMdSections(claudeMd)` since the proposal payload itself
+   *  intentionally omits source bodies (see #176 out-of-scope: keep the
+   *  --json payload lean). */
+  sources?: Map<string, string>;
+}
+
+export function formatTightenProposal(
+  p: TightenProposal,
+  opts?: FormatTightenProposalOpts,
+): string {
+  const showDiffs = opts?.showDiffs ?? true;
+  const maxDiffLines = opts?.maxDiffLines ?? DEFAULT_MAX_DIFF_LINES;
+  const sources = opts?.sources;
   const lines: string[] = [];
   const heading = `Tighten proposal for ${p.agentId}`;
   lines.push(heading);
@@ -483,6 +599,27 @@ export function formatTightenProposal(p: TightenProposal): string {
         lines.push(
           `     ⚠ EXCESSIVE SAVINGS: ${w.savingsPct}% > ${w.maxSavingsPct}% (likely paraphrasing-with-loss)`,
         );
+      }
+    }
+    // Per-rewrite diff. Emitted only when (a) the operator hasn't opted
+    // out via --no-diff, (b) savings clear the low-signal floor, and
+    // (c) the caller supplied a source body for this section. Indented
+    // 5 cols to nest under the `-> [sN]` summary line.
+    if (
+      showDiffs &&
+      r.estimatedBytesSaved >= MIN_DIFF_SAVINGS_BYTES &&
+      sources?.has(r.sectionId)
+    ) {
+      const sourceBody = sources.get(r.sectionId)!;
+      const diff = formatRewriteDiff({
+        sectionId: r.sectionId,
+        sourceBody,
+        rewrittenBody: r.rewrittenBody,
+        maxLines: maxDiffLines,
+      });
+      lines.push("     diff:");
+      for (const dl of diff.split("\n")) {
+        lines.push(`       ${dl}`);
       }
     }
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,6 +74,7 @@ import {
   applySplit,
   detectOverload,
   formatProposal,
+  parseClaudeMdSections,
   proposeSplit,
   readAgentClaudeMdBytes,
 } from "./agent/split.js";
@@ -318,6 +319,10 @@ export function buildCli(): Command {
           "Soft cap on per-section savings before flagging the rewrite as 'excessive-savings' (default 40)",
           parsePositive,
           DEFAULT_MAX_SAVINGS_PCT,
+        )
+        .option(
+          "--no-diff",
+          "Suppress per-rewrite unified diffs in the human-readable output (#176). Falls back to the savings-only single-line summary; --json mode is unaffected (always omits diffs to keep the payload lean).",
         )
         .action(async (agentId, opts) => {
           await cmdAgentsTightenClaudeMd(agentId, opts);
@@ -2157,6 +2162,10 @@ async function cmdAgentsCompactClaudeMdConfirm(
 interface AgentsTightenClaudeMdOpts {
   json?: boolean;
   maxSavingsPct: number;
+  // Commander stores `--no-diff` as `diff: false` (boolean, defaults to
+  // true). Naming the option `noDiff` would invert the convention; using
+  // `diff` matches Commander's default and keeps the call-site readable.
+  diff?: boolean;
 }
 
 async function cmdAgentsTightenClaudeMd(
@@ -2193,10 +2202,25 @@ async function cmdAgentsTightenClaudeMd(
   });
 
   if (opts.json) {
+    // JSON mode keeps its lean payload — `rewrittenBody` is already in
+    // each rewrite, so a JSON consumer that wants a diff can derive one
+    // by re-parsing the agent's CLAUDE.md (#176 out of scope: per-rewrite
+    // diff field for --json mode).
     process.stdout.write(JSON.stringify({ agentId, proposal }, null, 2) + "\n");
     return;
   }
-  process.stdout.write(formatTightenProposal(proposal) + "\n");
+  // Build the source-body lookup from the same MD we just proposed
+  // against. Commander parses `--no-diff` into `opts.diff === false`;
+  // when the flag is absent, `opts.diff` is `undefined` (effectively
+  // true → show diffs by default, per #176).
+  const sections = parseClaudeMdSections(md);
+  const sources = new Map(sections.map((s) => [s.sectionId, s.body]));
+  process.stdout.write(
+    formatTightenProposal(proposal, {
+      showDiffs: opts.diff !== false,
+      sources,
+    }) + "\n",
+  );
 }
 
 interface AgentsPruneOpts {


### PR DESCRIPTION
Closes #176

## Summary

Default `vp-dev agents tighten-claude-md` output now shows a unified diff per rewrite (capped at 60 body lines, fallback to the savings-only single-line summary below the 50-byte savings floor). Add `--no-diff` to suppress diffs for batch / wall-of-rewrites runs. `--json` mode is unchanged — its consumers can re-derive a diff from the agent's CLAUDE.md if they want one.

This unblocks Phase B (#173) operator review: the confirm-token decision is *"is this rewrite worth applying?"* — only a diff answers that, byte-savings alone don't.

## Changes

- `src/agent/tightenClaudeMd.ts`: add `lineDiff()` (LCS-based, O(M·N) bounded by `BODY_MAX = 6000`), `formatRewriteDiff()` (unified-diff renderer with `maxLines` cap), `MIN_DIFF_SAVINGS_BYTES = 50`, `DEFAULT_MAX_DIFF_LINES = 60`. `formatTightenProposal` now accepts an optional `{ showDiffs, maxDiffLines, sources }` opts arg; sources map keyed by sectionId comes from the caller (the proposal payload deliberately doesn't carry source bodies — keeps `--json` lean per #176 out-of-scope).
- `src/cli.ts`: `--no-diff` option on `tighten-claude-md`; CLI builds the source-body lookup from `parseClaudeMdSections(md)` and threads it to the formatter.
- `src/agent/tightenClaudeMd.test.ts`: 9 new tests (`lineDiff` shape, `formatRewriteDiff` headers + line cap + truncation marker, formatter shows / omits diffs by savings floor / `showDiffs` flag / missing-source fallback, plus back-compat with the legacy single-arg call).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 415/415 pass (was 406)
- [ ] Real-data spot-check: run `vp-dev agents tighten-claude-md <agentId>` against an active agent, confirm diff output reads cleanly; then re-run with `--no-diff` and confirm fallback to the prior summary; then `--json` and confirm payload unchanged.

— Cook (agent-fe90)
