### PR TITLE
feat(lessons): cost/benefit gating Phase 1 — transparency + dedup + prune

### DIFF
--- a/src/agent/lessonPrune.test.ts
+++ b/src/agent/lessonPrune.test.ts
@@ -1,0 +1,231 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  applyLessonPrune,
+  computePruneProposalHash,
+  formatLessonPruneProposal,
+  hashFile,
+  type PruneProposal,
+} from "./lessonPrune.js";
+import { dropSentinelsByStableId } from "../util/sentinels.js";
+import { deriveStableSectionId } from "../state/lessonUtility.js";
+import { formatSentinelHeader } from "../util/sentinels.js";
+
+function makeAgentClaudeMd(
+  blocks: ReadonlyArray<{
+    runId: string;
+    issueId: number;
+    heading: string;
+    body: string;
+    ts: string;
+  }>,
+): string {
+  const out: string[] = ["# Project rules", ""];
+  for (const b of blocks) {
+    out.push(
+      formatSentinelHeader({
+        runId: b.runId,
+        issueId: b.issueId,
+        outcome: "implement",
+        ts: b.ts,
+      }),
+    );
+    out.push(`## ${b.heading}`);
+    out.push("");
+    out.push(b.body);
+    out.push("");
+  }
+  return out.join("\n");
+}
+
+async function withTempClaudeMd<T>(
+  initialContent: string,
+  fn: (filePath: string) => Promise<T>,
+): Promise<T> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "lesson-prune-test-"));
+  const filePath = path.join(dir, "CLAUDE.md");
+  await fs.writeFile(filePath, initialContent);
+  try {
+    return await fn(filePath);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+// -----------------------------------------------------------------------
+// dropSentinelsByStableId — the underlying surgery
+// -----------------------------------------------------------------------
+
+test("dropSentinelsByStableId: drops only matched stable IDs", () => {
+  const content = makeAgentClaudeMd([
+    { runId: "run-A", issueId: 1, heading: "First", body: "body 1", ts: "2026-04-01T00:00:00Z" },
+    { runId: "run-B", issueId: 2, heading: "Second", body: "body 2", ts: "2026-04-02T00:00:00Z" },
+    { runId: "run-C", issueId: 3, heading: "Third", body: "body 3", ts: "2026-04-03T00:00:00Z" },
+  ]);
+  const dropId = deriveStableSectionId("run-B", [2]);
+  const result = dropSentinelsByStableId(
+    content,
+    new Set([dropId]),
+    (h) => deriveStableSectionId(h.runId, h.issueIds ?? [h.issueId]),
+  );
+  assert.equal(result.droppedHeaders.length, 1);
+  assert.equal(result.droppedHeaders[0].issueId, 2);
+  assert.match(result.content, /## First/);
+  assert.match(result.content, /## Third/);
+  assert.doesNotMatch(result.content, /## Second/);
+});
+
+test("dropSentinelsByStableId: empty drop set is a no-op", () => {
+  const content = makeAgentClaudeMd([
+    { runId: "run-A", issueId: 1, heading: "First", body: "body 1", ts: "2026-04-01T00:00:00Z" },
+  ]);
+  const result = dropSentinelsByStableId(content, new Set(), () => "");
+  assert.equal(result.droppedHeaders.length, 0);
+  assert.equal(result.content, content);
+});
+
+// -----------------------------------------------------------------------
+// applyLessonPrune — full two-step path
+// -----------------------------------------------------------------------
+
+function makeProposal(stableIds: string[]): PruneProposal {
+  return {
+    agentId: "agent-test",
+    generatedAt: "2026-05-06T10:00:00Z",
+    pruned: stableIds.map((id) => ({
+      stableId: id,
+      reason: "zero-reinforcement" as const,
+      introducedRunId: "run-X",
+      introducedAt: "2026-04-01T00:00:00Z",
+      siblingsIntroducedAfter: 11,
+      reinforcementRuns: 0,
+      pushbackRuns: 0,
+    })),
+    bytesBefore: 1000,
+    minSiblingsAfter: 10,
+  };
+}
+
+test("applyLessonPrune: applies a valid token, drops the matching section", async () => {
+  const content = makeAgentClaudeMd([
+    { runId: "run-A", issueId: 1, heading: "Keeper", body: "body 1", ts: "2026-04-01T00:00:00Z" },
+    { runId: "run-B", issueId: 2, heading: "Stale rule", body: "body 2", ts: "2026-04-02T00:00:00Z" },
+  ]);
+  await withTempClaudeMd(content, async (filePath) => {
+    const dropId = deriveStableSectionId("run-B", [2]);
+    const proposal = makeProposal([dropId]);
+    const hash = computePruneProposalHash(proposal, content);
+    const result = await applyLessonPrune({
+      agentId: "agent-test",
+      proposal,
+      expectedProposalHash: hash,
+      claudeMdPathOverride: filePath,
+    });
+    assert.equal(result.kind, "applied");
+    if (result.kind === "applied") {
+      assert.equal(result.sectionsDropped, 1);
+      assert.ok(result.bytesAfter < result.bytesBefore);
+    }
+    const after = await fs.readFile(filePath, "utf-8");
+    assert.match(after, /## Keeper/);
+    assert.doesNotMatch(after, /## Stale rule/);
+  });
+});
+
+test("applyLessonPrune: rejects token with stale proposalHash (file drifted)", async () => {
+  const content = makeAgentClaudeMd([
+    { runId: "run-A", issueId: 1, heading: "Original", body: "body 1", ts: "2026-04-01T00:00:00Z" },
+  ]);
+  await withTempClaudeMd(content, async (filePath) => {
+    const dropId = deriveStableSectionId("run-A", [1]);
+    const proposal = makeProposal([dropId]);
+    const hashAtPlan = computePruneProposalHash(proposal, content);
+
+    // Simulate concurrent edit: file content changes between plan and confirm.
+    await fs.writeFile(filePath, content + "\n## Manual edit\n");
+
+    const result = await applyLessonPrune({
+      agentId: "agent-test",
+      proposal,
+      expectedProposalHash: hashAtPlan,
+      claudeMdPathOverride: filePath,
+    });
+    assert.equal(result.kind, "drift-rejected");
+    if (result.kind === "drift-rejected") {
+      assert.equal(result.reason, "proposal-hash");
+    }
+  });
+});
+
+test("applyLessonPrune: rejects empty proposal as no-sections", async () => {
+  await withTempClaudeMd("# empty\n", async (filePath) => {
+    const proposal = makeProposal([]);
+    const hash = computePruneProposalHash(proposal, "# empty\n");
+    const result = await applyLessonPrune({
+      agentId: "agent-test",
+      proposal,
+      expectedProposalHash: hash,
+      claudeMdPathOverride: filePath,
+    });
+    assert.equal(result.kind, "drift-rejected");
+    if (result.kind === "drift-rejected") {
+      assert.equal(result.reason, "no-sections");
+    }
+  });
+});
+
+test("applyLessonPrune: rejects when proposal references a stable ID not in the file", async () => {
+  const content = makeAgentClaudeMd([
+    { runId: "run-A", issueId: 1, heading: "Only one", body: "body 1", ts: "2026-04-01T00:00:00Z" },
+  ]);
+  await withTempClaudeMd(content, async (filePath) => {
+    // Reference a non-existent section.
+    const phantomId = deriveStableSectionId("run-PHANTOM", [999]);
+    const proposal = makeProposal([phantomId]);
+    const hash = computePruneProposalHash(proposal, content);
+    const result = await applyLessonPrune({
+      agentId: "agent-test",
+      proposal,
+      expectedProposalHash: hash,
+      claudeMdPathOverride: filePath,
+    });
+    assert.equal(result.kind, "drift-rejected");
+    if (result.kind === "drift-rejected") {
+      assert.equal(result.reason, "no-match");
+    }
+  });
+});
+
+test("computePruneProposalHash: stable across object key ordering", () => {
+  const a = makeProposal(["aaa", "bbb"]);
+  const b = makeProposal(["bbb", "aaa"]);
+  // Sort happens inside the helper, so the hashes must agree.
+  assert.equal(
+    computePruneProposalHash(a, "content"),
+    computePruneProposalHash(b, "content"),
+  );
+});
+
+test("computePruneProposalHash: changes when file content changes", () => {
+  const proposal = makeProposal(["aaa"]);
+  const h1 = computePruneProposalHash(proposal, "content-1");
+  const h2 = computePruneProposalHash(proposal, "content-2");
+  assert.notEqual(h1, h2);
+});
+
+test("hashFile: returns sha256 hex", () => {
+  const h = hashFile("hello");
+  assert.match(h, /^[a-f0-9]{64}$/);
+});
+
+test("formatLessonPruneProposal: renders empty case + populated case readably", () => {
+  const empty = formatLessonPruneProposal(makeProposal([]));
+  assert.match(empty, /Nothing to prune/);
+  const populated = formatLessonPruneProposal(makeProposal(["abcdef0123456789"]));
+  assert.match(populated, /1 section\(s\) eligible for removal/);
+  assert.match(populated, /\[zero-reinforcement\]/);
+  assert.match(populated, /Pass --apply/);
+});

--- a/src/agent/lessonPrune.ts
+++ b/src/agent/lessonPrune.ts
@@ -1,0 +1,237 @@
+// Empirical post-hoc lesson prune (#179 Phase 1, option C).
+//
+// Surfaces sections in an agent's CLAUDE.md that are eligible for removal
+// based on the per-section utility data already collected by #178 Phase 1.
+// Eligibility (from `findStaleSections` in `lessonUtility.ts`):
+//   - "zero-reinforcement": no reinforcementRuns AND ≥ minSiblingsAfter
+//     other sections introduced after this one.
+//   - "pushback-dominant" (bonus J): pushbackRuns > reinforcementRuns AND
+//     the same cool-off applies.
+//
+// Two-step token gate mirrors `compactClaudeMd` (#162) so the destructive
+// path requires explicit operator review between proposal and apply:
+//   vp-dev agents prune-lessons <agentId>           # advisory
+//   vp-dev agents prune-lessons <agentId> --apply   # mints token
+//   vp-dev agents prune-lessons <agentId> --confirm <token>   # rewrites
+//
+// File-hash binding in the token rejects the confirm if the agent's
+// CLAUDE.md drifted between plan and confirm (concurrent appendBlock,
+// hand-edit, summarizer run, etc.).
+
+import { promises as fs } from "node:fs";
+import crypto from "node:crypto";
+import { withFileLock } from "../state/locks.js";
+import { agentClaudeMdPath } from "./specialization.js";
+import {
+  deriveStableSectionId,
+  findStaleSections,
+  type StaleSection,
+} from "../state/lessonUtility.js";
+import {
+  dropSentinelsByStableId,
+  type SentinelHeader,
+} from "../util/sentinels.js";
+
+export interface PrunedSection {
+  stableId: string;
+  reason: "zero-reinforcement" | "pushback-dominant";
+  introducedRunId: string;
+  introducedAt: string;
+  siblingsIntroducedAfter: number;
+  reinforcementRuns: number;
+  pushbackRuns: number;
+}
+
+export interface PruneProposal {
+  agentId: string;
+  generatedAt: string;
+  /** Sections eligible for removal. Empty when there's nothing to prune. */
+  pruned: PrunedSection[];
+  /** Bytes before the rewrite (informational). */
+  bytesBefore: number;
+  /** Configuration that produced this proposal. */
+  minSiblingsAfter: number;
+}
+
+export interface ProposeLessonPruneInput {
+  agentId: string;
+  /** Override default cool-off; sections need this many later siblings. */
+  minSiblingsAfter?: number;
+  /** Pre-loaded file path for tests; defaults to `agentClaudeMdPath`. */
+  claudeMdPathOverride?: string;
+}
+
+export async function proposeLessonPrune(
+  input: ProposeLessonPruneInput,
+): Promise<PruneProposal> {
+  const stale = await findStaleSections({
+    agentId: input.agentId,
+    minSiblingsAfter: input.minSiblingsAfter,
+  });
+  const filePath = input.claudeMdPathOverride ?? agentClaudeMdPath(input.agentId);
+  let currentBytes = 0;
+  try {
+    const content = await fs.readFile(filePath, "utf-8");
+    currentBytes = Buffer.byteLength(content, "utf-8");
+  } catch {
+    // File missing — proposal is empty. Caller renders a clean "nothing to do."
+  }
+  return {
+    agentId: input.agentId,
+    generatedAt: new Date().toISOString(),
+    pruned: stale.map(toPrunedSection),
+    bytesBefore: currentBytes,
+    minSiblingsAfter:
+      input.minSiblingsAfter ??
+      // Re-resolve via lessonUtility's default to keep the proposal self-describing.
+      stale[0]?.siblingsIntroducedAfter !== undefined
+        ? Math.min(...stale.map((s) => s.siblingsIntroducedAfter))
+        : 10,
+  };
+}
+
+function toPrunedSection(s: StaleSection): PrunedSection {
+  return {
+    stableId: s.record.sectionId,
+    reason: s.reason,
+    introducedRunId: s.record.introducedRunId,
+    introducedAt: s.record.introducedAt,
+    siblingsIntroducedAfter: s.siblingsIntroducedAfter,
+    reinforcementRuns: s.record.reinforcementRuns.length,
+    pushbackRuns: s.record.pushbackRuns.length,
+  };
+}
+
+export function formatLessonPruneProposal(p: PruneProposal): string {
+  const lines: string[] = [];
+  lines.push(`Lesson-prune proposal for ${p.agentId}`);
+  lines.push(
+    `  CLAUDE.md size: ${(p.bytesBefore / 1024).toFixed(1)} KB`,
+  );
+  lines.push(
+    `  Cool-off: at least ${p.minSiblingsAfter} sibling sections introduced after the candidate.`,
+  );
+  if (p.pruned.length === 0) {
+    lines.push(
+      "  Nothing to prune. All sections either have ≥ 1 reinforcement, are too young, or are pushback-balanced.",
+    );
+    return lines.join("\n");
+  }
+  lines.push(
+    `  ${p.pruned.length} section(s) eligible for removal:`,
+  );
+  for (const s of p.pruned) {
+    lines.push(
+      `    [${s.reason}] ${s.stableId.slice(0, 12)}…  introduced ${s.introducedAt.slice(0, 10)} (${s.siblingsIntroducedAfter} later siblings, reinforcements=${s.reinforcementRuns}, pushbacks=${s.pushbackRuns})`,
+    );
+  }
+  lines.push(
+    "Pass --apply to mint a confirm token; --confirm <token> to perform the rewrite.",
+  );
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Two-step token binding.
+// ---------------------------------------------------------------------------
+
+export function hashFile(content: string): string {
+  return crypto.createHash("sha256").update(content).digest("hex");
+}
+
+/**
+ * proposalHash = sha256(JSON.stringify(stableIdsSorted) + sha256(currentFile))
+ * Stable across plan/confirm so long as the proposal's drop set and the file
+ * bytes don't change. Same recipe shape as `compactConfirm.computeProposalHash`.
+ */
+export function computePruneProposalHash(
+  proposal: PruneProposal,
+  currentFile: string,
+): string {
+  const sorted = [...proposal.pruned.map((s) => s.stableId)].sort();
+  const fileHash = hashFile(currentFile);
+  return crypto
+    .createHash("sha256")
+    .update(JSON.stringify(sorted))
+    .update(fileHash)
+    .digest("hex");
+}
+
+export interface ApplyLessonPruneInput {
+  agentId: string;
+  proposal: PruneProposal;
+  expectedProposalHash: string;
+  /** Override file path for tests; defaults to `agentClaudeMdPath`. */
+  claudeMdPathOverride?: string;
+}
+
+export type ApplyLessonPruneResult =
+  | {
+      kind: "applied";
+      bytesBefore: number;
+      bytesAfter: number;
+      sectionsDropped: number;
+      droppedHeaders: SentinelHeader[];
+    }
+  | {
+      kind: "drift-rejected";
+      reason: "proposal-hash" | "missing-file" | "no-sections" | "no-match";
+      details: string;
+    };
+
+export async function applyLessonPrune(
+  input: ApplyLessonPruneInput,
+): Promise<ApplyLessonPruneResult> {
+  if (input.proposal.pruned.length === 0) {
+    return {
+      kind: "drift-rejected",
+      reason: "no-sections",
+      details: "Proposal has zero sections to drop; nothing to apply.",
+    };
+  }
+  const filePath = input.claudeMdPathOverride ?? agentClaudeMdPath(input.agentId);
+  return withFileLock(filePath, async () => {
+    let current: string;
+    try {
+      current = await fs.readFile(filePath, "utf-8");
+    } catch {
+      return {
+        kind: "drift-rejected",
+        reason: "missing-file",
+        details: `agents/${input.agentId}/CLAUDE.md no longer exists; nothing to prune.`,
+      };
+    }
+    const computed = computePruneProposalHash(input.proposal, current);
+    if (computed !== input.expectedProposalHash) {
+      return {
+        kind: "drift-rejected",
+        reason: "proposal-hash",
+        details:
+          "CLAUDE.md content changed between --apply and --confirm. Re-run --apply to generate a fresh proposal + token.",
+      };
+    }
+    const dropSet = new Set(input.proposal.pruned.map((s) => s.stableId));
+    const result = dropSentinelsByStableId(current, dropSet, (header) => {
+      const ids = header.issueIds ?? [header.issueId];
+      return deriveStableSectionId(header.runId, ids);
+    });
+    if (result.droppedHeaders.length === 0) {
+      return {
+        kind: "drift-rejected",
+        reason: "no-match",
+        details:
+          "No sentinel matched any stable ID in the proposal. The file may have been pruned out-of-band; re-run --apply.",
+      };
+    }
+    const tmp = `${filePath}.tmp.${process.pid}`;
+    await fs.writeFile(tmp, result.content);
+    await fs.rename(tmp, filePath);
+    return {
+      kind: "applied",
+      bytesBefore: Buffer.byteLength(current, "utf-8"),
+      bytesAfter: Buffer.byteLength(result.content, "utf-8"),
+      sectionsDropped: result.droppedHeaders.length,
+      droppedHeaders: result.droppedHeaders,
+    };
+  });
+}

--- a/src/agent/runIssueCore.ts
+++ b/src/agent/runIssueCore.ts
@@ -11,6 +11,7 @@ import {
 import { isInfraFlake, summarizeFailureRun, summarizeRun, type SummarizerOutput } from "./summarizer.js";
 import { resolveExpiryPolicies } from "../util/sentinels.js";
 import {
+  checkLessonNovelty,
   deriveStableSectionId,
   extractCitedStableIds,
   recordIntroduction,
@@ -190,6 +191,16 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
       applyTagUpdate(input.agent, envelope);
 
       if (!input.skipSummary && !budgetExceededAtCompletion) {
+        // Read current CLAUDE.md size for the marginal-cost transparency line
+        // injected into the summarizer prompt (#179 Phase 1, option F). Surfaces
+        // the empirical accuracy-degradation cost so the LLM can choose to skip
+        // low-value lessons. Fail-soft: if the file is missing or unreadable, we
+        // pass undefined and the prompt drops the line cleanly.
+        const currentClaudeMdBytes = await fs
+          .readFile(agentClaudeMdPath(input.agent.agentId), "utf-8")
+          .then((s) => Buffer.byteLength(s, "utf-8"))
+          .catch(() => undefined);
+
         // Failure-mode branch: agent emitted decision="error" — fire the
         // failure summarizer (different prompt, biased toward extracting a
         // lesson). Success/pushback paths stay on summarizeRun.
@@ -203,6 +214,7 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
               toolUseTrace: result.toolUseTrace,
               finalText: result.finalText,
               logger: input.logger,
+              currentClaudeMdBytes,
             })
           : await summarizeRun({
               agent: input.agent,
@@ -211,6 +223,7 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
               toolUseTrace: result.toolUseTrace,
               finalText: result.finalText,
               logger: input.logger,
+              currentClaudeMdBytes,
             });
 
         const outcomeTag = isAgentFailure ? "failure-lesson" : envelope.decision;
@@ -299,6 +312,10 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
             reason: summarySkipReason,
           });
         } else if (result.errorReason || result.parseError || result.finalText) {
+          const currentClaudeMdBytes = await fs
+            .readFile(agentClaudeMdPath(input.agent.agentId), "utf-8")
+            .then((s) => Buffer.byteLength(s, "utf-8"))
+            .catch(() => undefined);
           const summary = await summarizeFailureRun({
             agent: input.agent,
             issue: input.issue,
@@ -306,6 +323,7 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
             toolUseTrace: result.toolUseTrace,
             finalText: result.finalText,
             logger: input.logger,
+            currentClaudeMdBytes,
           });
           const appendResult = await maybeAppendSummary({
             summary,
@@ -490,6 +508,53 @@ async function maybeAppendSummary(args: AppendArgs): Promise<{
       reason: summarySkipReason,
     });
     return { summarySkipReason };
+  }
+
+  // Dedup gate (#179 Phase 1, option G): if the candidate is a near-duplicate
+  // of an existing section, skip the append and credit the matched section
+  // via recordReinforcement instead. Fail-soft: read errors fall through to
+  // the normal append path so a missing file never blocks lesson capture.
+  try {
+    const claudeMd = await fs
+      .readFile(agentClaudeMdPath(args.agent.agentId), "utf-8")
+      .catch(() => "");
+    if (claudeMd) {
+      const novelty = checkLessonNovelty({
+        heading: args.summary.heading,
+        body: args.summary.body,
+        tags: args.tags,
+        claudeMd,
+      });
+      if (novelty.kind === "duplicate") {
+        args.logger.info("specialization.skipped_duplicate", {
+          agentId: args.agent.agentId,
+          issueId: args.issue.id,
+          matchedStableIds: novelty.matchedStableIds,
+          reason: "near-duplicate of existing section(s)",
+        });
+        // Credit the matched section(s) via reinforcement — the candidate
+        // didn't add new bytes, but it DID re-validate the existing rule.
+        await recordReinforcement({
+          agentId: args.agent.agentId,
+          runId: args.runId,
+          citedSectionStableIds: novelty.matchedStableIds,
+        }).catch((err) => {
+          args.logger.warn("specialization.utility_record_failed", {
+            agentId: args.agent.agentId,
+            issueId: args.issue.id,
+            err: (err as Error).message,
+          });
+        });
+        return { summarySkipReason: "duplicate" };
+      }
+    }
+  } catch (err) {
+    args.logger.warn("specialization.dedup_check_failed", {
+      agentId: args.agent.agentId,
+      issueId: args.issue.id,
+      err: (err as Error).message,
+    });
+    // Fall through to the normal append path — dedup is advisory.
   }
 
   const appendOutcome = await appendBlock({

--- a/src/agent/summarizer.test.ts
+++ b/src/agent/summarizer.test.ts
@@ -1,0 +1,146 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildCostTransparencyLine,
+  buildFailurePrompt,
+  buildPrompt,
+  type FailureSummarizerInput,
+  type SummarizerInput,
+} from "./summarizer.js";
+import type { Logger } from "../log/logger.js";
+import type { AgentRecord, IssueSummary, ResultEnvelope } from "../types.js";
+
+const stubLogger: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+} as unknown as Logger;
+
+const stubAgent: AgentRecord = {
+  agentId: "agent-test",
+  name: "Test",
+  tags: ["solana", "evm"],
+  createdAt: "2026-04-01T00:00:00Z",
+  lastActiveAt: "2026-05-06T00:00:00Z",
+  issuesHandled: 5,
+  implementCount: 2,
+  pushbackCount: 2,
+  errorCount: 1,
+};
+
+const stubIssue: IssueSummary = {
+  id: 42,
+  title: "Test issue",
+  labels: ["bug"],
+  state: "open",
+};
+
+const stubEnvelope: ResultEnvelope = {
+  decision: "implement",
+  reason: "Did the work",
+  prUrl: "https://example.com/pr/1",
+  memoryUpdate: { addTags: ["solana"] },
+};
+
+// -----------------------------------------------------------------------
+// #179 Phase 1, option F — buildCostTransparencyLine
+// -----------------------------------------------------------------------
+
+test("buildCostTransparencyLine: returns empty string when bytes undefined", () => {
+  assert.equal(buildCostTransparencyLine(undefined), "");
+});
+
+test("buildCostTransparencyLine: returns empty string when bytes is zero", () => {
+  assert.equal(buildCostTransparencyLine(0), "");
+});
+
+test("buildCostTransparencyLine: returns empty string for negative bytes", () => {
+  assert.equal(buildCostTransparencyLine(-100), "");
+});
+
+test("buildCostTransparencyLine: emits cost line with KB + degradation factor", () => {
+  const line = buildCostTransparencyLine(20 * 1024);
+  assert.match(line, /Marginal cost of adding a lesson/);
+  assert.match(line, /CLAUDE\.md is currently 20\.0 KB/);
+  assert.match(line, /predicted accuracy degradation factor [\d.]+/);
+  assert.match(line, /Adding a worst-case lesson grows it to ~/);
+  assert.match(line, /Skip if the lesson isn't carrying weight/);
+  assert.match(line, /linear-log accuracy fit, #179/);
+});
+
+test("buildCostTransparencyLine: predicted-after factor ≥ predicted-now factor (monotonic)", () => {
+  // Linear-log slope is positive on the pre-study placeholder samples;
+  // adding bytes can only increase the predicted factor (or stay equal in
+  // edge cases). Parse the two factors from the rendered line and confirm.
+  const line = buildCostTransparencyLine(10 * 1024);
+  const factors = [...line.matchAll(/factor [~]?([\d.]+)/g)].map((m) =>
+    Number(m[1]),
+  );
+  assert.equal(factors.length, 2);
+  assert.ok(
+    factors[1] >= factors[0],
+    `expected factor-after ≥ factor-now, got ${factors[1]} < ${factors[0]}`,
+  );
+});
+
+// -----------------------------------------------------------------------
+// buildPrompt / buildFailurePrompt incorporate the cost line when given bytes
+// -----------------------------------------------------------------------
+
+test("buildPrompt: omits cost line when currentClaudeMdBytes is undefined", () => {
+  const input: SummarizerInput = {
+    agent: stubAgent,
+    issue: stubIssue,
+    envelope: stubEnvelope,
+    toolUseTrace: [],
+    finalText: "did the work",
+    logger: stubLogger,
+  };
+  const prompt = buildPrompt(input);
+  assert.doesNotMatch(prompt, /Marginal cost of adding a lesson/);
+});
+
+test("buildPrompt: includes cost line when currentClaudeMdBytes is provided", () => {
+  const input: SummarizerInput = {
+    agent: stubAgent,
+    issue: stubIssue,
+    envelope: stubEnvelope,
+    toolUseTrace: [],
+    finalText: "did the work",
+    logger: stubLogger,
+    currentClaudeMdBytes: 25_000,
+  };
+  const prompt = buildPrompt(input);
+  assert.match(prompt, /Marginal cost of adding a lesson/);
+  assert.match(prompt, /linear-log accuracy fit, #179/);
+});
+
+test("buildFailurePrompt: includes cost line when currentClaudeMdBytes is provided", () => {
+  const input: FailureSummarizerInput = {
+    agent: stubAgent,
+    issue: stubIssue,
+    envelope: { ...stubEnvelope, decision: "error" },
+    errorReason: "max turns",
+    toolUseTrace: [],
+    finalText: "ran out of turns",
+    logger: stubLogger,
+    currentClaudeMdBytes: 30_000,
+  };
+  const prompt = buildFailurePrompt(input);
+  assert.match(prompt, /Marginal cost of adding a lesson/);
+});
+
+test("buildFailurePrompt: omits cost line when currentClaudeMdBytes is undefined", () => {
+  const input: FailureSummarizerInput = {
+    agent: stubAgent,
+    issue: stubIssue,
+    envelope: { ...stubEnvelope, decision: "error" },
+    errorReason: "max turns",
+    toolUseTrace: [],
+    finalText: "ran out of turns",
+    logger: stubLogger,
+  };
+  const prompt = buildFailurePrompt(input);
+  assert.doesNotMatch(prompt, /Marginal cost of adding a lesson/);
+});

--- a/src/agent/summarizer.ts
+++ b/src/agent/summarizer.ts
@@ -3,6 +3,7 @@ import { query } from "@anthropic-ai/claude-agent-sdk";
 import { claudeBinPath } from "./sdkBinary.js";
 import { parseJsonEnvelope } from "../util/parseJsonEnvelope.js";
 import { ORCHESTRATOR_MODEL_SUMMARIZER } from "../orchestrator/models.js";
+import { accuracyDegradationFactor } from "../util/contextCostCurve.js";
 import type { AgentRecord, IssueSummary, ResultEnvelope } from "../types.js";
 import type { Logger } from "../log/logger.js";
 
@@ -34,6 +35,18 @@ export interface SummarizerInput {
   toolUseTrace: { tool: string; input: string }[];
   finalText: string;
   logger: Logger;
+  /**
+   * Current size of the agent's CLAUDE.md, in bytes. Threaded by
+   * `runIssueCore` from a `Buffer.byteLength` of the file just before this
+   * summarizer call. Surfaced in the prompt as a marginal-cost transparency
+   * signal (#179 Phase 1, option F): the LLM sees what its proposed lesson
+   * will cost on the empirical accuracy-degradation curve before it commits.
+   * No gating — the LLM's existing "no GENERALIZABLE rule → skip" hard-rule
+   * absorbs cost-awareness on its own terms. Optional for back-compat with
+   * call sites that pre-date this field; absence drops the line from the
+   * prompt rather than failing.
+   */
+  currentClaudeMdBytes?: number;
 }
 
 export async function summarizeRun(input: SummarizerInput): Promise<SummarizerOutput> {
@@ -56,6 +69,8 @@ export interface FailureSummarizerInput {
   toolUseTrace: { tool: string; input: string }[];
   finalText: string;
   logger: Logger;
+  /** See `SummarizerInput.currentClaudeMdBytes`. */
+  currentClaudeMdBytes?: number;
 }
 
 export async function summarizeFailureRun(
@@ -273,7 +288,7 @@ Hard rules:
 Output: a single JSON object, no fences, no prose. The \`skip\` field is MANDATORY in every response. Schema:
   {"skip": boolean, "skipReason"?: string, "heading"?: string, "body"?: string}`;
 
-function buildFailurePrompt(input: FailureSummarizerInput): string {
+export function buildFailurePrompt(input: FailureSummarizerInput): string {
   const trace = input.toolUseTrace
     .slice(-12)
     .map((t) => `- ${t.tool}: ${t.input}`)
@@ -288,6 +303,8 @@ function buildFailurePrompt(input: FailureSummarizerInput): string {
   const tagsRemoved = input.envelope
     ? JSON.stringify(input.envelope.memoryUpdate.removeTags ?? [])
     : "[]";
+
+  const costLine = buildCostTransparencyLine(input.currentClaudeMdBytes);
 
   return `Agent ${input.agent.agentId} just FAILED work on an issue. Distill the lesson.
 
@@ -309,15 +326,17 @@ ${trace || "(none captured)"}
 
 Agent's final reasoning text (truncated):
 ${truncate(input.finalText, 4000)}
+${costLine}
 
 Decide: is there a generalizable failure lesson worth committing to this agent's CLAUDE.md? Lean toward yes — failure-mode runs exist to capture signal that success-mode discards. If yes, emit {"skip": false, "heading": "...", "body": "..."}. If the failure is genuinely opaque, emit {"skip": true, "skipReason": "..."}. The skip field is mandatory in both shapes. JSON only — escape every \\" inside string values.`;
 }
 
-function buildPrompt(input: SummarizerInput): string {
+export function buildPrompt(input: SummarizerInput): string {
   const trace = input.toolUseTrace
     .slice(-12)
     .map((t) => `- ${t.tool}: ${t.input}`)
     .join("\n");
+  const costLine = buildCostTransparencyLine(input.currentClaudeMdBytes);
 
   return `Agent ${input.agent.agentId} just finished work.
 
@@ -341,6 +360,7 @@ ${trace || "(none captured)"}
 
 Agent's final reasoning text (truncated):
 ${truncate(input.finalText, 4000)}
+${costLine}
 
 Decide: is there a generalizable rule worth committing to this agent's CLAUDE.md? If yes, emit {"skip": false, "heading": "...", "body": "..."}. If no, emit {"skip": true, "skipReason": "..."}. The skip field is mandatory in both shapes. JSON only — escape every \\" inside string values.`;
 }
@@ -348,5 +368,35 @@ Decide: is there a generalizable rule worth committing to this agent's CLAUDE.md
 function truncate(s: string, max: number): string {
   if (s.length <= max) return s;
   return s.slice(0, max - 3) + "...";
+}
+
+/**
+ * Render a marginal-cost transparency line for the summarizer prompt. Returns
+ * an empty string when `currentClaudeMdBytes` is undefined (back-compat) or
+ * when the curve evaluates to NaN (e.g., zero-byte file before fork). The
+ * line cites #179 so the LLM has provenance for the prediction.
+ *
+ * The "added bytes" estimate uses the schema's HEADING_MAX (120) + BODY_MAX
+ * (2000) caps as an upper bound — the actual lesson will usually be smaller,
+ * making this a *worst-case* cost estimate. We don't see the body before the
+ * call, so this is the tightest forecast available without a chicken-and-egg.
+ */
+export function buildCostTransparencyLine(currentBytes: number | undefined): string {
+  if (currentBytes == null || !Number.isFinite(currentBytes) || currentBytes <= 0) {
+    return "";
+  }
+  const upperBoundAddedBytes = HEADING_MAX + BODY_MAX + 200; // 200 for sentinel + headings
+  const factorNow = accuracyDegradationFactor(currentBytes);
+  const factorAfter = accuracyDegradationFactor(currentBytes + upperBoundAddedBytes);
+  if (!Number.isFinite(factorNow) || !Number.isFinite(factorAfter)) return "";
+  const kbNow = (currentBytes / 1024).toFixed(1);
+  const kbAfter = ((currentBytes + upperBoundAddedBytes) / 1024).toFixed(1);
+  return [
+    "",
+    "Marginal cost of adding a lesson here (linear-log accuracy fit, #179):",
+    `  CLAUDE.md is currently ${kbNow} KB (predicted accuracy degradation factor ${factorNow.toFixed(3)}).`,
+    `  Adding a worst-case lesson grows it to ~${kbAfter} KB (factor ~${factorAfter.toFixed(3)}).`,
+    `  Skip if the lesson isn't carrying weight — every byte degrades future runs.`,
+  ].join("\n");
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -370,6 +370,31 @@ export function buildCli(): Command {
         }),
     )
     .addCommand(
+      new Command("prune-lessons")
+        .description(
+          "Propose removal of stale sections from an agent's CLAUDE.md (#179 Phase 1, option C). Uses utility-scoring data already collected by #178: drops sections with zero reinforcementRuns OR pushbackRuns > reinforcementRuns, after a cool-off of N later siblings. With --apply: mint a confirm token (15-min TTL); with --confirm <token>: perform the destructive rewrite under the per-file lock. Two-step pattern mirrors compact-claude-md.",
+        )
+        .argument("<agentId>", "Agent to inspect (e.g. agent-916a)")
+        .option("--json", "Print machine-readable JSON")
+        .option(
+          "--min-siblings-after <n>",
+          "Cool-off: a section is eligible only if at least this many other sections were introduced after it (default 10).",
+          parsePositive,
+          10,
+        )
+        .option(
+          "--apply",
+          "Compute the proposal AND mint a confirm token under state/lesson-prune-confirm-<token>.json (15-min TTL). Re-invoke with --confirm <token> to perform the rewrite.",
+        )
+        .option(
+          "--confirm <token>",
+          "Apply the proposal recorded in the named token, after re-validating against the live file content.",
+        )
+        .action(async (agentId, opts) => {
+          await cmdAgentsPruneLessons(agentId, opts);
+        }),
+    )
+    .addCommand(
       new Command("stats")
         .description("Per-agent rollup of PR outcomes (merge rate, median rework, median CI cycles).")
         .option("--json", "Print machine-readable JSON")
@@ -2251,6 +2276,114 @@ async function cmdAgentsCompactClaudeMdConfirm(
       `  ${(result.bytesBefore / 1024).toFixed(1)}KB -> ${(result.bytesAfter / 1024).toFixed(1)}KB ` +
       `(${result.clustersApplied} cluster(s), ${result.sectionsMerged} sections merged)\n` +
       `  merge runId: ${result.runId}\n`,
+  );
+}
+
+interface AgentsPruneLessonsOpts {
+  json?: boolean;
+  minSiblingsAfter: number;
+  apply?: boolean;
+  confirm?: string;
+}
+
+async function cmdAgentsPruneLessons(
+  agentId: string,
+  opts: AgentsPruneLessonsOpts,
+): Promise<void> {
+  const {
+    proposeLessonPrune,
+    formatLessonPruneProposal,
+    computePruneProposalHash,
+    applyLessonPrune,
+  } = await import("./agent/lessonPrune.js");
+  const {
+    mintToken,
+    writeLessonPruneConfirmToken,
+    readLessonPruneConfirmToken,
+    deleteLessonPruneConfirmToken,
+  } = await import("./state/lessonPruneConfirm.js");
+  const { agentClaudeMdPath } = await import("./agent/specialization.js");
+
+  if (opts.confirm) {
+    const tokenResult = await readLessonPruneConfirmToken(opts.confirm);
+    if (!tokenResult.ok) {
+      process.stderr.write(`ERROR: ${tokenResult.message}\n`);
+      process.exit(2);
+    }
+    const { record } = tokenResult;
+    if (record.agentId !== agentId) {
+      process.stderr.write(
+        `ERROR: token ${opts.confirm} is bound to ${record.agentId}, not ${agentId}.\n`,
+      );
+      process.exit(2);
+    }
+    const result = await applyLessonPrune({
+      agentId,
+      proposal: record.proposal,
+      expectedProposalHash: record.proposalHash,
+    });
+    if (result.kind === "drift-rejected") {
+      process.stderr.write(`ERROR: ${result.details}\n`);
+      process.exit(2);
+    }
+    await deleteLessonPruneConfirmToken(opts.confirm);
+    if (opts.json) {
+      process.stdout.write(
+        JSON.stringify({ agentId, token: opts.confirm, result }, null, 2) + "\n",
+      );
+      return;
+    }
+    process.stdout.write(
+      `Pruned ${agentId}/CLAUDE.md\n` +
+        `  ${(result.bytesBefore / 1024).toFixed(1)}KB -> ${(result.bytesAfter / 1024).toFixed(1)}KB ` +
+        `(${result.sectionsDropped} section(s) dropped)\n`,
+    );
+    return;
+  }
+
+  const proposal = await proposeLessonPrune({
+    agentId,
+    minSiblingsAfter: opts.minSiblingsAfter,
+  });
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(proposal, null, 2) + "\n");
+    return;
+  }
+
+  process.stdout.write(formatLessonPruneProposal(proposal) + "\n");
+
+  if (!opts.apply) return;
+
+  if (proposal.pruned.length === 0) {
+    process.stdout.write(
+      "Nothing to prune; no token minted.\n",
+    );
+    return;
+  }
+
+  // Compute hash from the live file (the proposal hash binds plan-time bytes
+  // to the listed stable IDs; any drift between plan and confirm rejects).
+  let currentFile = "";
+  try {
+    currentFile = await fs.readFile(agentClaudeMdPath(agentId), "utf-8");
+  } catch {
+    process.stderr.write(
+      `ERROR: agents/${agentId}/CLAUDE.md is missing; cannot mint a token.\n`,
+    );
+    process.exit(2);
+  }
+  const proposalHash = computePruneProposalHash(proposal, currentFile);
+  const token = mintToken();
+  await writeLessonPruneConfirmToken({
+    token,
+    agentId,
+    proposal,
+    proposalHash,
+  });
+  process.stdout.write(
+    `\nConfirm token: ${token} (15-min TTL, written to state/lesson-prune-confirm-${token}.json)\n` +
+      `Apply with:    vp-dev agents prune-lessons ${agentId} --confirm ${token}\n`,
   );
 }
 

--- a/src/state/lessonPruneConfirm.ts
+++ b/src/state/lessonPruneConfirm.ts
@@ -1,0 +1,102 @@
+// Two-step approval token flow for `vp-dev agents prune-lessons --apply`.
+//
+// Mirrors `compactConfirm.ts` (#162's two-step gate for compact-claude-md)
+// with a per-agent PruneProposal binding. The proposalHash is computed from
+// the stable-IDs list + a sha256 of the file content at plan time; any drift
+// between plan and confirm invalidates the token.
+
+import { promises as fs } from "node:fs";
+import crypto from "node:crypto";
+import path from "node:path";
+import { STATE_DIR, atomicWriteJson } from "./runState.js";
+import type { PruneProposal } from "../agent/lessonPrune.js";
+
+const TOKEN_TTL_MS = 15 * 60 * 1000;
+const TOKEN_FILE_PREFIX = "lesson-prune-confirm-";
+
+export interface LessonPruneConfirmRecord {
+  token: string;
+  agentId: string;
+  /** sha256(JSON.stringify(stableIdsSorted) + sha256(currentFileAtPlanTime)). */
+  proposalHash: string;
+  /** The proposal verbatim — re-used at confirm time without re-reading utility. */
+  proposal: PruneProposal;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export function mintToken(): string {
+  return crypto.randomBytes(8).toString("hex");
+}
+
+function tokenFilePath(token: string): string {
+  if (!/^[a-f0-9]+$/i.test(token)) {
+    throw new Error("Invalid token format: must be hex.");
+  }
+  return path.join(STATE_DIR, `${TOKEN_FILE_PREFIX}${token}.json`);
+}
+
+export async function writeLessonPruneConfirmToken(input: {
+  token: string;
+  agentId: string;
+  proposal: PruneProposal;
+  proposalHash: string;
+}): Promise<LessonPruneConfirmRecord> {
+  const now = new Date();
+  const record: LessonPruneConfirmRecord = {
+    token: input.token,
+    agentId: input.agentId,
+    proposalHash: input.proposalHash,
+    proposal: input.proposal,
+    createdAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + TOKEN_TTL_MS).toISOString(),
+  };
+  await atomicWriteJson(tokenFilePath(input.token), record);
+  return record;
+}
+
+export type ReadResult =
+  | { ok: true; record: LessonPruneConfirmRecord }
+  | { ok: false; reason: "missing" | "expired" | "malformed"; message: string };
+
+export async function readLessonPruneConfirmToken(
+  token: string,
+): Promise<ReadResult> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(tokenFilePath(token), "utf-8");
+  } catch {
+    return {
+      ok: false,
+      reason: "missing",
+      message: `No prune token found for ${token}. Re-run with --apply to generate a fresh one.`,
+    };
+  }
+  let record: LessonPruneConfirmRecord;
+  try {
+    record = JSON.parse(raw) as LessonPruneConfirmRecord;
+  } catch {
+    return {
+      ok: false,
+      reason: "malformed",
+      message: `Prune token ${token} is malformed. Re-run with --apply to generate a fresh one.`,
+    };
+  }
+  if (Date.now() > Date.parse(record.expiresAt)) {
+    await deleteLessonPruneConfirmToken(token).catch(() => {});
+    return {
+      ok: false,
+      reason: "expired",
+      message: `Prune token ${token} expired at ${record.expiresAt}. Re-run with --apply to generate a fresh one.`,
+    };
+  }
+  return { ok: true, record };
+}
+
+export async function deleteLessonPruneConfirmToken(token: string): Promise<void> {
+  try {
+    await fs.unlink(tokenFilePath(token));
+  } catch {
+    // already gone — fine
+  }
+}

--- a/src/state/lessonUtility.test.ts
+++ b/src/state/lessonUtility.test.ts
@@ -2,18 +2,25 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { promises as fs } from "node:fs";
 import {
+  checkLessonNovelty,
   deriveStableSectionId,
   extractCitedStableIds,
   extractPastIncidentDates,
+  findStaleSections,
   lessonUtilityPath,
   loadLessonUtility,
   recordIntroduction,
   recordMergeHistory,
   recordPushback,
   recordReinforcement,
+  resolveDedupJaccardMin,
   resolveJaccardMin,
+  DEFAULT_DEDUP_JACCARD_MIN,
+  DEFAULT_PRUNE_MIN_SIBLINGS_AFTER,
   DEFAULT_REINFORCEMENT_JACCARD_MIN,
   LESSON_UTILITY_SCHEMA_VERSION,
+  type AgentUtilityFile,
+  type SectionUtilityRecord,
 } from "./lessonUtility.js";
 
 // STATE_DIR is captured at module-load via path.resolve(process.cwd(),
@@ -347,4 +354,208 @@ test("extractCitedStableIds: returns empty on a CLAUDE.md with no attributable s
 test("lessonUtilityPath is under STATE_DIR", () => {
   const p = lessonUtilityPath("agent-916a");
   assert.match(p, /state[\\/]lesson-utility-agent-916a\.json$/);
+});
+
+// -----------------------------------------------------------------------
+// #179 Phase 1, option G — checkLessonNovelty
+// -----------------------------------------------------------------------
+
+test("checkLessonNovelty: empty CLAUDE.md → novel", () => {
+  const result = checkLessonNovelty({
+    heading: "Test rule",
+    body: "Test body",
+    claudeMd: "",
+  });
+  assert.equal(result.kind, "novel");
+});
+
+test("checkLessonNovelty: near-duplicate heading → duplicate", () => {
+  const claudeMd = [
+    "# Project rules",
+    "",
+    "<!-- run:run-A issue:#42 outcome:implement ts:2026-05-01T10:00:00Z -->",
+    "## Verify build before opening a PR",
+    "",
+    "Always run typecheck and tests before pushing.",
+    "",
+  ].join("\n");
+  // Same heading concept, different specific phrasing.
+  const result = checkLessonNovelty({
+    heading: "Verify build before opening a PR",
+    body: "Run typecheck and tests before pushing — catches obvious regressions.",
+    claudeMd,
+    jaccardMin: 0.5, // lower threshold to make the test deterministic
+  });
+  assert.equal(result.kind, "duplicate");
+  if (result.kind === "duplicate") {
+    assert.equal(result.matchedStableIds.length, 1);
+  }
+});
+
+test("checkLessonNovelty: semantically distinct candidate → novel", () => {
+  const claudeMd = [
+    "# Project rules",
+    "",
+    "<!-- run:run-A issue:#42 outcome:implement ts:2026-05-01T10:00:00Z -->",
+    "## Verify build before opening a PR",
+    "",
+    "Always run typecheck and tests before pushing.",
+    "",
+  ].join("\n");
+  const result = checkLessonNovelty({
+    heading: "Solana RPC drops transactions above 1.4M compute units",
+    body: "Stay under the CU ceiling for reliable inclusion.",
+    claudeMd,
+  });
+  assert.equal(result.kind, "novel");
+});
+
+test("resolveDedupJaccardMin: defaults + env override + invalid env", () => {
+  assert.equal(resolveDedupJaccardMin({}), DEFAULT_DEDUP_JACCARD_MIN);
+  assert.equal(resolveDedupJaccardMin({ VP_DEV_DEDUP_JACCARD_MIN: "0.7" }), 0.7);
+  assert.equal(
+    resolveDedupJaccardMin({ VP_DEV_DEDUP_JACCARD_MIN: "abc" }),
+    DEFAULT_DEDUP_JACCARD_MIN,
+  );
+  assert.equal(
+    resolveDedupJaccardMin({ VP_DEV_DEDUP_JACCARD_MIN: "1.5" }),
+    DEFAULT_DEDUP_JACCARD_MIN,
+  );
+});
+
+// -----------------------------------------------------------------------
+// #179 Phase 1, option C — findStaleSections
+// -----------------------------------------------------------------------
+
+function makeSection(opts: {
+  sectionId: string;
+  introducedAt: string;
+  reinforcementRuns?: string[];
+  pushbackRuns?: string[];
+}): SectionUtilityRecord {
+  return {
+    sectionId: opts.sectionId,
+    introducedRunId: `run-${opts.sectionId.slice(0, 6)}`,
+    introducedAt: opts.introducedAt,
+    reinforcementRuns: opts.reinforcementRuns ?? [],
+    pushbackRuns: opts.pushbackRuns ?? [],
+    pastIncidentDates: [],
+    crossReferenceCount: 0,
+  };
+}
+
+function makeUtilityFile(sections: SectionUtilityRecord[]): AgentUtilityFile {
+  return {
+    agentId: "test-agent",
+    schemaVersion: LESSON_UTILITY_SCHEMA_VERSION,
+    sections,
+    mergeHistory: [],
+  };
+}
+
+test("findStaleSections: empty file → empty", async () => {
+  const result = await findStaleSections({
+    agentId: "test-agent",
+    fileOverride: null,
+  });
+  assert.deepEqual(result, []);
+});
+
+test("findStaleSections: zero-reinforcement old section is stale", async () => {
+  // Section S0 is the oldest; all 11 others are newer. S0 has zero
+  // reinforcements → stale. The 11 newer ones haven't accumulated 10
+  // siblings-after yet, so they're not eligible.
+  const sections: SectionUtilityRecord[] = [
+    makeSection({ sectionId: "S0", introducedAt: "2026-04-01T00:00:00Z" }),
+  ];
+  for (let i = 1; i <= 11; i++) {
+    sections.push(
+      makeSection({
+        sectionId: `S${i}`,
+        introducedAt: `2026-04-${String(i + 1).padStart(2, "0")}T00:00:00Z`,
+        reinforcementRuns: [`run-${i}`], // each has 1 reinforcement → not stale even if eligible
+      }),
+    );
+  }
+  const result = await findStaleSections({
+    agentId: "test-agent",
+    fileOverride: makeUtilityFile(sections),
+  });
+  assert.equal(result.length, 1);
+  assert.equal(result[0].record.sectionId, "S0");
+  assert.equal(result[0].reason, "zero-reinforcement");
+  assert.equal(result[0].siblingsIntroducedAfter, 11);
+});
+
+test("findStaleSections: cool-off prevents pruning brand-new zero-reinforcement section", async () => {
+  // 5 sections, all zero-reinforcement. The youngest has 0 siblings-after
+  // → not eligible regardless. The oldest has 4 siblings-after, less than
+  // the default 10 → also not eligible.
+  const sections: SectionUtilityRecord[] = [];
+  for (let i = 0; i < 5; i++) {
+    sections.push(
+      makeSection({
+        sectionId: `S${i}`,
+        introducedAt: `2026-04-${String(i + 1).padStart(2, "0")}T00:00:00Z`,
+      }),
+    );
+  }
+  const result = await findStaleSections({
+    agentId: "test-agent",
+    fileOverride: makeUtilityFile(sections),
+  });
+  assert.deepEqual(result, []);
+});
+
+test("findStaleSections: pushback-dominant section is stale (bonus J)", async () => {
+  const sections: SectionUtilityRecord[] = [
+    makeSection({
+      sectionId: "S0",
+      introducedAt: "2026-04-01T00:00:00Z",
+      reinforcementRuns: ["run-r1"],
+      pushbackRuns: ["run-p1", "run-p2", "run-p3"], // 3 pushbacks > 1 reinforcement
+    }),
+  ];
+  for (let i = 1; i <= 11; i++) {
+    sections.push(
+      makeSection({
+        sectionId: `S${i}`,
+        introducedAt: `2026-04-${String(i + 1).padStart(2, "0")}T00:00:00Z`,
+        reinforcementRuns: [`run-${i}`],
+      }),
+    );
+  }
+  const result = await findStaleSections({
+    agentId: "test-agent",
+    fileOverride: makeUtilityFile(sections),
+  });
+  assert.equal(result.length, 1);
+  assert.equal(result[0].record.sectionId, "S0");
+  assert.equal(result[0].reason, "pushback-dominant");
+});
+
+test("findStaleSections: minSiblingsAfter override loosens cool-off", async () => {
+  const sections: SectionUtilityRecord[] = [];
+  for (let i = 0; i < 5; i++) {
+    sections.push(
+      makeSection({
+        sectionId: `S${i}`,
+        introducedAt: `2026-04-${String(i + 1).padStart(2, "0")}T00:00:00Z`,
+      }),
+    );
+  }
+  const result = await findStaleSections({
+    agentId: "test-agent",
+    fileOverride: makeUtilityFile(sections),
+    minSiblingsAfter: 2,
+  });
+  // S0 (4 after), S1 (3 after), S2 (2 after) all eligible at threshold 2;
+  // all zero-reinforcement → all flagged.
+  assert.equal(result.length, 3);
+  const ids = result.map((r) => r.record.sectionId).sort();
+  assert.deepEqual(ids, ["S0", "S1", "S2"]);
+});
+
+test("DEFAULT_PRUNE_MIN_SIBLINGS_AFTER is the documented default", () => {
+  assert.equal(DEFAULT_PRUNE_MIN_SIBLINGS_AFTER, 10);
 });

--- a/src/state/lessonUtility.ts
+++ b/src/state/lessonUtility.ts
@@ -23,6 +23,15 @@ export const LESSON_UTILITY_SCHEMA_VERSION = 1;
 /** Default Jaccard threshold for the heading/tag-overlap fallback matcher. */
 export const DEFAULT_REINFORCEMENT_JACCARD_MIN = 0.6;
 
+/**
+ * Default Jaccard threshold for the dedup gate (#179 Phase 1, option G).
+ * Stricter than `DEFAULT_REINFORCEMENT_JACCARD_MIN` because dedup says "this
+ * candidate IS one of the existing sections — don't append," while
+ * reinforcement says "this candidate cites Y — credit Y." Same metric,
+ * different decision threshold. Override via `VP_DEV_DEDUP_JACCARD_MIN`.
+ */
+export const DEFAULT_DEDUP_JACCARD_MIN = 0.85;
+
 export interface SectionUtilityRecord {
   /** Stable ID — sha256(runId + ":" + sorted compound-id token). Survives
    * positional renumbering and body edits. Compact merges synthesize a
@@ -411,6 +420,18 @@ export function resolveJaccardMin(
   return n;
 }
 
+export function resolveDedupJaccardMin(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = env.VP_DEV_DEDUP_JACCARD_MIN;
+  if (raw == null || raw === "") return DEFAULT_DEDUP_JACCARD_MIN;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0 || n > 1) {
+    return DEFAULT_DEDUP_JACCARD_MIN;
+  }
+  return n;
+}
+
 /**
  * Extract stable IDs of sections cited by the given text. Returns a deduped
  * list. Pure / synchronous so tests can exercise it without I/O.
@@ -454,4 +475,153 @@ export function extractCitedStableIds(input: ExtractCitedInput): string[] {
   }
 
   return [...out];
+}
+
+// ---------------------------------------------------------------------------
+// Dedup gate (#179 Phase 1, option G).
+//
+// Reuses `extractCitedStableIds` at a stricter threshold (default 0.85 vs
+// reinforcement's 0.6). Reinforcement says "candidate cites Y — credit Y";
+// dedup says "candidate IS Y — don't append, just credit Y." Same metric,
+// different decision.
+// ---------------------------------------------------------------------------
+
+export interface CheckLessonNoveltyInput {
+  /** Heading of the candidate lesson — the primary signal for dedup. */
+  heading: string;
+  /**
+   * Body of the candidate lesson. Currently unused by `checkLessonNovelty`
+   * (heading-only comparison) but accepted for interface symmetry with the
+   * rest of the lesson-add pipeline. Reserved for a future hybrid metric.
+   */
+  body?: string;
+  /** Tags this issue contributed. Reserved (see `body`). */
+  tags?: string[];
+  /** Current contents of the agent's CLAUDE.md. */
+  claudeMd: string;
+  /** Override threshold; defaults to env or DEFAULT_DEDUP_JACCARD_MIN. */
+  jaccardMin?: number;
+  /** Exclude these stable IDs from matching (e.g., the candidate's own future ID). */
+  exclude?: Set<string>;
+}
+
+export type LessonNoveltyResult =
+  | { kind: "novel" }
+  | { kind: "duplicate"; matchedStableIds: string[] };
+
+/**
+ * Check whether a candidate lesson is a near-duplicate of an existing
+ * section in the agent's CLAUDE.md. Pure / synchronous so tests can exercise
+ * it without I/O.
+ *
+ * Returns `{kind: "novel"}` if no existing section crosses the dedup
+ * threshold, or `{kind: "duplicate", matchedStableIds}` listing every
+ * section that did. The caller's responsibility is to decide what to do
+ * on duplicate (typical: skip the append + record reinforcement on the
+ * matched section instead).
+ *
+ * Comparison shape: heading-tokens-vs-heading-tokens. This deliberately
+ * differs from `extractCitedStableIds` (which compares
+ * heading+tags+body-tokens vs heading-only) — that function answers "does
+ * this lesson CITE Y?", whereas dedup asks "does this lesson IS Y?". A
+ * wide-vs-narrow Jaccard is right for citation but pessimistic for dedup;
+ * a narrow-vs-narrow Jaccard captures heading overlap directly.
+ */
+export function checkLessonNovelty(
+  input: CheckLessonNoveltyInput,
+): LessonNoveltyResult {
+  const min = input.jaccardMin ?? resolveDedupJaccardMin();
+  const exclude = input.exclude ?? new Set<string>();
+  const sections = withStableIds(parseClaudeMdSections(input.claudeMd));
+  if (sections.length === 0) return { kind: "novel" };
+
+  const candidateTokens = tokenize(input.heading);
+  const matched: string[] = [];
+  for (const section of sections) {
+    if (exclude.has(section.stableId)) continue;
+    const sectionTokens = tokenize(section.heading);
+    if (jaccard(candidateTokens, sectionTokens) >= min) {
+      matched.push(section.stableId);
+    }
+  }
+  if (matched.length === 0) return { kind: "novel" };
+  return { kind: "duplicate", matchedStableIds: matched };
+}
+
+// ---------------------------------------------------------------------------
+// Empirical post-hoc prune (#179 Phase 1, option C).
+//
+// Identifies sections that are eligible for pruning based on the utility
+// signals already collected by Phase 1 of #178:
+//   - "stale": the section has zero reinforcementRuns AND at least
+//     `minSiblingsAfter` other sections have been introduced after it.
+//   - "misleading" (bonus J): pushbackRuns.length > reinforcementRuns.length
+//     AND the same minSiblingsAfter cool-off applies.
+// Cool-off prevents pruning brand-new sections before they have a chance to
+// be cited. Default `minSiblingsAfter=10` is conservative; operators can
+// pass a smaller value (e.g., 5) when they trust the utility signal.
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_PRUNE_MIN_SIBLINGS_AFTER = 10;
+
+export type StaleReason = "zero-reinforcement" | "pushback-dominant";
+
+export interface StaleSection {
+  record: SectionUtilityRecord;
+  /** Why this section is eligible for pruning. */
+  reason: StaleReason;
+  /** Number of sections introduced after this one. */
+  siblingsIntroducedAfter: number;
+}
+
+export interface FindStaleSectionsInput {
+  agentId: string;
+  /** Override default cool-off; sections need this many later siblings. */
+  minSiblingsAfter?: number;
+  /** Pre-loaded utility file (for tests); when omitted, we load from disk. */
+  fileOverride?: AgentUtilityFile | null;
+}
+
+/**
+ * Return the subset of an agent's sections that are stale per the rules
+ * above. Pure logic (`fileOverride` skips disk I/O for tests).
+ */
+export async function findStaleSections(
+  input: FindStaleSectionsInput,
+): Promise<StaleSection[]> {
+  const file =
+    input.fileOverride !== undefined
+      ? input.fileOverride
+      : await loadLessonUtility(input.agentId);
+  if (!file || file.sections.length === 0) return [];
+  const minSiblings =
+    input.minSiblingsAfter ?? DEFAULT_PRUNE_MIN_SIBLINGS_AFTER;
+
+  // Compute siblings-after via introducedAt timestamp comparison. Stable
+  // under hand-edits (timestamps don't shift) and concurrent-safe under the
+  // same atomic-write contract that protects the file.
+  const sortedByIntro = [...file.sections].sort((a, b) =>
+    a.introducedAt.localeCompare(b.introducedAt),
+  );
+  const siblingsAfter = new Map<string, number>();
+  for (let i = 0; i < sortedByIntro.length; i++) {
+    siblingsAfter.set(
+      sortedByIntro[i].sectionId,
+      sortedByIntro.length - 1 - i,
+    );
+  }
+
+  const out: StaleSection[] = [];
+  for (const r of file.sections) {
+    const siblings = siblingsAfter.get(r.sectionId) ?? 0;
+    if (siblings < minSiblings) continue;
+    if (r.reinforcementRuns.length === 0) {
+      out.push({ record: r, reason: "zero-reinforcement", siblingsIntroducedAfter: siblings });
+      continue;
+    }
+    if (r.pushbackRuns.length > r.reinforcementRuns.length) {
+      out.push({ record: r, reason: "pushback-dominant", siblingsIntroducedAfter: siblings });
+    }
+  }
+  return out;
 }

--- a/src/util/sentinels.ts
+++ b/src/util/sentinels.ts
@@ -251,6 +251,52 @@ export function expireSentinelsInContent(
 }
 
 /**
+ * Drop sentinel blocks whose stable IDs match `stableIdsToDrop`. Stable IDs
+ * are computed via the supplied `deriveId` callback so this module doesn't
+ * need to import the lessonUtility hashing logic. Used by the prune-lessons
+ * CLI (#179 Phase 1, option C) to remove specifically-listed sections.
+ *
+ * Idempotent — re-applying with the same drop set on already-pruned content
+ * is a no-op.
+ */
+export function dropSentinelsByStableId(
+  content: string,
+  stableIdsToDrop: ReadonlySet<string>,
+  deriveId: (header: SentinelHeader) => string,
+): ExpireResult {
+  if (stableIdsToDrop.size === 0) return { content, droppedHeaders: [] };
+  const lines = content.split("\n");
+  const located = locateSentinels(lines);
+  if (located.length === 0) return { content, droppedHeaders: [] };
+
+  const dropIndices: number[] = [];
+  const dropped: SentinelHeader[] = [];
+  for (let i = 0; i < located.length; i++) {
+    const id = deriveId(located[i].header);
+    if (stableIdsToDrop.has(id)) {
+      dropIndices.push(i);
+      dropped.push(located[i].header);
+    }
+  }
+  if (dropIndices.length === 0) return { content, droppedHeaders: [] };
+
+  const dropSet = new Set(dropIndices);
+  const out: string[] = [];
+  for (let i = 0; i < located[0].startLine; i++) out.push(lines[i]);
+  for (let idx = 0; idx < located.length; idx++) {
+    const loc = located[idx];
+    if (dropSet.has(idx)) {
+      // Trim a single trailing blank line so the dropped block's leading
+      // blank doesn't survive the drop. Mirrors expireSentinelsInContent.
+      if (out.length > 0 && out[out.length - 1] === "") out.pop();
+      continue;
+    }
+    for (let i = loc.startLine; i < loc.endLine; i++) out.push(lines[i]);
+  }
+  return { content: out.join("\n"), droppedHeaders: dropped };
+}
+
+/**
  * Backward-compatible wrapper: drop expired `failure-lesson` blocks using
  * the legacy single-K rule. Delegates to `expireSentinelsInContent` with
  * the failure-lesson policy only.


### PR DESCRIPTION
## Summary

Three independent, curve-form-independent components that move per-agent CLAUDE.md from "always append" toward measured discipline. All three reuse existing infrastructure (#178 utility scoring, #162 two-step token pattern, #179 cost curve) so the diff stays narrow.

**Why now:** [#179 leg-1](https://github.com/szhygulin/vaultpilot-development-agents/pull/189) measured the COST of every byte added to CLAUDE.md (linear-log accuracy degradation, p=0.097 with two outliers in, p=2.76e-4 with them out). We don't yet have a quantitative benefit per lesson. This PR ships components that don't require a statistically-significant curve to be defensible — they use either deterministic similarity (G) or ground-truth citation counts already collected by #178 (C), or just inform the LLM (F).

## What changes

### F — Marginal-cost transparency in summarizer prompt

`summarizer.ts` `buildPrompt()` now injects a cost line:

> CLAUDE.md is currently X KB (predicted accuracy degradation factor N).
> Adding a worst-case lesson grows it to ~Y KB (factor ~M).
> Skip if the lesson isn't carrying weight — every byte degrades future runs.

`runIssueCore.ts` reads `Buffer.byteLength` of the agent's CLAUDE.md before each summarizer call; both `summarizeRun` and `summarizeFailureRun` receive a new optional `currentClaudeMdBytes`. **No gating** — the LLM's existing "no GENERALIZABLE rule → skip" hard-rule absorbs cost-awareness. Defensible at p=0.097 because it's information, not a numerical threshold.

### G — Jaccard dedup gate before appendBlock

New `checkLessonNovelty(input)` in `lessonUtility.ts`. **Heading-only Jaccard** against existing sections (default threshold 0.85, env-overridable via `VP_DEV_DEDUP_JACCARD_MIN`). On match, `runIssueCore.ts` skips the append AND credits the matched section via `recordReinforcement` — candidate didn't add bytes but DID re-validate the existing rule.

The heading-only shape is deliberate: `extractCitedStableIds` does heading+body+tags-vs-heading-only (right for "this lesson cites Y"), but dedup asks "this lesson IS Y" — narrow-vs-narrow Jaccard captures heading overlap directly.

### C — Empirical post-hoc prune (+J pushback-decay)

`findStaleSections({agentId, minSiblingsAfter})` flags two kinds of sections:

- `zero-reinforcement`: no `reinforcementRuns` AND ≥ minSiblingsAfter other sections introduced after this one (cool-off prevents pruning brand-new sections).
- `pushback-dominant`: `pushbackRuns > reinforcementRuns` AND same cool-off — sections actively misleading the agent (bonus J from the planning analysis).

Default cool-off: 10 later siblings.

New CLI: `vp-dev agents prune-lessons <agentId> [--apply | --confirm <token>]`. Mirrors `compact-claude-md`'s two-step gate (#162):
- advisory: prints the proposal, exits.
- `--apply`: mints a 15-min TTL token bound to (proposal + file hash).
- `--confirm <token>`: re-validates the hash, then drops the matched sentinel blocks under the per-file lock.

### Supporting changes

- `dropSentinelsByStableId(content, stableIds, deriveId)` in `sentinels.ts` — generic locate-and-drop mirroring `expireSentinelsInContent`'s line-rebuild discipline (collapses the leading blank of each dropped block).
- `state/lessonPruneConfirm.ts` — token persistence (parallel to `compactConfirm.ts`).
- `DEFAULT_DEDUP_JACCARD_MIN = 0.85` constant + `resolveDedupJaccardMin()` env helper.
- `DEFAULT_PRUNE_MIN_SIBLINGS_AFTER = 10` constant.

## Phase 2 deferred

The plan menu had 10 options (A-J). This PR ships F + G + C (the curve-form-independent subset). The four cost-curve-derived options wait for #179 leg-2 K=13 to bring p < 0.05:
- **A** (cost-only forecast threshold, hard refuse if Δ > X)
- **E** (fixed byte budget at curve elbow + forced swap)
- **B** (LLM-emitted predictedUtility score)
- **D** (B + C hybrid)

H (embedding-distance dedup) and I (contradiction-check second LLM pass) are escalations only if F+G+C prove insufficient.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm test` — **547/547 pass** (518 baseline + 29 new)
- F coverage: 8 tests for `buildCostTransparencyLine` + integration into both summarizer prompts.
- G coverage: 4 tests covering empty CLAUDE.md, near-duplicate match, semantic-distinct novelty, env threshold override.
- C coverage: 5 tests for `findStaleSections` (empty / zero-reinforcement / cool-off / pushback-dominant / threshold override) + 11 tests for `dropSentinelsByStableId` and `applyLessonPrune` covering the two-step token flow (apply success, drift rejection, empty proposal, no-match, hash stability).

Plan file: `~/.claude/plans/now-plan-the-feature-graceful-wirth.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)