### PR TITLE
feat(lessons): predictedUtility self-rating + soft gate (#179 Phase 2 option B early)

### DIFF
--- a/src/agent/runIssueCore.ts
+++ b/src/agent/runIssueCore.ts
@@ -10,6 +10,7 @@ import {
 } from "./specialization.js";
 import { isInfraFlake, summarizeFailureRun, summarizeRun, type SummarizerOutput } from "./summarizer.js";
 import { resolveExpiryPolicies } from "../util/sentinels.js";
+import { normalizedAccuracyFactor } from "../util/contextCostCurve.js";
 import {
   checkLessonNovelty,
   deriveStableSectionId,
@@ -252,6 +253,7 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
             body: summary.body ?? "",
             tags: envelope.memoryUpdate.addTags,
             logger: input.logger,
+            predictedUtility: summary.predictedUtility,
           });
         }
 
@@ -352,6 +354,7 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
               body: summary.body ?? "",
               tags: input.agent.tags,
               logger: input.logger,
+              predictedUtility: summary.predictedUtility,
             });
           }
         }
@@ -557,6 +560,30 @@ async function maybeAppendSummary(args: AppendArgs): Promise<{
     // Fall through to the normal append path — dedup is advisory.
   }
 
+  // Predicted-utility soft gate (#179 Phase 2 option B, half-ready-curve probe):
+  // if the LLM emitted a `predictedUtility` value, compare it to the cost
+  // score derived from `normalizedAccuracyFactor` at the post-append byte
+  // size. Skip if utility < cost × ratio. Always log the decision so the
+  // operator can analyze the (utility, cost, decision) distribution post-hoc.
+  // Missing predictedUtility = no signal to act on; let through (back-compat
+  // with summarizer responses pre-this-change).
+  const currentBytesForGate = await fs
+    .readFile(agentClaudeMdPath(args.agent.agentId), "utf-8")
+    .then((s) => Buffer.byteLength(s, "utf-8"))
+    .catch(() => 0);
+  const utilityGate = evaluatePredictedUtilityGate({
+    predictedUtility: args.summary.predictedUtility,
+    agentId: args.agent.agentId,
+    issueId: args.issue.id,
+    headingLength: args.summary.heading.length,
+    bodyLength: args.summary.body.length,
+    currentClaudeMdBytes: currentBytesForGate,
+    logger: args.logger,
+  });
+  if (utilityGate.kind === "skip") {
+    return { summarySkipReason: utilityGate.reason };
+  }
+
   const appendOutcome = await appendBlock({
     agentId: args.agent.agentId,
     runId: args.runId,
@@ -586,6 +613,96 @@ async function maybeAppendSummary(args: AppendArgs): Promise<{
   return { appendOutcome };
 }
 
+// Predicted-utility soft gate (#179 Phase 2 option B, half-ready-curve probe).
+// Computes a cost score from `normalizedAccuracyFactor` at the post-append
+// byte size and compares it to the LLM's self-rated `predictedUtility`.
+// Skip = utility < cost × ratio. Missing utility = let through (no signal).
+// Tunable via `VP_DEV_UTILITY_COST_RATIO` env var; default 1.0 means "utility
+// just needs to match the cost score."
+
+export const DEFAULT_UTILITY_COST_RATIO = 1.0;
+
+export function resolveUtilityCostRatio(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = env.VP_DEV_UTILITY_COST_RATIO;
+  if (raw == null || raw === "") return DEFAULT_UTILITY_COST_RATIO;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return DEFAULT_UTILITY_COST_RATIO;
+  return n;
+}
+
+export interface UtilityGateInput {
+  predictedUtility?: number;
+  agentId: string;
+  issueId: number;
+  headingLength: number;
+  bodyLength: number;
+  /**
+   * Current byte size of the agent's CLAUDE.md. Caller reads it once and
+   * passes it in (mirrors the F-path's `currentClaudeMdBytes` plumbing).
+   * Undefined or 0 = treat as fresh / empty file → costScore=0 → any
+   * predictedUtility passes (no cost yet, gate is fully open).
+   */
+  currentClaudeMdBytes?: number;
+  logger: Logger;
+  /** Override env-resolved ratio for tests. */
+  ratio?: number;
+}
+
+export type UtilityGateResult =
+  | { kind: "let-through"; reason: "no-utility" | "utility-passes-gate" }
+  | { kind: "skip"; reason: "low-predicted-utility" };
+
+/**
+ * Decide whether the candidate's `predictedUtility` justifies the byte cost
+ * the lesson would add. Always logs the decision (with the computed cost
+ * score and the threshold) so post-hoc analysis can read the distribution.
+ *
+ * The estimated added bytes uses the heading + body lengths plus a small
+ * sentinel header allowance; it's a tighter forecast than the worst-case
+ * upper bound used by `buildCostTransparencyLine`.
+ *
+ * Pure function (no I/O) so tests can exercise the gate logic directly.
+ */
+export function evaluatePredictedUtilityGate(
+  input: UtilityGateInput,
+): UtilityGateResult {
+  if (input.predictedUtility === undefined) {
+    input.logger.info("specialization.utility_gate", {
+      agentId: input.agentId,
+      issueId: input.issueId,
+      decision: "let-through",
+      reason: "no-utility",
+    });
+    return { kind: "let-through", reason: "no-utility" };
+  }
+  const currentBytes = input.currentClaudeMdBytes ?? 0;
+  const sentinelOverhead = 200;
+  const projectedBytes =
+    currentBytes + input.headingLength + input.bodyLength + sentinelOverhead;
+  // normalizedAccuracyFactor returns values in [1, 2] across the calibration
+  // range, so subtracting 1 yields a 0-1 cost score directly.
+  const factor = normalizedAccuracyFactor(projectedBytes);
+  const costScore = Number.isFinite(factor)
+    ? Math.max(0, Math.min(1, factor - 1))
+    : 0;
+  const ratio = input.ratio ?? resolveUtilityCostRatio();
+  const threshold = costScore * ratio;
+  const decision = input.predictedUtility >= threshold ? "let-through" : "skip";
+  input.logger.info("specialization.utility_gate", {
+    agentId: input.agentId,
+    issueId: input.issueId,
+    decision,
+    predictedUtility: input.predictedUtility,
+    costScore,
+    threshold,
+    ratio,
+  });
+  if (decision === "skip") return { kind: "skip", reason: "low-predicted-utility" };
+  return { kind: "let-through", reason: "utility-passes-gate" };
+}
+
 // Issue #178 (Phase 1 of #177): per-section utility-scoring data collection.
 // These helpers wrap the lessonUtility module in fail-soft try/catch so a
 // utility-scoring write failure can never block the orchestrator's main path.
@@ -598,6 +715,13 @@ interface RecordUtilityForAppendArgs {
   body: string;
   tags?: string[];
   logger: Logger;
+  /**
+   * LLM self-rating from `SummarizerOutput.predictedUtility` (#179 Phase 2,
+   * option B). Persisted via `recordIntroduction` so post-hoc analysis can
+   * read it back. Optional for back-compat with summarizer responses
+   * pre-this-change.
+   */
+  predictedUtility?: number;
 }
 
 async function recordUtilityForAppend(
@@ -611,6 +735,7 @@ async function recordUtilityForAppend(
       issueId: args.issueId,
       body: args.body,
       ts,
+      predictedUtility: args.predictedUtility,
     });
     // Read the post-append CLAUDE.md and find which prior sections this
     // new block reinforces. Exclude the just-introduced block itself.

--- a/src/agent/summarizer.test.ts
+++ b/src/agent/summarizer.test.ts
@@ -4,6 +4,7 @@ import {
   buildCostTransparencyLine,
   buildFailurePrompt,
   buildPrompt,
+  SummarizerOutputSchema,
   type FailureSummarizerInput,
   type SummarizerInput,
 } from "./summarizer.js";
@@ -143,4 +144,76 @@ test("buildFailurePrompt: omits cost line when currentClaudeMdBytes is undefined
   };
   const prompt = buildFailurePrompt(input);
   assert.doesNotMatch(prompt, /Marginal cost of adding a lesson/);
+});
+
+// -----------------------------------------------------------------------
+// #179 Phase 2 option B — predictedUtility schema + prompt
+// -----------------------------------------------------------------------
+
+test("SummarizerOutputSchema: accepts predictedUtility in [0, 1]", () => {
+  const ok = SummarizerOutputSchema.safeParse({
+    skip: false,
+    heading: "Some rule",
+    body: "Some body",
+    predictedUtility: 0.7,
+  });
+  assert.equal(ok.success, true);
+});
+
+test("SummarizerOutputSchema: rejects predictedUtility > 1", () => {
+  const out = SummarizerOutputSchema.safeParse({
+    skip: false,
+    heading: "Some rule",
+    body: "Some body",
+    predictedUtility: 1.5,
+  });
+  assert.equal(out.success, false);
+});
+
+test("SummarizerOutputSchema: rejects predictedUtility < 0", () => {
+  const out = SummarizerOutputSchema.safeParse({
+    skip: false,
+    heading: "Some rule",
+    body: "Some body",
+    predictedUtility: -0.1,
+  });
+  assert.equal(out.success, false);
+});
+
+test("SummarizerOutputSchema: predictedUtility is optional (back-compat)", () => {
+  const ok = SummarizerOutputSchema.safeParse({
+    skip: false,
+    heading: "Some rule",
+    body: "Some body",
+  });
+  assert.equal(ok.success, true);
+});
+
+test("buildPrompt: instructs the LLM to emit predictedUtility", () => {
+  // The system prompt is what carries the calibration anchor; the user
+  // prompt's tail also names the field. Check the user-prompt side here.
+  const input: SummarizerInput = {
+    agent: stubAgent,
+    issue: stubIssue,
+    envelope: stubEnvelope,
+    toolUseTrace: [],
+    finalText: "did the work",
+    logger: stubLogger,
+  };
+  const prompt = buildPrompt(input);
+  assert.match(prompt, /predictedUtility/);
+});
+
+test("buildFailurePrompt: instructs the LLM to emit predictedUtility", () => {
+  const input: FailureSummarizerInput = {
+    agent: stubAgent,
+    issue: stubIssue,
+    envelope: { ...stubEnvelope, decision: "error" },
+    errorReason: "max turns",
+    toolUseTrace: [],
+    finalText: "ran out of turns",
+    logger: stubLogger,
+  };
+  const prompt = buildFailurePrompt(input);
+  assert.match(prompt, /predictedUtility/);
 });

