### PR TITLE
feat(state): per-section utility-scoring data collection (#178)

### DIFF
--- a/src/agent/runIssueCore.ts
+++ b/src/agent/runIssueCore.ts
@@ -2,6 +2,7 @@ import { promises as fs } from "node:fs";
 import { ensureAgent, mutateRegistry } from "../state/registry.js";
 import { runCodingAgent } from "./codingAgent.js";
 import {
+  agentClaudeMdPath,
   appendBlock,
   expireSentinels,
   forkClaudeMd,
@@ -9,6 +10,13 @@ import {
 } from "./specialization.js";
 import { isInfraFlake, summarizeFailureRun, summarizeRun, type SummarizerOutput } from "./summarizer.js";
 import { resolveExpiryPolicies } from "../util/sentinels.js";
+import {
+  deriveStableSectionId,
+  extractCitedStableIds,
+  recordIntroduction,
+  recordPushback,
+  recordReinforcement,
+} from "../state/lessonUtility.js";
 import { shouldPushPartial } from "./shouldPushPartial.js";
 import {
   buildIncompleteBranchName,
@@ -206,6 +214,21 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
         appendOutcome = appendResult.appendOutcome;
         summarySkipReason = appendResult.summarySkipReason;
 
+        // Issue #178 (Phase 1 of #177): record utility-scoring signals for
+        // the just-appended block. Fire-and-forget; never block the main
+        // run path on a utility-scoring failure.
+        if (appendOutcome?.kind === "appended") {
+          await recordUtilityForAppend({
+            agentId: input.agent.agentId,
+            runId: input.runId,
+            issueId: input.issue.id,
+            heading: summary.heading ?? "",
+            body: summary.body ?? "",
+            tags: envelope.memoryUpdate.addTags,
+            logger: input.logger,
+          });
+        }
+
         // Sentinel expiry: after a successful implement run has been
         // recorded, walk the agent's CLAUDE.md and drop sentinels that
         // newer blocks have superseded. Per-kind policies cover
@@ -286,8 +309,38 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
           });
           appendOutcome = appendResult.appendOutcome;
           summarySkipReason = appendResult.summarySkipReason;
+
+          // Issue #178: record utility-scoring signals for failure-lesson
+          // blocks too — they're attributable sections like any other.
+          if (appendOutcome?.kind === "appended") {
+            await recordUtilityForAppend({
+              agentId: input.agent.agentId,
+              runId: input.runId,
+              issueId: input.issue.id,
+              heading: summary.heading ?? "",
+              body: summary.body ?? "",
+              tags: input.agent.tags,
+              logger: input.logger,
+            });
+          }
         }
       }
+    }
+
+    // Issue #178: record pushback citation against existing sections
+    // whose heading + tags overlap the agent's pushback reasoning. Runs
+    // regardless of whether maybeAppendSummary appended — the signal is
+    // about which prior rule the agent applied, not the new lesson.
+    if (envelope?.decision === "pushback" && !input.skipSummary) {
+      await recordUtilityForPushback({
+        agentId: input.agent.agentId,
+        runId: input.runId,
+        issueId: input.issue.id,
+        commentText: envelope.reason ?? "",
+        tags: envelope.memoryUpdate.addTags,
+        targetRepoPath: input.targetRepoPath,
+        logger: input.logger,
+      });
     }
 
     await mutateRegistry((reg) => {
@@ -453,4 +506,109 @@ async function maybeAppendSummary(args: AppendArgs): Promise<{
     });
   }
   return { appendOutcome };
