### PR TITLE
fix(curve-study): widen aggregate log-filename regex for trim-agent IDs

### DIFF
--- a/src/research/curveStudy/aggregate.test.ts
+++ b/src/research/curveStudy/aggregate.test.ts
@@ -1,6 +1,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { extractEnvelope } from "./aggregate.js";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { aggregateLogsDir, extractEnvelope } from "./aggregate.js";
 
 test("extractEnvelope: finds the last top-level JSON object after npm chatter", () => {
   const text =
@@ -36,4 +39,34 @@ test("extractEnvelope: handles trailing whitespace after the JSON", () => {
   const env = extractEnvelope(text) as { envelope: { decision: string } } | null;
   assert.ok(env);
   assert.equal(env!.envelope.decision, "pushback");
+});
+
+test("aggregateLogsDir: matches plan-trims agent IDs (hex + hyphens, not just digits)", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "agg-trim-test-"));
+  try {
+    const envelope = {
+      envelope: { decision: "pushback", reason: "tracking issue" },
+      costUsd: 0.244,
+      durationMs: 47666,
+      isError: false,
+    };
+    const trimAgentId = "agent-916a-trim-6000-s8026";
+    await fs.writeFile(
+      path.join(dir, `curveStudy-${trimAgentId}-156.log`),
+      `> spawn chatter\n\n${JSON.stringify(envelope, null, 2)}\n`,
+    );
+    const cells = await aggregateLogsDir({
+      logsDir: dir,
+      prefix: "curveStudy-",
+      agentSizes: new Map([[trimAgentId, 5935]]),
+    });
+    assert.equal(cells.length, 1, "trim-agent log must aggregate to 1 cell");
+    assert.equal(cells[0].agentId, trimAgentId);
+    assert.equal(cells[0].issueId, 156);
+    assert.equal(cells[0].agentSizeBytes, 5935);
+    assert.equal(cells[0].decision, "pushback");
+    assert.equal(cells[0].costUsd, 0.244);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
 });

--- a/src/research/curveStudy/aggregate.ts
+++ b/src/research/curveStudy/aggregate.ts
@@ -81,7 +81,7 @@ export async function aggregateLogsDir(opts: {
   agentSizes: Map<string, number>;
 }): Promise<Cell[]> {
   const files = await fs.readdir(opts.logsDir);
-  const re = new RegExp(`^${opts.prefix}(agent-\\d+)-(\\d+)\\.log$`);
+  const re = new RegExp(`^${opts.prefix}(agent-[a-z0-9-]+)-(\\d+)\\.log$`);
   const cells: Cell[] = [];
   for (const f of files.sort()) {
     const m = re.exec(f);


### PR DESCRIPTION
## Summary

- `aggregateLogsDir` regex narrowly matched `agent-\d+`, so plan-trims-generated trim-agent IDs of the form `agent-916a-trim-6000-s8026` (hex + hyphens) never matched their log filenames. Cells ran successfully at the spawn level but produced `cellCount: 0` in the curve-study output and no curve fit.
- Same family of regression the roadmap flagged for the branch-name regex — `VP_DEV_BRANCH_RE` was widened to `agent-[a-z0-9-]+` already, but `aggregate.ts` slipped through. Fix mirrors that pattern.
- Added an `aggregateLogsDir` test that exercises a trim-agent log filename end-to-end.

Caught by the phase 3 smoke run on vp-mcp #156: spawn returned a valid envelope (\$0.244, decision=pushback, 47s) but orchestrator reported `"Done. 0 cells, \$0.00, 1.0min"`. Without this fix, the planned 234-cell phase 3 dispatch would burn ~\$1,640 producing zero aggregated cells.

Validated against the real smoke log:
```
cells.length = 1
agentId=agent-916a-trim-6000-s8026, issueId=156, decision=pushback, costUsd=0.243925
```

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `node --test dist/src/research/curveStudy/aggregate.test.js` — 4/4 pass (3 existing + 1 new)
- [x] One-off `aggregateLogsDir` invocation against the real phase 3 smoke log produces 1 correctly-shaped cell

🤖 Generated with [Claude Code](https://claude.com/claude-code)