--- a/src/agent/summarizer.ts
+++ b/src/agent/summarizer.ts
@@ -25,6 +25,17 @@ export const SummarizerOutputSchema = z.object({
   skipReason: z.string().optional(),
   heading: z.string().min(3).max(HEADING_MAX).optional(),
   body: z.string().min(3).max(BODY_MAX).optional(),
+  // #179 Phase 2 (option B from the cost/benefit menu, shipped early as a
+  // half-ready-curve data probe): the LLM's self-rating of how much
+  // future-leverage the lesson carries. 0 = restates an existing rule or
+  // captures a generic platitude; 1 = names a specific past failure with
+  // date/PR/file path that the agent would otherwise repeat. Optional for
+  // back-compat with summarizer responses pre-this-change; missing field
+  // means the gate in `runIssueCore.maybeAppendSummary` lets the lesson
+  // through (no signal to act on). Persisted into
+  // `SectionUtilityRecord.predictedUtility` so post-hoc analysis can
+  // correlate self-ratings with actual reinforcement.
+  predictedUtility: z.number().min(0).max(1).optional(),
 });
 export type SummarizerOutput = z.infer<typeof SummarizerOutputSchema>;
 
@@ -253,8 +264,17 @@ Hard rules:
 - Do NOT mention the specific issue number, PR number, or run id — that's in the provenance comment. Talk about the class of situation, not this instance.
 - Inside heading / body / skipReason string values: escape every double-quote as \\" and every literal newline as \\n. Do NOT escape apostrophes — \\' is INVALID JSON (the parser only knows \\", \\\\, \\/, \\b, \\f, \\n, \\r, \\t, \\uXXXX). Write apostrophes as a plain ': don't, isn't, can't. Prefer single-quote ' or backticks for emphasis when the alternative is acceptable.
 
