### PR TITLE
fix(compact-claude-md): refuse --apply when clampClusterFields truncated bodies

### DIFF
--- a/src/agent/compactClaudeMd.test.ts
+++ b/src/agent/compactClaudeMd.test.ts
@@ -65,6 +65,7 @@ test("findDroppedIncidentDates: flags cluster where merged body drops a source d
 
   assert.equal(warnings.length, 1);
   assert.equal(warnings[0].kind, "dropped-incident-date");
+  if (warnings[0].kind !== "dropped-incident-date") return;
   assert.deepEqual(warnings[0].missingDates, ["2026-04-28"]);
   assert.deepEqual(warnings[0].fromSectionIds, ["s0"]);
 });
@@ -148,6 +149,7 @@ test("findDroppedIncidentDates: clusterIndex matches the position in the input a
   );
   assert.equal(warnings.length, 1);
   assert.equal(warnings[0].clusterIndex, 1);
+  if (warnings[0].kind !== "dropped-incident-date") return;
   assert.deepEqual(warnings[0].missingDates, ["2026-04-04"]);
 });
 
@@ -201,7 +203,7 @@ test("formatCompactionProposal: surfaces dropped-date warnings inline per cluste
   assert.match(out, /merging 3 sections/);
   assert.match(out, /provenance: #100, #101/);
   assert.match(out, /DROPPED DATES: 2026-04-28/);
-  assert.match(out, /1 cluster\(s\) flagged/);
+  assert.match(out, /1 validator finding\(s\)/);
   assert.match(out, /Unclustered \(1\): s3/);
 });
 
@@ -703,7 +705,7 @@ void AGENTS_ROOT;
 // that had received a #142+ summarizer pass — i.e. nearly every active one.
 // ---------------------------------------------------------------------------
 