+}
+
+// Issue #178 (Phase 1 of #177): per-section utility-scoring data collection.
+// These helpers wrap the lessonUtility module in fail-soft try/catch so a
+// utility-scoring write failure can never block the orchestrator's main path.
+
+interface RecordUtilityForAppendArgs {
+  agentId: string;
+  runId: string;
+  issueId: number;
+  heading: string;
+  body: string;
+  tags?: string[];
+  logger: Logger;
+}
+
+async function recordUtilityForAppend(
+  args: RecordUtilityForAppendArgs,
+): Promise<void> {
+  try {
+    const ts = new Date().toISOString();
+    await recordIntroduction({
+      agentId: args.agentId,
+      runId: args.runId,
+      issueId: args.issueId,
+      body: args.body,
+      ts,
+    });
+    // Read the post-append CLAUDE.md and find which prior sections this
+    // new block reinforces. Exclude the just-introduced block itself.
+    const claudeMd = await fs
+      .readFile(agentClaudeMdPath(args.agentId), "utf-8")
+      .catch(() => "");
+    if (!claudeMd) return;
+    const selfStableId = deriveStableSectionId(args.runId, [args.issueId]);
+    const cited = extractCitedStableIds({
+      text: args.body,
+      heading: args.heading,
+      tags: args.tags,
+      claudeMd,
+      exclude: new Set([selfStableId]),
+    });
+    if (cited.length > 0) {
+      await recordReinforcement({
+        agentId: args.agentId,
+        runId: args.runId,
+        citedSectionStableIds: cited,
+      });
+      args.logger.info("specialization.utility_reinforced", {
+        agentId: args.agentId,
+        issueId: args.issueId,
+        citedCount: cited.length,
+      });
+    }
+  } catch (err) {
+    args.logger.warn("specialization.utility_record_failed", {
+      agentId: args.agentId,
+      issueId: args.issueId,
+      err: (err as Error).message,
+    });
+  }
+}
+
+interface RecordUtilityForPushbackArgs {
+  agentId: string;
+  runId: string;
+  issueId: number;
+  commentText: string;
+  tags?: string[];
+  targetRepoPath: string;
+  logger: Logger;
+}
+
+async function recordUtilityForPushback(
+  args: RecordUtilityForPushbackArgs,
+): Promise<void> {
+  try {
+    const claudeMd = await fs
+      .readFile(agentClaudeMdPath(args.agentId), "utf-8")
+      .catch(() => "");
+    if (!claudeMd) return;
+    const cited = extractCitedStableIds({
+      text: args.commentText,
+      tags: args.tags,
+      claudeMd,
+    });
+    if (cited.length > 0) {
+      await recordPushback({
+        agentId: args.agentId,
+        runId: args.runId,
+        citedSectionStableIds: cited,
+      });
+      args.logger.info("specialization.utility_pushback_recorded", {
+        agentId: args.agentId,
+        issueId: args.issueId,
+        citedCount: cited.length,
+      });
+    }
+  } catch (err) {
+    args.logger.warn("specialization.utility_record_failed", {
+      agentId: args.agentId,
+      issueId: args.issueId,
+      err: (err as Error).message,
+    });
+  }
 }

