### PR TITLE
fix(prune-lessons): minSiblingsAfter default falls back to 10, never Infinity

### DIFF
--- a/src/agent/lessonPrune.test.ts
+++ b/src/agent/lessonPrune.test.ts
@@ -8,10 +8,11 @@ import {
   computePruneProposalHash,
   formatLessonPruneProposal,
   hashFile,
+  proposeLessonPrune,
   type PruneProposal,
 } from "./lessonPrune.js";
 import { dropSentinelsByStableId } from "../util/sentinels.js";
-import { deriveStableSectionId } from "../state/lessonUtility.js";
+import { DEFAULT_PRUNE_MIN_SIBLINGS_AFTER, deriveStableSectionId } from "../state/lessonUtility.js";
 import { formatSentinelHeader } from "../util/sentinels.js";
 
 function makeAgentClaudeMd(
@@ -228,4 +229,46 @@ test("formatLessonPruneProposal: renders empty case + populated case readably", 
   assert.match(populated, /1 section\(s\) eligible for removal/);
   assert.match(populated, /\[zero-reinforcement\]/);
   assert.match(populated, /Pass --apply/);
+});
+
+// Regression for the smoke-test bug: when a caller passed minSiblingsAfter
+// to proposeLessonPrune AND the resulting stale list was empty, the
+// fallback expression took the Math.min(...empty) branch and surfaced
+// `Infinity` as the threshold in the rendered output. The proposal's
+// minSiblingsAfter must always reflect the configured policy, not be
+// derived from the (possibly empty) stale list.
+test("proposeLessonPrune: minSiblingsAfter mirrors the configured threshold even when nothing is stale", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "prune-empty-test-"));
+  const filePath = path.join(dir, "CLAUDE.md");
+  await fs.writeFile(filePath, "# empty\n");
+  try {
+    const proposal = await proposeLessonPrune({
+      agentId: "agent-nonexistent-test",
+      minSiblingsAfter: 7,
+      claudeMdPathOverride: filePath,
+    });
+    assert.equal(proposal.pruned.length, 0);
+    assert.equal(proposal.minSiblingsAfter, 7);
+    assert.notEqual(proposal.minSiblingsAfter, Infinity);
+    const rendered = formatLessonPruneProposal(proposal);
+    assert.doesNotMatch(rendered, /Infinity/);
+    assert.match(rendered, /at least 7/);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("proposeLessonPrune: minSiblingsAfter falls back to DEFAULT when not provided", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "prune-default-test-"));
+  const filePath = path.join(dir, "CLAUDE.md");
+  await fs.writeFile(filePath, "# empty\n");
+  try {
+    const proposal = await proposeLessonPrune({
+      agentId: "agent-nonexistent-default",
+      claudeMdPathOverride: filePath,
+    });
+    assert.equal(proposal.minSiblingsAfter, DEFAULT_PRUNE_MIN_SIBLINGS_AFTER);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
 });

--- a/src/agent/lessonPrune.ts
+++ b/src/agent/lessonPrune.ts
@@ -23,6 +23,7 @@ import crypto from "node:crypto";
 import { withFileLock } from "../state/locks.js";
 import { agentClaudeMdPath } from "./specialization.js";
 import {
+  DEFAULT_PRUNE_MIN_SIBLINGS_AFTER,
   deriveStableSectionId,
   findStaleSections,
   type StaleSection,
@@ -81,12 +82,10 @@ export async function proposeLessonPrune(
     generatedAt: new Date().toISOString(),
     pruned: stale.map(toPrunedSection),
     bytesBefore: currentBytes,
-    minSiblingsAfter:
-      input.minSiblingsAfter ??
-      // Re-resolve via lessonUtility's default to keep the proposal self-describing.
-      stale[0]?.siblingsIntroducedAfter !== undefined
-        ? Math.min(...stale.map((s) => s.siblingsIntroducedAfter))
-        : 10,
+    // Surface the threshold that produced this proposal so the rendered
+    // output (and any consumer of the JSON) can self-describe the policy.
+    // Falls back to the documented default when the caller didn't override.
+    minSiblingsAfter: input.minSiblingsAfter ?? DEFAULT_PRUNE_MIN_SIBLINGS_AFTER,
   };
 }
 


### PR DESCRIPTION
## Summary

Smoke-testing the `vp-dev agents prune-lessons` CLI added in [#190](https://github.com/szhygulin/vaultpilot-development-agents/pull/190) surfaced a precedence bug: when a caller passed `minSiblingsAfter` AND the resulting stale list was empty (the common case for a fresh agent), the proposal's reported `minSiblingsAfter` was `Infinity` instead of the configured threshold. The CLI rendered:

> Cool-off: at least **Infinity** sibling sections introduced after the candidate.

The bug was in `proposeLessonPrune`'s fallback expression — the operator precedence of `??` vs `?:` made the truthy branch run `Math.min(...[])` (which is `Infinity`) when the stale list was empty. Fix: drop the derived-from-stale fallback and just use `input.minSiblingsAfter ?? DEFAULT_PRUNE_MIN_SIBLINGS_AFTER`. The proposal should reflect the configured policy, not be back-derived from the (possibly empty) stale list.

## Verification

- Two regression tests: empty-stale at override threshold + empty-stale at default threshold, both assert `proposal.minSiblingsAfter` is finite and matches the input.
- Live smoke against a synthetic 15-section fixture with one zero-reinforcement and one pushback-dominant section confirms:
  - Default cool-off: "at least 10" (no `Infinity`).
  - `--min-siblings-after 5`: 2 sections flagged (S5 zero-reinforcement, S7 pushback-dominant).
  - Two-step token mint + confirm: drops both sections, file shrinks 2.7KB → 2.3KB, surviving headings exclude the pruned ones.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm test` — **549/549 pass** (547 baseline + 2 new regression tests)
- [x] End-to-end CLI smoke against a synthetic agent: advisory → `--apply` → `--confirm` succeeds; bytes shrink; correct sections dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)