-import { clampClusterFields } from "./compactClaudeMd.js";
+import { clampClusterFields, findClampedBodies } from "./compactClaudeMd.js";
 
 test("parseClaudeMdSections: matches sentinels with the optional `tags:` suffix (#142+ shape)", () => {
   // Pre-fix, SECTION_RE required `ts:\S+\s*-->`, so any sentinel emitted by
@@ -755,7 +757,7 @@ test("clampClusterFields: still trims cluster body / heading / rationale alongsi
       {
         sectionIds: ["s0", "s1", "s2"],
         proposedHeading: "x".repeat(200),
-        proposedBody: "y".repeat(8000),
+        proposedBody: "y".repeat(12000),
         rationale: "z".repeat(1200),
       },
     ],
@@ -766,7 +768,156 @@ test("clampClusterFields: still trims cluster body / heading / rationale alongsi
     notes: string;
   };
   assert.ok(out.clusters[0].proposedHeading.length <= 160);
-  assert.ok(out.clusters[0].proposedBody.length <= 6000);
+  // Issue #175: BODY_MAX raised from 6000 to 10000 to give the model
+  // room for dense 3-6 source-section merges without firing the clamp.
+  assert.ok(out.clusters[0].proposedBody.length <= 10000);
   assert.ok(out.clusters[0].rationale.length <= 800);
   assert.ok(out.notes.length <= 500);
+});
+
+// ---------------------------------------------------------------------------
+// Issue #175: clamp-leak validator. clampClusterFields tacks on `\n[…truncated]`
+// when a body or rationale exceeds the byte cap; findClampedBodies surfaces
+// that as a CompactionWarning so the --apply gate refuses to write the marker
+// into the file.
+// ---------------------------------------------------------------------------
+
+test("findClampedBodies: flags clusters whose proposedBody ends in the truncation marker", () => {
+  const warnings = findClampedBodies({
+    clusters: [
+      {
+        sectionIds: ["s0", "s1", "s2"],
+        proposedHeading: "Merged",
+        // The literal sentinel clampClusterFields appends.
+        proposedBody: "Combined content...\n[…truncated]",
+        rationale: "shared thesis",
+        sourceProvenance: [],
+      },
+    ],
+  });
+  assert.equal(warnings.length, 1);
+  assert.equal(warnings[0].kind, "clamped-body");
+  assert.equal(warnings[0].clusterIndex, 0);
+  if (warnings[0].kind !== "clamped-body") return;
+  assert.deepEqual(warnings[0].fields, ["proposedBody"]);
+});
+
+test("findClampedBodies: flags clusters whose rationale ends in the truncation marker", () => {
+  const warnings = findClampedBodies({
+    clusters: [
+      {
+        sectionIds: ["s0", "s1", "s2"],
+        proposedHeading: "Merged",
+        proposedBody: "Combined content (clean).",
+        rationale: "shared thesis is...\n[…truncated]",
+        sourceProvenance: [],
+      },
+    ],
+  });
+  assert.equal(warnings.length, 1);
+  if (warnings[0].kind !== "clamped-body") return;
+  assert.deepEqual(warnings[0].fields, ["rationale"]);
+});
+
+test("findClampedBodies: reports both fields when both were clamped on the same cluster", () => {
+  const warnings = findClampedBodies({
+    clusters: [
+      {
+        sectionIds: ["s0", "s1", "s2"],
+        proposedHeading: "Merged",
+        proposedBody: "Body content...\n[…truncated]",
+        rationale: "Rationale content...\n[…truncated]",
+        sourceProvenance: [],
+      },
+    ],
+  });
+  assert.equal(warnings.length, 1);
+  if (warnings[0].kind !== "clamped-body") return;
+  assert.deepEqual(warnings[0].fields, ["proposedBody", "rationale"]);
+});
+
+test("findClampedBodies: clean cluster with no clamping yields no warning", () => {
+  const warnings = findClampedBodies({
+    clusters: [
+      {
+        sectionIds: ["s0", "s1", "s2"],
+        proposedHeading: "Merged",
+        proposedBody: "Combined content (clean).",
+        rationale: "shared thesis",
+        sourceProvenance: [],
+      },
+    ],
+  });
+  assert.equal(warnings.length, 0);
+});
+
+test("findClampedBodies: marker mid-body (not at end) is ignored — only end-of-field clamps are flagged", () => {
+  // Operators may legitimately quote prior incidents that contain the marker
+  // inside a longer body. Only the end-of-field clamp (clampClusterFields'
+  // own emission) counts as a true clamp leak.
+  const warnings = findClampedBodies({
+    clusters: [
+      {
+        sectionIds: ["s0", "s1", "s2"],
+        proposedHeading: "Merged",
+        proposedBody:
+          "Past incident: the model output ended with `\n[…truncated]` and then we followed up with this clean paragraph.",
+        rationale: "shared",
+        sourceProvenance: [],
+      },
+    ],
+  });
+  assert.equal(warnings.length, 0);
+});
+
+test("findClampedBodies: clusterIndex matches the position in the input array", () => {
+  const warnings = findClampedBodies({
+    clusters: [
+      {
+        sectionIds: ["s0", "s1"],
+        proposedHeading: "Clean",
+        proposedBody: "clean body",
+        rationale: "ok",
+        sourceProvenance: [],
+      },
+      {
+        sectionIds: ["s2", "s3"],
+        proposedHeading: "Clamped",
+        proposedBody: "clamped...\n[…truncated]",
+        rationale: "ok",
+        sourceProvenance: [],
+      },
+    ],
+  });
+  assert.equal(warnings.length, 1);
+  assert.equal(warnings[0].clusterIndex, 1);
+});
+
+test("formatCompactionProposal: surfaces clamped-body warnings inline per cluster", () => {
+  const proposal: CompactionProposal = {
+    agentId: "agent-test",
+    clusters: [
+      {
+        sectionIds: ["s0", "s1", "s2"],
+        proposedHeading: "Merged rule",
+        proposedBody: "body ending in...\n[…truncated]",
+        rationale: "shared thesis",
+        sourceProvenance: [],
+      },
+    ],
+    unclusteredSectionIds: [],
+    estimatedBytesSaved: 1024,
+    inputBytes: 8192,
+    sectionCount: 3,
+    warnings: [
+      {
+        kind: "clamped-body",
+        clusterIndex: 0,
+        fields: ["proposedBody"],
+      },
+    ],
+  };
+  const out = formatCompactionProposal(proposal);
+  assert.match(out, /CLAMPED FIELDS: proposedBody/);
+  assert.match(out, /1 validator finding\(s\)/);
 });