--- a/src/state/lessonUtility.test.ts
+++ b/src/state/lessonUtility.test.ts
@@ -1,0 +1,350 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import {
+  deriveStableSectionId,
+  extractCitedStableIds,
+  extractPastIncidentDates,
+  lessonUtilityPath,
+  loadLessonUtility,
+  recordIntroduction,
+  recordMergeHistory,
+  recordPushback,
+  recordReinforcement,
+  resolveJaccardMin,
+  DEFAULT_REINFORCEMENT_JACCARD_MIN,
+  LESSON_UTILITY_SCHEMA_VERSION,
+} from "./lessonUtility.js";
+
+// STATE_DIR is captured at module-load via path.resolve(process.cwd(),
+// "state"), so tests can't redirect by chdir. Instead each test uses a
+// unique agentId (gitignored state file) and cleans up its own file on
+// completion. Mirrors the pattern in runConfirm.test.ts.
+let testCounter = 0;
+async function withTestAgent<T>(
+  fn: (agentId: string) => Promise<T>,
+): Promise<T> {
+  const agentId = `agent-test-${process.pid}-${++testCounter}`;
+  try {
+    return await fn(agentId);
+  } finally {
+    await fs.rm(lessonUtilityPath(agentId), { force: true });
+    await fs.rm(`${lessonUtilityPath(agentId)}.lock`, { force: true });
+  }
+}
+
+test("deriveStableSectionId: stable for same runId+issueId", () => {
+  const a = deriveStableSectionId("run-2026-05-06T10-00-00Z", [42]);
+  const b = deriveStableSectionId("run-2026-05-06T10-00-00Z", [42]);
+  assert.equal(a, b);
+  assert.match(a, /^[0-9a-f]{64}$/);
+});
+
+test("deriveStableSectionId: different runId produces different ID", () => {
+  const a = deriveStableSectionId("run-A", [42]);
+  const b = deriveStableSectionId("run-B", [42]);
+  assert.notEqual(a, b);
+});
+
+test("deriveStableSectionId: compound issueIds produce sorted-stable hash (issue #162 shape)", () => {
+  const a = deriveStableSectionId("run-X", [102, 100, 101]);
+  const b = deriveStableSectionId("run-X", [100, 101, 102]);
+  const c = deriveStableSectionId("run-X", [101, 102, 100]);
+  assert.equal(a, b);
+  assert.equal(b, c);
+});
+
+test("deriveStableSectionId: throws on empty issueIds", () => {
+  assert.throws(() => deriveStableSectionId("run-X", []), /non-empty/);
+});
+
+test("extractPastIncidentDates: scrapes distinct ISO dates, sorted", () => {
+  const body = "incident 2026-05-04, 2026-05-04 again, and 2026-04-29 earlier";
+  assert.deepEqual(extractPastIncidentDates(body), ["2026-04-29", "2026-05-04"]);
+});
+
+test("extractPastIncidentDates: returns empty array when none present", () => {
+  assert.deepEqual(extractPastIncidentDates("no dates here"), []);
+});
+
+test("recordIntroduction: creates a fresh record when file is absent", async () => {
+  await withTestAgent(async (agentId) => {
+    await recordIntroduction({
+      agentId,
+      runId: "run-1",
+      issueId: 178,
+      body: "saw this 2026-05-06",
+      ts: "2026-05-06T10:00:00.000Z",
+    });
+    const file = await loadLessonUtility(agentId);
+    assert.ok(file);
+    assert.equal(file?.schemaVersion, LESSON_UTILITY_SCHEMA_VERSION);
+    assert.equal(file?.sections.length, 1);
+    const sec = file!.sections[0];
+    assert.equal(sec.sectionId, deriveStableSectionId("run-1", [178]));
+    assert.equal(sec.introducedRunId, "run-1");
+    assert.deepEqual(sec.pastIncidentDates, ["2026-05-06"]);
+    assert.equal(sec.crossReferenceCount, 0);
+    assert.deepEqual(sec.reinforcementRuns, []);
+  });
+});
+
+test("recordIntroduction: idempotent on the same stable ID, refreshes pastIncidentDates", async () => {
+  await withTestAgent(async (agentId) => {
+    await recordIntroduction({
+      agentId,
+      runId: "run-1",
+      issueId: 178,
+      body: "incident 2026-05-06",
+      ts: "2026-05-06T10:00:00.000Z",
+    });
+    await recordIntroduction({
+      agentId,
+      runId: "run-1",
+      issueId: 178,
+      body: "incident 2026-05-06 and 2026-05-07",
+      ts: "2026-05-06T11:00:00.000Z",
+    });
+    const file = await loadLessonUtility(agentId);
+    assert.equal(file?.sections.length, 1);
+    assert.deepEqual(file?.sections[0].pastIncidentDates, [
+      "2026-05-06",
+      "2026-05-07",
+    ]);
+    // introducedRunId / introducedAt do not change
+    assert.equal(file?.sections[0].introducedAt, "2026-05-06T10:00:00.000Z");
+  });
+});
+
+test("recordReinforcement: appends runId, dedups, stamps lastReinforcedAt", async () => {
+  await withTestAgent(async (agentId) => {
+    await recordIntroduction({
+      agentId,
+      runId: "run-1",
+      issueId: 178,
+      body: "",
+      ts: "2026-05-06T10:00:00.000Z",
+    });
+    const target = deriveStableSectionId("run-1", [178]);
+    await recordReinforcement({
+      agentId,
+      runId: "run-2",
+      citedSectionStableIds: [target],
+    });
+    await recordReinforcement({
+      agentId,
+      runId: "run-2",
+      citedSectionStableIds: [target],
+    });
+    const file = await loadLessonUtility(agentId);
+    const sec = file!.sections.find((s) => s.sectionId === target)!;
+    assert.deepEqual(sec.reinforcementRuns, ["run-2"]);
+    assert.ok(sec.lastReinforcedAt);
+  });
+});
+
+test("recordReinforcement: silently skips unknown stable IDs", async () => {
+  await withTestAgent(async (agentId) => {
+    await recordIntroduction({
+      agentId,
+      runId: "run-1",
+      issueId: 178,
+      body: "",
+      ts: "2026-05-06T10:00:00.000Z",
+    });
+    await recordReinforcement({
+      agentId,
+      runId: "run-2",
+      citedSectionStableIds: ["unknown-stable-id-zzz"],
+    });
+    const file = await loadLessonUtility(agentId);
+    const sec = file!.sections[0];
+    assert.deepEqual(sec.reinforcementRuns, []);
+  });
+});
+
+test("recordReinforcement: empty citedSectionStableIds is a no-op (no file write)", async () => {
+  await withTestAgent(async (agentId) => {
+    await recordReinforcement({
+      agentId,
+      runId: "run-2",
+      citedSectionStableIds: [],
+    });
+    const file = await loadLessonUtility(agentId);
+    assert.equal(file, null);
+  });
+});
+
+test("recordPushback: appends to pushbackRuns separately from reinforcementRuns", async () => {
+  await withTestAgent(async (agentId) => {
+    await recordIntroduction({
+      agentId,
+      runId: "run-1",
+      issueId: 178,
+      body: "",
+      ts: "2026-05-06T10:00:00.000Z",
+    });
+    const target = deriveStableSectionId("run-1", [178]);
+    await recordReinforcement({
+      agentId,
+      runId: "run-2",
+      citedSectionStableIds: [target],
+    });
+    await recordPushback({
+      agentId,
+      runId: "run-3",
+      citedSectionStableIds: [target],
+    });
+    const file = await loadLessonUtility(agentId);
+    const sec = file!.sections[0];
+    assert.deepEqual(sec.reinforcementRuns, ["run-2"]);
+    assert.deepEqual(sec.pushbackRuns, ["run-3"]);
+  });
+});
+
+test("recordMergeHistory: merges source records into a new merged stable ID", async () => {
+  await withTestAgent(async (agentId) => {
+    await recordIntroduction({
+      agentId,
+      runId: "run-A",
+      issueId: 100,
+      body: "incident 2026-04-01",
+      ts: "2026-04-01T10:00:00.000Z",
+    });
+    await recordIntroduction({
+      agentId,
+      runId: "run-B",
+      issueId: 101,
+      body: "incident 2026-04-15",
+      ts: "2026-04-15T10:00:00.000Z",
+    });
+    const idA = deriveStableSectionId("run-A", [100]);
+    const idB = deriveStableSectionId("run-B", [101]);
+    await recordReinforcement({
+      agentId,
+      runId: "run-C",
+      citedSectionStableIds: [idA],
+    });
+    await recordPushback({
+      agentId,
+      runId: "run-D",
+      citedSectionStableIds: [idB],
+    });
+    const merged = deriveStableSectionId("run-merge", [100, 101]);
+    await recordMergeHistory({
+      agentId,
+      sourceStableIds: [idA, idB],
+      mergedStableId: merged,
+      mergedAt: "2026-05-06T12:00:00.000Z",
+    });
+    const file = await loadLessonUtility(agentId);
+    assert.ok(file);
+    assert.equal(file?.mergeHistory.length, 1);
+    assert.deepEqual(
+      [...(file?.mergeHistory[0].sourceStableIds ?? [])].sort(),
+      [idA, idB].sort(),
+    );
+    const mergedSec = file!.sections.find((s) => s.sectionId === merged)!;
+    assert.ok(mergedSec);
+    assert.deepEqual(mergedSec.reinforcementRuns, ["run-C"]);
+    assert.deepEqual(mergedSec.pushbackRuns, ["run-D"]);
+    assert.deepEqual(mergedSec.pastIncidentDates, [
+      "2026-04-01",
+      "2026-04-15",
+    ]);
+  });
+});
+
+test("resolveJaccardMin: defaults when env unset", () => {
+  assert.equal(resolveJaccardMin({}), DEFAULT_REINFORCEMENT_JACCARD_MIN);
+});
+
+test("resolveJaccardMin: parses valid (0,1] env values", () => {
+  assert.equal(
+    resolveJaccardMin({ VP_DEV_REINFORCEMENT_JACCARD_MIN: "0.5" }),
+    0.5,
+  );
+});
+
+test("resolveJaccardMin: falls back on invalid env values", () => {
+  assert.equal(
+    resolveJaccardMin({ VP_DEV_REINFORCEMENT_JACCARD_MIN: "garbage" }),
+    DEFAULT_REINFORCEMENT_JACCARD_MIN,
+  );
+  assert.equal(
+    resolveJaccardMin({ VP_DEV_REINFORCEMENT_JACCARD_MIN: "0" }),
+    DEFAULT_REINFORCEMENT_JACCARD_MIN,
+  );
+  assert.equal(
+    resolveJaccardMin({ VP_DEV_REINFORCEMENT_JACCARD_MIN: "1.5" }),
+    DEFAULT_REINFORCEMENT_JACCARD_MIN,
+  );
+});
+
+test("extractCitedStableIds: matches via Jaccard heading overlap above threshold", () => {
+  const md = `
+<!-- run:run-A issue:#100 outcome:implement ts:2026-04-01T10:00:00.000Z tags:cli-gate,cost-surface -->
+## Some lesson about cost-surface CLI gates and approval
+
+body line.
+`;
+  const cited = extractCitedStableIds({
+    text: "approval flow tightened",
+    heading: "Cost-surface CLI gate approval improvements",
+    tags: ["cli-gate", "cost-surface"],
+    claudeMd: md,
+    jaccardMin: 0.2,
+  });
+  assert.equal(cited.length, 1);
+  assert.equal(cited[0], deriveStableSectionId("run-A", [100]));
+});
+
+test("extractCitedStableIds: returns empty when no overlap above threshold", () => {
+  const md = `
+<!-- run:run-A issue:#100 outcome:implement ts:2026-04-01T10:00:00.000Z tags:foo -->
+## Wholly unrelated lesson about widgets
+
+body
+`;
+  const cited = extractCitedStableIds({
+    text: "approval flow tightened",
+    heading: "Cost-surface CLI gate approval improvements",
+    tags: ["cli-gate", "cost-surface"],
+    claudeMd: md,
+    jaccardMin: 0.6,
+  });
+  assert.deepEqual(cited, []);
+});
+
+test("extractCitedStableIds: respects exclude set so a section never cites itself", () => {
+  const md = `
+<!-- run:run-A issue:#100 outcome:implement ts:2026-04-01T10:00:00.000Z tags:cli-gate -->
+## Lesson about cli gate
+
+body
+`;
+  const self = deriveStableSectionId("run-A", [100]);
+  const cited = extractCitedStableIds({
+    text: "lesson about cli gate body",
+    heading: "Lesson about cli gate",
+    claudeMd: md,
+    jaccardMin: 0.1,
+    exclude: new Set([self]),
+  });
+  assert.deepEqual(cited, []);
+});
+
+test("extractCitedStableIds: returns empty on a CLAUDE.md with no attributable sections", () => {
+  const md = "# heading\n\nNo sentinels here.\n";
+  const cited = extractCitedStableIds({
+    text: "anything",
+    heading: "anything",
+    claudeMd: md,
+  });
+  assert.deepEqual(cited, []);
+});
+
+test("lessonUtilityPath is under STATE_DIR", () => {
+  const p = lessonUtilityPath("agent-916a");
+  assert.match(p, /state[\\/]lesson-utility-agent-916a\.json$/);
+});