-Output: a single JSON object, no fences, no prose. The \`skip\` field is MANDATORY in every response. Use \`{"skip": false, "heading": "...", "body": "..."}\` when there is a lesson worth saving, and \`{"skip": true, "skipReason": "..."}\` otherwise. Schema:
-  {"skip": boolean, "skipReason"?: string, "heading"?: string, "body"?: string}`;
+Predicted-utility self-rating (issue #179, half-ready-curve probe):
+- For every non-skip emission, ALSO emit \`predictedUtility\` — a number in [0, 1] estimating how much future-leverage the lesson carries. The harness uses this to decide whether the lesson's expected benefit justifies the byte-cost in the cost-transparency line above; it gets persisted so the operator can later correlate self-ratings with whether the lesson actually fired (got reinforced by future runs).
+- Calibration:
+  - 0.0–0.2: restates an existing rule; generic platitude ("verify before merging"); applies-to-everything; adds little beyond rules already in the file.
+  - 0.3–0.5: useful but partially redundant or could be inferred from existing sections; modest sharpening of an already-known principle.
+  - 0.6–0.8: introduces a specific rule with a named failure mode the agent has hit before or would hit again; cites concrete files / tools / protocols.
+  - 0.9–1.0: names a specific past incident (date / PR / file path / function name) with a concrete failure mode the agent would otherwise repeat; high-leverage rule with narrow tells.
+- Be calibrated, not generous. A field full of 0.8s is useless for tuning. If you'd skip the lesson under the cost-transparency line above, mark it 0.1–0.3 instead of inflating.
+
+Output: a single JSON object, no fences, no prose. The \`skip\` field is MANDATORY in every response. Use \`{"skip": false, "heading": "...", "body": "...", "predictedUtility": 0.X}\` when there is a lesson worth saving, and \`{"skip": true, "skipReason": "..."}\` otherwise. Schema:
+  {"skip": boolean, "skipReason"?: string, "heading"?: string, "body"?: string, "predictedUtility"?: number}`;
 
 const FAILURE_SUMMARIZER_SYSTEM_PROMPT = `You are a distillation agent. A coding agent JUST FAILED on a single GitHub issue — CI red after retry, agent gave up, envelope decision="error", or the SDK crashed mid-run after producing partial work. Your job is to extract the highest-signal failure lesson worth committing to the agent's CLAUDE.md.
 
@@ -278,6 +298,13 @@ Cross-agent promotion (optional, gated by human review):
 - Cap the wrapped content at ~40 non-empty lines / ~1500 chars.
 - Promote-candidates are queued for human review; they do NOT auto-promote. The human reviewer rejects noise.
 
+Predicted-utility self-rating (issue #179, half-ready-curve probe):
+- For every non-skip failure-lesson emission, ALSO emit \`predictedUtility\` — a number in [0, 1] estimating how much future-leverage the lesson carries. Failure lessons skew higher than success lessons because they capture signal that's normally lost; calibration:
+  - 0.0–0.3: agent burned turns on a one-off configuration quirk; lesson is "this run was unlucky"; nothing repeatable.
+  - 0.4–0.7: lesson names a specific tooling / SDK / protocol shape the agent didn't anticipate but a sibling agent would.
+  - 0.8–1.0: lesson names a structural fact (with concrete file path / function / protocol field) that prevents the same failure mode on the next similar issue. Strong candidate for cross-agent promotion if wrapped.
+- Be calibrated, not generous. The harness gates appends on this score; inflating it wastes the byte-budget on weak lessons.
+
 Hard rules:
 - If the failure was genuinely uninformative (single ambiguous error string, no agent reasoning, no clear missed assumption), emit \`{"skip": true, "skipReason": "<one short sentence>"}\`. Wrong-lesson risk beats noisy-lesson risk.
 - Heading: ≤ 120 chars, no trailing colon, no markdown prefix (no leading "##"). The append step prepends "##".
@@ -286,7 +313,7 @@ Hard rules:
 - Inside heading / body / skipReason string values: escape every double-quote as \\" and every literal newline as \\n. Do NOT escape apostrophes — \\' is INVALID JSON. Write apostrophes as a plain ': don't, isn't, can't.
 
 Output: a single JSON object, no fences, no prose. The \`skip\` field is MANDATORY in every response. Schema:
-  {"skip": boolean, "skipReason"?: string, "heading"?: string, "body"?: string}`;
+  {"skip": boolean, "skipReason"?: string, "heading"?: string, "body"?: string, "predictedUtility"?: number}`;
 
 export function buildFailurePrompt(input: FailureSummarizerInput): string {
   const trace = input.toolUseTrace
@@ -328,7 +355,7 @@ Agent's final reasoning text (truncated):
 ${truncate(input.finalText, 4000)}
 ${costLine}
 
-Decide: is there a generalizable failure lesson worth committing to this agent's CLAUDE.md? Lean toward yes — failure-mode runs exist to capture signal that success-mode discards. If yes, emit {"skip": false, "heading": "...", "body": "..."}. If the failure is genuinely opaque, emit {"skip": true, "skipReason": "..."}. The skip field is mandatory in both shapes. JSON only — escape every \\" inside string values.`;
+Decide: is there a generalizable failure lesson worth committing to this agent's CLAUDE.md? Lean toward yes — failure-mode runs exist to capture signal that success-mode discards. If yes, emit {"skip": false, "heading": "...", "body": "...", "predictedUtility": 0.X}. If the failure is genuinely opaque, emit {"skip": true, "skipReason": "..."}. The skip field is mandatory in both shapes; predictedUtility is mandatory whenever skip=false. JSON only — escape every \\" inside string values.`;
 }
 
 export function buildPrompt(input: SummarizerInput): string {
@@ -362,7 +389,7 @@ Agent's final reasoning text (truncated):
 ${truncate(input.finalText, 4000)}
 ${costLine}
 
-Decide: is there a generalizable rule worth committing to this agent's CLAUDE.md? If yes, emit {"skip": false, "heading": "...", "body": "..."}. If no, emit {"skip": true, "skipReason": "..."}. The skip field is mandatory in both shapes. JSON only — escape every \\" inside string values.`;
+Decide: is there a generalizable rule worth committing to this agent's CLAUDE.md? If yes, emit {"skip": false, "heading": "...", "body": "...", "predictedUtility": 0.X}. If no, emit {"skip": true, "skipReason": "..."}. The skip field is mandatory in both shapes; predictedUtility is mandatory whenever skip=false. JSON only — escape every \\" inside string values.`;
 }
 
 function truncate(s: string, max: number): string {

--- a/src/agent/utilityGate.test.ts
+++ b/src/agent/utilityGate.test.ts
@@ -1,0 +1,149 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_UTILITY_COST_RATIO,
+  evaluatePredictedUtilityGate,
+  resolveUtilityCostRatio,
+  type UtilityGateInput,
+} from "./runIssueCore.js";
+import type { Logger } from "../log/logger.js";
+
+const stubLogger: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+} as unknown as Logger;
+
+function input(
+  overrides: Partial<UtilityGateInput> = {},
+): UtilityGateInput {
+  return {
+    agentId: "agent-test",
+    issueId: 1,
+    headingLength: 50,
+    bodyLength: 500,
+    logger: stubLogger,
+    ...overrides,
+  };
+}
+
+// -----------------------------------------------------------------------
+// Pass-through paths
+// -----------------------------------------------------------------------
+
+test("evaluatePredictedUtilityGate: undefined predictedUtility lets through", () => {
+  const result = evaluatePredictedUtilityGate(input({ predictedUtility: undefined }));
+  assert.equal(result.kind, "let-through");
+  if (result.kind === "let-through") assert.equal(result.reason, "no-utility");
+});
+
+test("evaluatePredictedUtilityGate: empty CLAUDE.md (cost=0) lets through any utility ≥ 0", () => {
+  const result = evaluatePredictedUtilityGate(
+    input({ predictedUtility: 0.0, currentClaudeMdBytes: 0 }),
+  );
+  assert.equal(result.kind, "let-through");
+});
+
+test("evaluatePredictedUtilityGate: high utility passes the gate at any size", () => {
+  // At the upper end of the calibration range (~65 KB) costScore ≈ 1.0;
+  // utility=1.0 with default ratio=1.0 produces threshold=1.0 — exactly
+  // matching, the gate's `>=` comparison lets it through.
+  const result = evaluatePredictedUtilityGate(
+    input({ predictedUtility: 1.0, currentClaudeMdBytes: 60_000 }),
+  );
+  assert.equal(result.kind, "let-through");
+});
+
+// -----------------------------------------------------------------------
+// Skip paths
+// -----------------------------------------------------------------------
+
+test("evaluatePredictedUtilityGate: low utility at mid-size CLAUDE.md is skipped", () => {
+  // Mid-calibration size produces a non-trivial costScore. Utility=0.05
+  // is below the threshold and should be skipped.
+  const result = evaluatePredictedUtilityGate(
+    input({ predictedUtility: 0.05, currentClaudeMdBytes: 35_000 }),
+  );
+  assert.equal(result.kind, "skip");
+  if (result.kind === "skip") assert.equal(result.reason, "low-predicted-utility");
+});
+
+test("evaluatePredictedUtilityGate: ratio override raises the bar (no signal at high ratio)", () => {
+  // At currentClaudeMdBytes=25_000 the costScore is ~0.36. Utility=0.5
+  // passes with ratio=1.0 (threshold ≈ 0.36) but fails with ratio=10
+  // (threshold ≈ 3.6, well above utility).
+  const passInput = input({
+    predictedUtility: 0.5,
+    currentClaudeMdBytes: 25_000,
+    ratio: 1.0,
+  });
+  assert.equal(evaluatePredictedUtilityGate(passInput).kind, "let-through");
+  const failInput = input({
+    predictedUtility: 0.5,
+    currentClaudeMdBytes: 25_000,
+    ratio: 10,
+  });
+  assert.equal(evaluatePredictedUtilityGate(failInput).kind, "skip");
+});
+
+// -----------------------------------------------------------------------
+// Logging contract
+// -----------------------------------------------------------------------
+
+test("evaluatePredictedUtilityGate: always logs the decision", () => {
+  const events: Array<{ event: string; data: unknown }> = [];
+  const captureLogger = {
+    info: (event: string, data: unknown) => events.push({ event, data }),
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  } as unknown as Logger;
+
+  evaluatePredictedUtilityGate(
+    input({ predictedUtility: 0.7, currentClaudeMdBytes: 10_000, logger: captureLogger }),
+  );
+  assert.equal(events.length, 1);
+  assert.equal(events[0].event, "specialization.utility_gate");
+  const data = events[0].data as { decision: string; predictedUtility: number };
+  assert.equal(data.decision, "let-through");
+  assert.equal(data.predictedUtility, 0.7);
+});
+
+test("evaluatePredictedUtilityGate: log carries costScore + threshold + ratio when utility is provided", () => {
+  const events: Array<Record<string, unknown>> = [];
+  const captureLogger = {
+    info: (_event: string, data: Record<string, unknown>) => {
+      events.push(data);
+    },
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  } as unknown as Logger;
+
+  evaluatePredictedUtilityGate(
+    input({ predictedUtility: 0.7, currentClaudeMdBytes: 25_000, logger: captureLogger }),
+  );
+  assert.equal(events.length, 1);
+  assert.equal(typeof events[0].costScore, "number");
+  assert.equal(typeof events[0].threshold, "number");
+  assert.equal(typeof events[0].ratio, "number");
+});
+
+// -----------------------------------------------------------------------
+// resolveUtilityCostRatio
+// -----------------------------------------------------------------------
+
+test("resolveUtilityCostRatio: defaults + valid + invalid env", () => {
+  assert.equal(resolveUtilityCostRatio({}), DEFAULT_UTILITY_COST_RATIO);
+  assert.equal(resolveUtilityCostRatio({ VP_DEV_UTILITY_COST_RATIO: "2.0" }), 2.0);
+  assert.equal(resolveUtilityCostRatio({ VP_DEV_UTILITY_COST_RATIO: "0" }), 0);
+  assert.equal(
+    resolveUtilityCostRatio({ VP_DEV_UTILITY_COST_RATIO: "abc" }),
+    DEFAULT_UTILITY_COST_RATIO,
+  );
+  assert.equal(
+    resolveUtilityCostRatio({ VP_DEV_UTILITY_COST_RATIO: "-1" }),
+    DEFAULT_UTILITY_COST_RATIO,
+  );
+});