--- a/src/agent/compactClaudeMd.ts
+++ b/src/agent/compactClaudeMd.ts
@@ -72,13 +72,27 @@ export function resolveMinClusterSize(opts: {
 // and a 100-char clamp truncates them with a literal `...` (issue #167).
 // 160 covers observed natural lengths without admitting essay-length headings.
 const HEADING_MAX = 160;
-const BODY_MAX = 6000;
+// Bumped from 6000 to 10000 (issue #175) — the prior ceiling forced the
+// clamp to fire on otherwise-valid merges of 3-6 dense source sections;
+// truncated bodies then leaked the `[…truncated]` marker through Phase B's
+// --apply path because the validator only checks for dropped past-incident
+// dates, not for the marker itself. Raising the cap reduces how often the
+// clamp fires; the new `findClampedBodies` validator (also #175) refuses
+// --apply when it does.
+const BODY_MAX = 10000;
 const RATIONALE_MAX = 800;
 // Top-level model-side `notes` field. Pre-clamp ceiling matches
 // `ProposalPayloadSchema.notes.max(500)`; verbose model commentary used to
 // hard-fail the entire proposal at Zod parse time, which is the wrong
 // failure mode for a cosmetic field that's already advisory.
 const NOTES_MAX = 500;
+
+// Literal sentinel `clampClusterFields` appends to over-long bodies and
+// rationales (`<truncated content>\n[…truncated]`). The clamp is for
+// schema-validation safety (Zod cap is the hard ceiling); the post-hoc
+// detector below catches when it fires so --apply can refuse to write the
+// truncated marker into the file (issue #175).
+const TRUNCATED_MARKER = "\n[…truncated]";
 
 export interface CompactionCluster {
   /** ≥2 sectionIds from parseClaudeMdSections, all to be merged into one. */
@@ -112,14 +126,21 @@ export interface CompactionProposal {
   warnings: CompactionWarning[];
 }
 
-export type CompactionWarning = {
-  kind: "dropped-incident-date";
-  clusterIndex: number;
-  /** Dates present in source section bodies but missing from the merged body. */
-  missingDates: string[];
-  /** sectionIds of the source sections whose dates were dropped. */
-  fromSectionIds: string[];
-};
+export type CompactionWarning =
+  | {
+      kind: "dropped-incident-date";
+      clusterIndex: number;
+      /** Dates present in source section bodies but missing from the merged body. */
+      missingDates: string[];
+      /** sectionIds of the source sections whose dates were dropped. */
+      fromSectionIds: string[];
+    }
+  | {
+      kind: "clamped-body";
+      clusterIndex: number;
+      /** Which fields ended in the truncation marker (model exceeded the byte cap). */
+      fields: Array<"proposedBody" | "rationale">;
+    };
 
 const ClusterSchema = z.object({
   sectionIds: z.array(z.string().min(1)).min(2),
@@ -222,6 +243,38 @@ export function findDroppedIncidentDates(
         missingDates: missing,
         fromSectionIds: Array.from(fromIds).sort(),
       });
+    }
+  });
+  return warnings;
+}
+
+/**
+ * Clamp-leak validator (per issue #175).
+ *
+ * `clampClusterFields` truncates `proposedBody` / `rationale` past their
+ * byte caps and tacks on a `\n[…truncated]` marker so the schema-validation
+ * gate doesn't hard-fail an otherwise-good proposal on a slightly-verbose
+ * cluster. The clamp is necessary safety, but the truncated content then
+ * flows through `applyCompaction` → `spliceCompactedSections` → atomic
+ * rename, leaving a literal `[…truncated]` marker in the file.
+ *
+ * `findDroppedIncidentDates` only checks for dropped ISO-style dates, not
+ * for the marker itself. This detector catches the marker directly so the
+ * `--apply` path's `warnings.length > 0` refusal gate fires before the
+ * rewrite. Match against the literal sentinel `\n[…truncated]` only at
+ * end-of-field — bodies citing the marker mid-text (e.g. quoting prior
+ * incidents) are ignored.
+ */
+export function findClampedBodies(proposal: {
+  clusters: CompactionCluster[];
+}): CompactionWarning[] {
+  const warnings: CompactionWarning[] = [];
+  proposal.clusters.forEach((c, idx) => {
+    const fields: Array<"proposedBody" | "rationale"> = [];
+    if (c.proposedBody.endsWith(TRUNCATED_MARKER)) fields.push("proposedBody");
+    if (c.rationale.endsWith(TRUNCATED_MARKER)) fields.push("rationale");
+    if (fields.length > 0) {
+      warnings.push({ kind: "clamped-body", clusterIndex: idx, fields });
     }
   });
   return warnings;
@@ -340,7 +393,10 @@ export async function proposeCompaction(
     .filter((id) => !seenIds.has(id));
 
   const estimatedBytesSaved = computeEstimatedBytesSaved(clusters, sectionById);
-  const warnings = findDroppedIncidentDates({ clusters }, sections);
+  const warnings: CompactionWarning[] = [
+    ...findDroppedIncidentDates({ clusters }, sections),
+    ...findClampedBodies({ clusters }),
+  ];
 
   return {
     ...baseProposal,
@@ -465,6 +521,10 @@ export function formatCompactionProposal(p: CompactionProposal): string {
         lines.push(
           `     ⚠ DROPPED DATES: ${w.missingDates.join(", ")} (from ${w.fromSectionIds.join(", ")})`,
         );
+      } else if (w.kind === "clamped-body") {
+        lines.push(
+          `     ⚠ CLAMPED FIELDS: ${w.fields.join(", ")} (model emission exceeded byte cap; detail dropped at truncation)`,
+        );
       }
     }
     lines.push("");
@@ -477,7 +537,7 @@ export function formatCompactionProposal(p: CompactionProposal): string {
   lines.push("");
   if (p.warnings.length > 0) {
     lines.push(
-      `⚠ ${p.warnings.length} cluster(s) flagged by the collapsed-distinct-rules validator — --apply will reject this proposal until re-run produces a clean output.`,
+      `⚠ ${p.warnings.length} validator finding(s) (dropped-incident-date or clamped-body) — --apply will reject this proposal until re-run produces a clean output.`,
     );
   } else {
     lines.push(
@@ -598,21 +658,26 @@ export async function applyCompaction(
       }
     }
 
-    const warnings = findDroppedIncidentDates(
-      { clusters: input.proposal.clusters },
-      sections,
-    );
+    const warnings: CompactionWarning[] = [
+      ...findDroppedIncidentDates(
+        { clusters: input.proposal.clusters },
+        sections,
+      ),
+      ...findClampedBodies({ clusters: input.proposal.clusters }),
+    ];
     if (warnings.length > 0) {
       const summary = warnings
-        .map(
-          (w) =>
-            `cluster[${w.clusterIndex}] dropped ${w.missingDates.join(",")}`,
-        )
+        .map((w) => {
+          if (w.kind === "dropped-incident-date") {
+            return `cluster[${w.clusterIndex}] dropped ${w.missingDates.join(",")}`;
+          }
+          return `cluster[${w.clusterIndex}] clamped ${w.fields.join(",")}`;
+        })
         .join("; ");
       return {
         kind: "drift-rejected",
         reason: "warnings-present",
-        details: `Collapsed-distinct-rules validator flagged the proposal at apply time: ${summary}. Re-run --apply.`,
+        details: `Compaction validator flagged the proposal at apply time: ${summary}. Re-run --apply.`,
       };
     }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2063,7 +2063,7 @@ async function cmdAgentsCompactClaudeMd(
     }
     process.stdout.write(formatCompactionProposal(proposal) + "\n");
     process.stdout.write(
-      `\nERROR: --apply refused; ${proposal.warnings.length} cluster(s) flagged by collapsed-distinct-rules validator. Re-run after the model emits a clean proposal.\n`,
+      `\nERROR: --apply refused; ${proposal.warnings.length} validator finding(s) (dropped-incident-date or clamped-body — see proposal output). Re-run after the model emits a clean proposal.\n`,
     );
     process.exit(2);
   }


### PR DESCRIPTION
Closes #175

## Summary

Fix the silent leak of `[…truncated]` markers from `compactClaudeMd`'s `--apply` path into per-agent CLAUDE.md files. Implements the issue's recommended `(1) + (3)` approach.

**(1) Refuse `--apply` on clamped bodies.** New `findClampedBodies(proposal)` validator scans every cluster's `proposedBody` and `rationale` for the literal `\n[…truncated]` end-of-field marker emitted by `clampClusterFields`. Detections surface as a new `kind: "clamped-body"` `CompactionWarning`, joining `dropped-incident-date` in the existing `warnings: CompactionWarning[]` array. The validator is run in two places:

- `proposeCompaction` → warnings flow through `formatCompactionProposal` (rendered as `⚠ CLAMPED FIELDS: proposedBody, rationale (model emission exceeded byte cap; detail dropped at truncation)`) and through `cmdAgentsCompactClaudeMd`'s existing `proposal.warnings.length > 0` `--apply` refusal.
- `applyCompaction` → re-run at confirm time so a token minted out-of-band can't bypass the gate.

**(3) Raise `BODY_MAX` from 6000 → 10000.** The prior ceiling fired the clamp on otherwise-valid merges of 3-6 dense source sections. 10000 covers observed natural lengths without admitting essay-length merges, reducing how often `(1)` needs to fire.

The CLI's `--apply` refusal message also generalizes: `validator finding(s) (dropped-incident-date or clamped-body — see proposal output)` instead of the prior validator-specific text.

## Why piggyback on the warnings array, not a separate field

The issue lists option (2) (validator extension) as redundant *if* the CLI also adds a separate refusal branch. Folding the new detector into the same `warnings: CompactionWarning[]` shape means:

- One refusal gate (`warnings.length > 0`) covers both kinds at both call sites (CLI `--apply`, `applyCompaction` confirm).
- One renderer path in `formatCompactionProposal` shows operators why the proposal was rejected.
- No new `applyRefused` enum branch in the JSON CLI output — both kinds report the same way.

The `CompactionWarning` type is a discriminated union now, so consumers narrow on `kind` to access kind-specific fields.

## Out of scope (per issue body)

- Analogous clamp in `src/agent/tightenClaudeMd.ts` (`BODY_MAX = 6000` for `rewrittenBody`, same `\n[…truncated]` marker). Phase B for tighten is still tracked at #173 — fix lands in lockstep with that PR.
- Retroactively scrubbing existing `[…truncated]` markers from per-agent files. Operators can hand-edit; new clamps won't appear once this lands.

## Test plan

- [x] `npm run build` — passes (typescript clean after narrowing the discriminated union)
- [x] `npm test` — 410/410 pass; new tests:
  - `findClampedBodies`: flags `proposedBody`-only, `rationale`-only, and both-fields-clamped cases
  - `findClampedBodies`: marker mid-body (not at end-of-field) is ignored — only `endsWith` matches
  - `findClampedBodies`: clean cluster yields no warning; clusterIndex matches input order
  - `formatCompactionProposal`: renders `⚠ CLAMPED FIELDS: proposedBody` and `1 validator finding(s)`
- [x] Existing `clampClusterFields` test updated for new 10000 cap (input bumped to 12000)
- [x] Existing dropped-date test type-narrowed for the new discriminated union

— Alonzo (agent-92ff)