--- a/src/state/lessonUtility.ts
+++ b/src/state/lessonUtility.ts
@@ -1,0 +1,457 @@
+// Per-section utility-scoring data collection (issue #178, Phase 1 of #177).
+//
+// Persists five signals per attributable section, updated by the summarizer
+// pipeline post-run, used by future Phase 3 (`vp-dev agents assess-claude-md`)
+// to produce keep/trim/drop verdicts. Phase 1 ships data collection only; no
+// behavior change visible to the operator.
+//
+// Persistence: `state/lesson-utility-<agentId>.json`. Gitignored, atomic
+// writes via the same lock helper used by run-state files.
+//
+// All write helpers fail-soft: callers wrap them in try/catch and the
+// orchestrator's main path is never blocked by a utility-scoring failure.
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { createHash } from "node:crypto";
+import { atomicWriteJson, STATE_DIR } from "./runState.js";
+import { withFileLock } from "./locks.js";
+import { parseClaudeMdSections, type ParsedSection } from "../agent/split.js";
+
+export const LESSON_UTILITY_SCHEMA_VERSION = 1;
+
+/** Default Jaccard threshold for the heading/tag-overlap fallback matcher. */
+export const DEFAULT_REINFORCEMENT_JACCARD_MIN = 0.6;
+
+export interface SectionUtilityRecord {
+  /** Stable ID — sha256(runId + ":" + sorted compound-id token). Survives
+   * positional renumbering and body edits. Compact merges synthesize a
+   * fresh stable ID via `mergeHistory` mapping. */
+  sectionId: string;
+  introducedRunId: string;
+  introducedAt: string;
+  /** Run IDs whose summarizer-emitted block cited this section. Deduped. */
+  reinforcementRuns: string[];
+  /** Run IDs where this section was cited in a pushback comment. Deduped. */
+  pushbackRuns: string[];
+  /** Distinct ISO `20XX-XX-XX` dates referenced in the body. Pure-derived. */
+  pastIncidentDates: string[];
+  lastReinforcedAt?: string;
+  /** Updated by a separate sweep (out of scope for #178); defaults to 0. */
+  crossReferenceCount: number;
+  crossReferenceUpdatedAt?: string;
+}
+
+export interface MergeHistoryEntry {
+  sourceStableIds: string[];
+  mergedStableId: string;
+  mergedAt: string;
+}
+
+export interface AgentUtilityFile {
+  agentId: string;
+  schemaVersion: typeof LESSON_UTILITY_SCHEMA_VERSION;
+  sections: SectionUtilityRecord[];
+  mergeHistory: MergeHistoryEntry[];
+}
+
+export function lessonUtilityPath(agentId: string): string {
+  return path.join(STATE_DIR, `lesson-utility-${agentId}.json`);
+}
+
+/**
+ * Derive the stable section ID. For single-issue blocks this is
+ * `sha256(runId + ":" + issueId)`. For compacted blocks (issue #162) the
+ * compound token is the sorted `#N1+#N2+#N3` string so re-running on the
+ * same merged block always produces the same hash.
+ */
+export function deriveStableSectionId(
+  runId: string,
+  issueIds: number[],
+): string {
+  if (issueIds.length === 0) {
+    throw new Error("deriveStableSectionId: issueIds must be non-empty");
+  }
+  const sorted = [...issueIds].sort((a, b) => a - b);
+  const token =
+    sorted.length === 1
+      ? String(sorted[0])
+      : sorted.map((n) => `#${n}`).join("+");
+  return createHash("sha256").update(`${runId}:${token}`).digest("hex");
+}
+
+/** Pure-derived: scrape distinct `20XX-XX-XX` ISO dates from a body. */
+export function extractPastIncidentDates(body: string): string[] {
+  const matches = body.match(/\b20\d{2}-\d{2}-\d{2}\b/g) ?? [];
+  return [...new Set(matches)].sort();
+}
+
+export async function loadLessonUtility(
+  agentId: string,
+): Promise<AgentUtilityFile | null> {
+  try {
+    const raw = await fs.readFile(lessonUtilityPath(agentId), "utf-8");
+    const parsed = JSON.parse(raw) as Partial<AgentUtilityFile>;
+    return normalizeFile(agentId, parsed);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+export async function saveLessonUtility(file: AgentUtilityFile): Promise<void> {
+  const filePath = lessonUtilityPath(file.agentId);
+  await withFileLock(filePath, async () => {
+    await atomicWriteJson(filePath, file);
+  });
+}
+
+function normalizeFile(
+  agentId: string,
+  raw: Partial<AgentUtilityFile>,
+): AgentUtilityFile {
+  return {
+    agentId: raw.agentId ?? agentId,
+    schemaVersion: LESSON_UTILITY_SCHEMA_VERSION,
+    sections: Array.isArray(raw.sections) ? raw.sections : [],
+    mergeHistory: Array.isArray(raw.mergeHistory) ? raw.mergeHistory : [],
+  };
+}
+
+function emptyFile(agentId: string): AgentUtilityFile {
+  return {
+    agentId,
+    schemaVersion: LESSON_UTILITY_SCHEMA_VERSION,
+    sections: [],
+    mergeHistory: [],
+  };
+}
+
+async function mutateFile(
+  agentId: string,
+  fn: (file: AgentUtilityFile) => void,
+): Promise<void> {
+  const filePath = lessonUtilityPath(agentId);
+  await withFileLock(filePath, async () => {
+    let file: AgentUtilityFile;
+    try {
+      const raw = await fs.readFile(filePath, "utf-8");
+      file = normalizeFile(agentId, JSON.parse(raw) as Partial<AgentUtilityFile>);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+      file = emptyFile(agentId);
+    }
+    fn(file);
+    await atomicWriteJson(filePath, file);
+  });
+}
+
+export interface RecordIntroductionInput {
+  agentId: string;
+  runId: string;
+  /** Canonical issue ID. */
+  issueId: number;
+  /** Set on `outcome:compacted` blocks — every source ID. Otherwise omit. */
+  issueIds?: number[];
+  body: string;
+  ts: string;
+}
+
+/**
+ * Insert a new SectionUtilityRecord for a freshly-appended block. Idempotent:
+ * if a record with the same stable ID already exists, only `pastIncidentDates`
+ * is refreshed (body may have been hand-edited or compact-merged in between).
+ */
+export async function recordIntroduction(
+  input: RecordIntroductionInput,
+): Promise<void> {
+  const ids = input.issueIds && input.issueIds.length > 0
+    ? input.issueIds
+    : [input.issueId];
+  const stableId = deriveStableSectionId(input.runId, ids);
+  const dates = extractPastIncidentDates(input.body);
+
+  await mutateFile(input.agentId, (file) => {
+    const existing = file.sections.find((s) => s.sectionId === stableId);
+    if (existing) {
+      existing.pastIncidentDates = dates;
+      return;
+    }
+    file.sections.push({
+      sectionId: stableId,
+      introducedRunId: input.runId,
+      introducedAt: input.ts,
+      reinforcementRuns: [],
+      pushbackRuns: [],
+      pastIncidentDates: dates,
+      crossReferenceCount: 0,
+    });
+  });
+}
+
+export interface RecordReinforcementInput {
+  agentId: string;
+  runId: string;
+  citedSectionStableIds: string[];
+}
+
+/**
+ * Append `runId` to the `reinforcementRuns` of each cited section (deduped),
+ * and stamp `lastReinforcedAt`. Citing a stable-ID that has no record is a
+ * silent no-op — the cited block may not have been an attributable
+ * sentinel-prefixed section. No-op when `citedSectionStableIds` is empty.
+ */
+export async function recordReinforcement(
+  input: RecordReinforcementInput,
+): Promise<void> {
+  if (input.citedSectionStableIds.length === 0) return;
+  const ts = new Date().toISOString();
+  await mutateFile(input.agentId, (file) => {
+    const cited = new Set(input.citedSectionStableIds);
+    for (const section of file.sections) {
+      if (!cited.has(section.sectionId)) continue;
+      if (!section.reinforcementRuns.includes(input.runId)) {
+        section.reinforcementRuns.push(input.runId);
+      }
+      section.lastReinforcedAt = ts;
+    }
+  });
+}
+
+/**
+ * Like `recordReinforcement` but writes to `pushbackRuns`.
+ */
+export async function recordPushback(
+  input: RecordReinforcementInput,
+): Promise<void> {
+  if (input.citedSectionStableIds.length === 0) return;
+  const ts = new Date().toISOString();
+  await mutateFile(input.agentId, (file) => {
+    const cited = new Set(input.citedSectionStableIds);
+    for (const section of file.sections) {
+      if (!cited.has(section.sectionId)) continue;
+      if (!section.pushbackRuns.includes(input.runId)) {
+        section.pushbackRuns.push(input.runId);
+      }
+      section.lastReinforcedAt = ts;
+    }
+  });
+}
+
+export interface RecordMergeHistoryInput {
+  agentId: string;
+  sourceStableIds: string[];
+  mergedStableId: string;
+  mergedAt: string;
+}
+
+/**
+ * Record a compact-merge: the merged section inherits the union of source
+ * sections' reinforcement / pushback runs, and a mergeHistory entry is added
+ * mapping old → new stable IDs. Source records are preserved (so audits can
+ * reconstruct lineage) but the merged record is the live signal carrier.
+ */
+export async function recordMergeHistory(
+  input: RecordMergeHistoryInput,
+): Promise<void> {
+  if (input.sourceStableIds.length === 0) return;
+  await mutateFile(input.agentId, (file) => {
+    const sources = file.sections.filter((s) =>
+      input.sourceStableIds.includes(s.sectionId),
+    );
+    const reinforcementUnion = new Set<string>();
+    const pushbackUnion = new Set<string>();
+    const datesUnion = new Set<string>();
+    let earliestIntroducedAt: string | undefined;
+    let earliestRunId: string | undefined;
+    let lastReinforcedAt: string | undefined;
+    for (const s of sources) {
+      for (const r of s.reinforcementRuns) reinforcementUnion.add(r);
+      for (const r of s.pushbackRuns) pushbackUnion.add(r);
+      for (const d of s.pastIncidentDates) datesUnion.add(d);
+      if (!earliestIntroducedAt || s.introducedAt < earliestIntroducedAt) {
+        earliestIntroducedAt = s.introducedAt;
+        earliestRunId = s.introducedRunId;
+      }
+      if (s.lastReinforcedAt) {
+        if (!lastReinforcedAt || s.lastReinforcedAt > lastReinforcedAt) {
+          lastReinforcedAt = s.lastReinforcedAt;
+        }
+      }
+    }
+    const existing = file.sections.find(
+      (s) => s.sectionId === input.mergedStableId,
+    );
+    if (existing) {
+      for (const r of reinforcementUnion) {
+        if (!existing.reinforcementRuns.includes(r)) {
+          existing.reinforcementRuns.push(r);
+        }
+      }
+      for (const r of pushbackUnion) {
+        if (!existing.pushbackRuns.includes(r)) {
+          existing.pushbackRuns.push(r);
+        }
+      }
+      const allDates = new Set([...existing.pastIncidentDates, ...datesUnion]);
+      existing.pastIncidentDates = [...allDates].sort();
+      if (lastReinforcedAt) {
+        if (
+          !existing.lastReinforcedAt ||
+          lastReinforcedAt > existing.lastReinforcedAt
+        ) {
+          existing.lastReinforcedAt = lastReinforcedAt;
+        }
+      }
+    } else {
+      file.sections.push({
+        sectionId: input.mergedStableId,
+        introducedRunId: earliestRunId ?? "merged",
+        introducedAt: earliestIntroducedAt ?? input.mergedAt,
+        reinforcementRuns: [...reinforcementUnion],
+        pushbackRuns: [...pushbackUnion],
+        pastIncidentDates: [...datesUnion].sort(),
+        lastReinforcedAt,
+        crossReferenceCount: 0,
+      });
+    }
+    file.mergeHistory.push({
+      sourceStableIds: [...input.sourceStableIds],
+      mergedStableId: input.mergedStableId,
+      mergedAt: input.mergedAt,
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Cited-section extraction.
+//
+// The summarizer's emitted body is a synthesized lesson; agents do not embed
+// stable-ID hashes in prose. Realistic extraction order:
+//   1. Explicit `s0`/`s1`/... position references (rare but possible — the
+//      compactor's prompt can refer to them). These are mapped to stable IDs
+//      via the order of `parseClaudeMdSections` over the current CLAUDE.md.
+//   2. Jaccard fallback over (heading + tags) tokens. Default ≥ 0.6.
+// ---------------------------------------------------------------------------
+
+const POSITION_REF_RE = /\bs(\d+)\b/g;
+const STOP_WORDS = new Set([
+  "a", "an", "and", "are", "as", "at", "be", "by", "for", "from", "has", "have",
+  "in", "into", "is", "it", "its", "of", "on", "or", "that", "the", "this",
+  "to", "was", "were", "will", "with", "the", "but", "if", "not", "no", "so",
+]);
+
+function tokenize(text: string): Set<string> {
+  const out = new Set<string>();
+  for (const raw of text.toLowerCase().split(/[^a-z0-9-]+/)) {
+    if (raw.length < 3) continue;
+    if (STOP_WORDS.has(raw)) continue;
+    out.add(raw);
+  }
+  return out;
+}
+
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersect = 0;
+  for (const t of a) if (b.has(t)) intersect++;
+  const union = a.size + b.size - intersect;
+  return union === 0 ? 0 : intersect / union;
+}
+
+function sectionTags(_section: ParsedSection): string[] {
+  // Sentinel tags aren't carried on ParsedSection — heading + body is what
+  // we have. Heading is the strongest signal; body provides backup tokens.
+  // Reserved for the future: when ParsedSection grows a `tags` field, lift
+  // them here so Jaccard incorporates the sentinel tag fingerprint.
+  return [];
+}
+
+interface ParsedSectionWithStableId extends ParsedSection {
+  stableId: string;
+}
+
+function withStableIds(sections: ParsedSection[]): ParsedSectionWithStableId[] {
+  return sections.map((s) => {
+    const ids = s.issueIds && s.issueIds.length > 0
+      ? s.issueIds
+      : [s.issueId ?? 0];
+    const stableId =
+      s.runId && ids[0] !== 0
+        ? deriveStableSectionId(s.runId, ids)
+        : `unattributable:${s.sectionId}`;
+    return { ...s, stableId };
+  });
+}
+
+export interface ExtractCitedInput {
+  /** Body of the just-appended summarizer block (or pushback comment). */
+  text: string;
+  /** Heading of the same block; used as primary signal in Jaccard fallback. */
+  heading?: string;
+  /** Tags this issue contributed; OR'd into the Jaccard token set. */
+  tags?: string[];
+  /** Current contents of the agent's CLAUDE.md. */
+  claudeMd: string;
+  /** Override for testability; defaults to env / DEFAULT_REINFORCEMENT_JACCARD_MIN. */
+  jaccardMin?: number;
+  /** Exclude these stable IDs (e.g. the section being introduced). */
+  exclude?: Set<string>;
+}
+
+export function resolveJaccardMin(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = env.VP_DEV_REINFORCEMENT_JACCARD_MIN;
+  if (raw == null || raw === "") return DEFAULT_REINFORCEMENT_JACCARD_MIN;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0 || n > 1) {
+    return DEFAULT_REINFORCEMENT_JACCARD_MIN;
+  }
+  return n;
+}
+
+/**
+ * Extract stable IDs of sections cited by the given text. Returns a deduped
+ * list. Pure / synchronous so tests can exercise it without I/O.
+ */
+export function extractCitedStableIds(input: ExtractCitedInput): string[] {
+  const sections = withStableIds(parseClaudeMdSections(input.claudeMd));
+  if (sections.length === 0) return [];
+  const exclude = input.exclude ?? new Set<string>();
+  const out = new Set<string>();
+
+  // Path 1: explicit `s0`/`s1` position references.
+  const positionRefs = new Set<number>();
+  for (const m of input.text.matchAll(POSITION_REF_RE)) {
+    positionRefs.add(Number(m[1]));
+  }
+  for (const idx of positionRefs) {
+    const section = sections[idx];
+    if (!section) continue;
+    if (exclude.has(section.stableId)) continue;
+    out.add(section.stableId);
+  }
+
+  // Path 2: Jaccard over (heading + tags + body-tokens) of the new block
+  // versus each prior section's heading.
+  const min = input.jaccardMin ?? resolveJaccardMin();
+  const newTokens = tokenize(
+    [
+      input.heading ?? "",
+      (input.tags ?? []).join(" "),
+      input.text.slice(0, 4096),
+    ].join(" "),
+  );
+  for (const section of sections) {
+    if (exclude.has(section.stableId)) continue;
+    if (out.has(section.stableId)) continue;
+    const sectionTokens = tokenize(
+      [section.heading, ...sectionTags(section)].join(" "),
+    );
+    const score = jaccard(newTokens, sectionTokens);
+    if (score >= min) out.add(section.stableId);
+  }
+
+  return [...out];
+}


### PR DESCRIPTION
Closes #178

## Summary

Phase 1 of #177 — persisted state and summarizer/pushback hooks for per-section CLAUDE.md utility scoring. Phase 3 (`assess-claude-md`) reads from this; nothing operator-visible until then.

- **`src/state/lessonUtility.ts`** (new): schema (`AgentUtilityFile` / `SectionUtilityRecord` / `MergeHistoryEntry`), atomic writes via `withFileLock` + `atomicWriteJson`, content-derived stable IDs (`sha256(runId + ":" + sorted compound-id token)`), `recordIntroduction` / `recordReinforcement` / `recordPushback` / `recordMergeHistory`, and a pure `extractCitedStableIds` matcher (explicit `sN` references first, Jaccard fallback over heading + tags + leading body tokens, env-tunable `VP_DEV_REINFORCEMENT_JACCARD_MIN`, default `0.6`).
- **`src/state/lessonUtility.test.ts`** (new): 22 tests covering ID stability across positional renumbering, compound-issue hash equality (#162 shape), idempotent introduction, reinforcement dedup, pushback isolation, merge-history union semantics, env knob clamping, Jaccard threshold behavior, and exclude-self.
- **`src/agent/runIssueCore.ts`**: two fail-soft hooks. After every successful `maybeAppendSummary` (success / pushback / failure-lesson branch), `recordUtilityForAppend` introduces the new section and reinforces prior cited sections (excluding self via the just-derived stable ID). On `envelope.decision === "pushback"`, `recordUtilityForPushback` cites prior sections matching the pushback reasoning text. Both wrap in try/catch and log a `specialization.utility_record_failed` warn on any failure — the main run path is never blocked.

State file persisted under `state/lesson-utility-<agentId>.json` (gitignored, same lifecycle as run-state files).

### Out of scope per the issue
- Cross-reference centrality sweep — separate, scheduled job; `crossReferenceCount` defaults to `0`.
- `assess-claude-md` subcommand (Phase 3).
- Phase 2's accuracy-degradation measurement.
- Active wiring of `recordMergeHistory` from `compactClaudeMd.ts` apply path — exposed as a public helper but not yet called from compact; suitable as a small follow-up issue.

## Test plan

- [x] `npm run build` — clean tsc.
- [x] `npm test` — 424/424 pass (22 new in `lessonUtility.test.js`).
- [ ] Soak: after ~2 weeks of runs against `agent-916a`, `state/lesson-utility-agent-916a.json` should accrue non-zero `reinforcementRuns` for the most-cited sections.
- [ ] Re-running an issue twice on the same `runId+issueId` produces no duplicate `SectionUtilityRecord` (idempotent introduction is covered by the test, pinned for soak).

— Advisory Scope Boundary (agent-916a)