--- a/src/state/lessonUtility.test.ts
+++ b/src/state/lessonUtility.test.ts
@@ -93,6 +93,22 @@ test("recordIntroduction: creates a fresh record when file is absent", async () 
     assert.deepEqual(sec.pastIncidentDates, ["2026-05-06"]);
     assert.equal(sec.crossReferenceCount, 0);
     assert.deepEqual(sec.reinforcementRuns, []);
+    assert.equal(sec.predictedUtility, undefined);
+  });
+});
+
+test("recordIntroduction: persists predictedUtility when provided", async () => {
+  await withTestAgent(async (agentId) => {
+    await recordIntroduction({
+      agentId,
+      runId: "run-1",
+      issueId: 178,
+      body: "specific incident 2026-05-06",
+      ts: "2026-05-06T10:00:00.000Z",
+      predictedUtility: 0.8,
+    });
+    const file = await loadLessonUtility(agentId);
+    assert.equal(file?.sections[0].predictedUtility, 0.8);
   });
 });
 

--- a/src/state/lessonUtility.ts
+++ b/src/state/lessonUtility.ts
@@ -49,6 +49,16 @@ export interface SectionUtilityRecord {
   /** Updated by a separate sweep (out of scope for #178); defaults to 0. */
   crossReferenceCount: number;
   crossReferenceUpdatedAt?: string;
+  /**
+   * LLM self-rating at introduction time, in [0, 1] (#179 Phase 2 option B,
+   * shipped early as a half-ready-curve probe). Persisted so post-hoc
+   * analysis can correlate self-ratings with subsequent
+   * `reinforcementRuns.length` / `pushbackRuns.length`. Optional for
+   * back-compat with records written before this field existed; absent =
+   * the LLM didn't emit a value (older summarizer prompt) or the spawn
+   * couldn't parse it.
+   */
+  predictedUtility?: number;
 }
 
 export interface MergeHistoryEntry {
@@ -164,6 +174,13 @@ export interface RecordIntroductionInput {
   issueIds?: number[];
   body: string;
   ts: string;
+  /**
+   * LLM self-rating from `SummarizerOutput.predictedUtility` (#179 Phase 2
+   * option B). Persisted into the new record's `predictedUtility` field
+   * for post-hoc correlation with reinforcement / pushback signals.
+   * Optional — older summarizer responses don't carry the field.
+   */
+  predictedUtility?: number;
 }
 
 /**
@@ -194,6 +211,9 @@ export async function recordIntroduction(
       pushbackRuns: [],
       pastIncidentDates: dates,
       crossReferenceCount: 0,
+      ...(input.predictedUtility !== undefined
+        ? { predictedUtility: input.predictedUtility }
+        : {}),
     });
   });
 }


### PR DESCRIPTION
## Summary

Ships option B from the [#179 cost/benefit menu](https://github.com/szhygulin/vaultpilot-development-agents/pull/190) — out of order vs the plan, which deferred B for "prompt-evolution churn" reasons. Operator override: the goal is to start collecting `predictedUtility` distribution data on the half-ready leg-1 curve, even if the gate threshold has to be re-tuned when leg-2 K=13 lands.

The pairing the operator wanted to test: each section's `predictedUtility` (LLM self-rating at introduction) vs its later `reinforcementRuns.length` / `pushbackRuns.length`. Strong correlation = LLM self-ratings have signal; weak/no correlation = the field is cosmetic and the gate should be removed in favor of A/E once K=13 lands.

## What changes

### Schema + prompts (`src/agent/summarizer.ts`)

`SummarizerOutputSchema` gains an optional `predictedUtility: z.number().min(0).max(1)`. Both system prompts carry a calibration anchor:

- 0.0–0.2: restates an existing rule; generic platitude.
- 0.3–0.5: useful but partially redundant.
- 0.6–0.8: specific named failure mode the agent has hit before.
- 0.9–1.0: dated past incident with file/PR pointer.

Both user prompts' `Decide:` tails name the field as mandatory whenever `skip=false`.

### Soft gate (`runIssueCore.ts evaluatePredictedUtilityGate`)

Pure function. Computes `costScore = clamp(0, 1, normalizedAccuracyFactor(currentBytes + heading + body + 200) - 1)`. Skips when `predictedUtility < costScore × ratio`. Tunable via `VP_DEV_UTILITY_COST_RATIO` env var (default 1.0). Missing `predictedUtility` = let-through (back-compat). Always logs the `(utility, costScore, threshold, ratio, decision)` tuple under `specialization.utility_gate` so the operator can analyze the distribution post-hoc.

Inserted between the dedup gate (G) and `appendBlock` so duplicates are still credited via `recordReinforcement` regardless of utility, and only novel-but-low-utility lessons get filtered.

### Persistence (`src/state/lessonUtility.ts`)

`SectionUtilityRecord` gains `predictedUtility?: number`. `recordIntroduction` accepts it; `runIssueCore.recordUtilityForAppend` threads `summary.predictedUtility` through.

## Why-not-defer (operator decision recorded)

Plan said: defer B until K=13. Operator overrode: "test real decisions on half-ready curve, just to understand if there is a signal." Risk acknowledged: LLM self-rating may be miscalibrated (always 0.8); the gate threshold may need to change when K=13 sharpens the cost numbers.

The gate is intentionally soft (default ratio 1.0, log-everything-always) so the data we collect during the wait for leg-2 is the dominant value, not the filtering.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm test` — **564/564 pass** (549 baseline + 15 new)

Coverage:
- `SummarizerOutputSchema`: accepts in [0,1], rejects out-of-range, optional for back-compat (4 tests).
- `buildPrompt` + `buildFailurePrompt` instruct the LLM to emit `predictedUtility` (2 tests).
- `evaluatePredictedUtilityGate`: undefined → let-through; empty CLAUDE.md → let-through; high utility passes; low utility skipped; ratio override changes the decision; logs the decision; log carries `costScore` + `threshold` + `ratio` (7 tests).
- `resolveUtilityCostRatio`: defaults + valid + invalid env (1 multi-case).
- `recordIntroduction`: persists predictedUtility when provided + leaves it undefined when not (1 test, plus assertion added to existing test).

## Phase 2 status

- **B** ✓ shipped this PR.
- **D** (B + C hybrid) partially shipped via the gate's reuse of `predictedUtility`.
- **A, E** still deferred — curve-dependent, wait for K=13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)