### PR TITLE
feat(lessons): @local-claude promote-candidate domain + L2 utility gate

### DIFF
--- a/src/agent/localClaudePr.test.ts
+++ b/src/agent/localClaudePr.test.ts
@@ -1,0 +1,177 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+import {
+  DEFAULT_BASE_REF,
+  openLocalClaudePr,
+  type PrCreator,
+} from "./localClaudePr.js";
+
+const execFile = promisify(execFileCb);
+
+/**
+ * Build a throwaway repo to host a worktree base ref. Returns the repo
+ * root + a base ref (`main`) that the openLocalClaudePr call can branch
+ * off. Uses `git init` + a minimal seed commit + a CLAUDE.md so the
+ * append step has something to read.
+ */
+async function makeFixtureRepo(): Promise<{
+  repoRoot: string;
+  baseRef: string;
+  cleanup: () => Promise<void>;
+}> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "local-claude-pr-test-"));
+  await execFile("git", ["init", "-q", "-b", "main", dir]);
+  await execFile("git", ["-C", dir, "config", "user.email", "test@example.com"]);
+  await execFile("git", ["-C", dir, "config", "user.name", "Test User"]);
+  await execFile("git", ["-C", dir, "config", "commit.gpgsign", "false"]);
+  await fs.writeFile(
+    path.join(dir, "CLAUDE.md"),
+    "# Project rules\n\n## Existing section\n\nExisting body.\n",
+  );
+  await execFile("git", ["-C", dir, "add", "CLAUDE.md"]);
+  await execFile("git", ["-C", dir, "commit", "-q", "-m", "seed"]);
+  return {
+    repoRoot: dir,
+    baseRef: "main",
+    cleanup: async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+// --------------------------------------------------------------------
+// Happy path: gate=let-through, prCreator returns a URL
+// --------------------------------------------------------------------
+
+test("openLocalClaudePr: appends to CLAUDE.md, commits, and reports the PR URL", async () => {
+  const { repoRoot, baseRef, cleanup } = await makeFixtureRepo();
+  try {
+    const captured: { branch?: string; title?: string; body?: string } = {};
+    // Mock the push (no remote) — replace `git push` by stubbing the prCreator
+    // and letting the rest of the flow run. Since push has no remote, the test
+    // environment skips it via prCreator override... but openLocalClaudePr
+    // calls push BEFORE prCreator. Stub git push by setting a fake remote.
+    await execFile("git", ["-C", repoRoot, "remote", "add", "origin", repoRoot]);
+    // Allow pushing into the same bare-ish repo. Easier: use a separate bare
+    // remote.
+    const bareDir = await fs.mkdtemp(path.join(os.tmpdir(), "bare-remote-"));
+    await execFile("git", ["init", "-q", "--bare", bareDir]);
+    await execFile("git", ["-C", repoRoot, "remote", "set-url", "origin", bareDir]);
+    try {
+      const prCreator: PrCreator = async (input) => {
+        captured.branch = input.branch;
+        captured.title = input.title;
+        captured.body = input.body;
+        return { prUrl: "https://example.test/pull/42" };
+      };
+      const outcome = await openLocalClaudePr({
+        sourceAgentId: "agent-test-001",
+        ts: "2026-05-06T16:00:00.000Z",
+        utility: 0.85,
+        gate: {
+          decision: "let-through",
+          costScore: 0.4,
+          threshold: 0.8,
+          ratio: 2.0,
+        },
+        body: "## Pre-dispatch foo\n\nProject-wide rule body.",
+        repoRoot,
+        baseRef,
+        prCreator,
+      });
+      assert.equal(outcome.kind, "pr-opened");
+      if (outcome.kind === "pr-opened") {
+        assert.equal(outcome.prUrl, "https://example.test/pull/42");
+        assert.match(outcome.branchName, /^chore\/local-claude-from-agent-test-001-/);
+      }
+      // PR creator received the right inputs.
+      assert.match(captured.branch ?? "", /^chore\/local-claude-from-agent-test-001-/);
+      assert.match(captured.title ?? "", /docs\(CLAUDE\.md\): Pre-dispatch foo/);
+      assert.match(captured.body ?? "", /predictedUtility: 0\.85/);
+      assert.match(captured.body ?? "", /L2 gate: decision=let-through/);
+      // Worktree was cleaned up.
+      const worktrees = await execFile("git", ["-C", repoRoot, "worktree", "list"]);
+      assert.equal(worktrees.stdout.split("\n").filter(Boolean).length, 1);
+    } finally {
+      await fs.rm(bareDir, { recursive: true, force: true });
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+// --------------------------------------------------------------------
+// PR creator throws → pr-failed; queue fallback is the caller's responsibility
+// --------------------------------------------------------------------
+
+test("openLocalClaudePr: prCreator failure surfaces as pr-failed with reason", async () => {
+  const { repoRoot, baseRef, cleanup } = await makeFixtureRepo();
+  try {
+    const bareDir = await fs.mkdtemp(path.join(os.tmpdir(), "bare-remote-"));
+    await execFile("git", ["init", "-q", "--bare", bareDir]);
+    await execFile("git", ["-C", repoRoot, "remote", "add", "origin", bareDir]);
+    try {
+      const prCreator: PrCreator = async () => {
+        throw new Error("simulated gh failure");
+      };
+      const outcome = await openLocalClaudePr({
+        sourceAgentId: "agent-test-002",
+        ts: "2026-05-06T16:01:00.000Z",
+        body: "## fail-path\n\nbody",
+        repoRoot,
+        baseRef,
+        prCreator,
+      });
+      assert.equal(outcome.kind, "pr-failed");
+      if (outcome.kind === "pr-failed") {
+        assert.match(outcome.reason, /gh-pr-create.*simulated gh failure/);
+        assert.match(outcome.branchName ?? "", /^chore\/local-claude-from-agent-test-002-/);
+      }
+      // Worktree still cleaned.
+      const worktrees = await execFile("git", ["-C", repoRoot, "worktree", "list"]);
+      assert.equal(worktrees.stdout.split("\n").filter(Boolean).length, 1);
+    } finally {
+      await fs.rm(bareDir, { recursive: true, force: true });
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+// --------------------------------------------------------------------
+// Worktree creation fails (no git in path / bad baseRef)
+// --------------------------------------------------------------------
+
+test("openLocalClaudePr: worktree-add failure surfaces as pr-failed", async () => {
+  const { repoRoot, cleanup } = await makeFixtureRepo();
+  try {
+    const prCreator: PrCreator = async () => ({ prUrl: "https://nope" });
+    const outcome = await openLocalClaudePr({
+      sourceAgentId: "agent-test-003",
+      ts: "2026-05-06T16:02:00.000Z",
+      body: "body",
+      repoRoot,
+      baseRef: "nonexistent-branch",
+      prCreator,
+    });
+    assert.equal(outcome.kind, "pr-failed");
+    if (outcome.kind === "pr-failed") {
+      assert.match(outcome.reason, /worktree-add/);
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+// --------------------------------------------------------------------
+// Constants sanity
+// --------------------------------------------------------------------
+
+test("DEFAULT_BASE_REF points at origin/main", () => {
+  assert.equal(DEFAULT_BASE_REF, "origin/main");
+});

--- a/src/agent/localClaudePr.ts
+++ b/src/agent/localClaudePr.ts
@@ -1,0 +1,248 @@
+// Auto-PR path for project-local CLAUDE.md candidates (#196 Phase 2).
+//
+// Creates a chore branch from a temp git worktree, appends the lesson body
+// as a new section to project-local CLAUDE.md, commits, pushes, opens a PR
+// via `gh pr create`. Operator-invoked through `vp-dev lessons review --pr`;
+// runs in the operator's shell on their own machine.
+//
+// Project-rule note: the project CLAUDE.md says "Don't modify the target
+// repo's CLAUDE.md from within a run." That rule covers IN-RUN side-effects
+// from agent dispatches (where the LLM has tools and could write the file
+// as a side-effect of its task). This module runs in the OPERATOR-INVOKED
+// CLI flow — the operator explicitly opted in via `--pr` and (in
+// interactive mode) confirmed each candidate. The L2 utility-vs-cost gate
+// is the second checkpoint. The rule's "no automatic, unreviewed writes
+// from within an LLM run" intent is preserved; this path is a different
+// trust boundary.
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+import type { LocalClaudeUtilityGateResult } from "./localClaudeQueue.js";
+
+const execFile = promisify(execFileCb);
+
+export interface OpenLocalClaudePrInput {
+  sourceAgentId: string;
+  ts: string;
+  utility?: number;
+  gate?: LocalClaudeUtilityGateResult;
+  /**
+   * The wrapped block's body. Expected to start with a `## Heading` line
+   * the operator wants in project-local CLAUDE.md, but no enforced shape —
+   * we append verbatim with a single leading blank line.
+   */
+  body: string;
+  /** Repo root the worktree branches off of. Defaults to cwd. */
+  repoRoot?: string;
+  /** Worktree base path (defaults to `<repoRoot>/.claude/worktrees`). */
+  worktreesRoot?: string;
+  /** Base branch for the chore branch. Defaults to `origin/main`. */
+  baseRef?: string;
+  /**
+   * Override the PR creation step. Default shells out to `gh pr create`.
+   * Tests pass a synthetic creator to assert the orchestration shape
+   * without invoking real GitHub.
+   */
+  prCreator?: PrCreator;
+}
+
+export interface PrCreatorInput {
+  branch: string;
+  title: string;
+  body: string;
+  /** Working directory for the gh invocation (the worktree). */
+  workdir: string;
+}
+
+export type PrCreator = (input: PrCreatorInput) => Promise<{ prUrl: string }>;
+
+export type OpenLocalClaudePrOutcome =
+  | { kind: "pr-opened"; prUrl: string; branchName: string }
+  | { kind: "pr-failed"; reason: string; branchName?: string };
+
+export const DEFAULT_BASE_REF = "origin/main";
+
+/**
+ * Append the lesson to project-local CLAUDE.md and open a PR. All work
+ * happens in a temp worktree so the operator's main checkout isn't dirtied.
+ *
+ * Failure modes (each returns `{kind: "pr-failed", reason}`):
+ *   - worktree creation fails (path collision, no git, etc.)
+ *   - push rejected (auth, branch already on remote, etc.)
+ *   - gh pr create fails (auth, no remote, gh missing)
+ *
+ * On any failure the worktree is removed, but the chore branch may persist
+ * locally. Caller should fall back to the queue-file path so the lesson
+ * isn't lost.
+ */
+export async function openLocalClaudePr(
+  input: OpenLocalClaudePrInput,
+): Promise<OpenLocalClaudePrOutcome> {
+  const repoRoot = input.repoRoot ?? process.cwd();
+  const worktreesRoot =
+    input.worktreesRoot ?? path.join(repoRoot, ".claude", "worktrees");
+  const baseRef = input.baseRef ?? DEFAULT_BASE_REF;
+  const branchName = mintBranchName(input.sourceAgentId, input.ts);
+  const worktreePath = path.join(worktreesRoot, branchName);
+  const prCreator = input.prCreator ?? defaultPrCreator;
+
+  // 1. Create the worktree off baseRef.
+  try {
+    await execFile(
+      "git",
+      ["worktree", "add", worktreePath, "-b", branchName, baseRef],
+      { cwd: repoRoot },
+    );
+  } catch (err) {
+    return { kind: "pr-failed", reason: `worktree-add: ${(err as Error).message}` };
+  }
+
+  try {
+    // 2. Append the lesson to <worktree>/CLAUDE.md.
+    const claudeMdPath = path.join(worktreePath, "CLAUDE.md");
+    let current = "";
+    try {
+      current = await fs.readFile(claudeMdPath, "utf-8");
+    } catch {
+      // No file yet — create it.
+    }
+    const block = formatLessonAppend(input);
+    const next =
+      current.length === 0 || current.endsWith("\n")
+        ? current + block
+        : current + "\n" + block;
+    await fs.writeFile(claudeMdPath, next);
+
+    // 3. Commit.
+    const commitMsg = formatCommitMessage(input);
+    await execFile("git", ["add", "CLAUDE.md"], { cwd: worktreePath });
+    await execFile("git", ["commit", "-m", commitMsg], { cwd: worktreePath });
+
+    // 4. Push.
+    try {
+      await execFile(
+        "git",
+        ["push", "-u", "origin", branchName],
+        { cwd: worktreePath },
+      );
+    } catch (err) {
+      return {
+        kind: "pr-failed",
+        reason: `push: ${(err as Error).message}`,
+        branchName,
+      };
+    }
+
+    // 5. Open the PR.
+    const { title, body } = formatPrTitleAndBody(input, commitMsg);
+    let prResult: { prUrl: string };
+    try {
+      prResult = await prCreator({
+        branch: branchName,
+        title,
+        body,
+        workdir: worktreePath,
+      });
+    } catch (err) {
+      return {
+        kind: "pr-failed",
+        reason: `gh-pr-create: ${(err as Error).message}`,
+        branchName,
+      };
+    }
+
+    return { kind: "pr-opened", prUrl: prResult.prUrl, branchName };
+  } finally {
+    // 6. Always remove the worktree to keep operator's tree clean. Branch
+    // stays — push already published it.
+    try {
+      await execFile(
+        "git",
+        ["worktree", "remove", "--force", worktreePath],
+        { cwd: repoRoot },
+      );
+    } catch {
+      // Best-effort cleanup; if it fails, operator can `git worktree prune`.
+    }
+  }
+}
+
+function mintBranchName(sourceAgentId: string, ts: string): string {
+  // Sanitize agent id (already shape `agent-...`) and timestamp.
+  const agentSafe = sourceAgentId.replace(/[^a-zA-Z0-9-]/g, "-");
+  const tsSafe = ts.replace(/[:.]/g, "-").replace(/[^a-zA-Z0-9-]/g, "-");
+  return `chore/local-claude-from-${agentSafe}-${tsSafe}`;
+}
+
+function formatLessonAppend(input: OpenLocalClaudePrInput): string {
+  const provenance: string[] = [
+    `source=${input.sourceAgentId}`,
+    `ts=${input.ts}`,
+  ];
+  if (input.utility !== undefined && Number.isFinite(input.utility)) {
+    provenance.push(`utility=${input.utility}`);
+  }
+  if (input.gate) {
+    provenance.push(`gate=${input.gate.decision}`);
+  }
+  const header = `<!-- promoted-from-summarizer ${provenance.join(" ")} -->`;
+  return `\n${header}\n${input.body.trim()}\n`;
+}
+
+function formatCommitMessage(input: OpenLocalClaudePrInput): string {
+  const headingMatch = input.body.match(/^##\s+(.+)$/m);
+  const subject = headingMatch
+    ? `docs(CLAUDE.md): ${headingMatch[1].trim()}`
+    : `docs(CLAUDE.md): promoted local-claude lesson from ${input.sourceAgentId}`;
+  return [
+    subject.slice(0, 70),
+    "",
+    `Promoted from ${input.sourceAgentId}'s summarizer output via`,
+    `vp-dev lessons review --pr (gate ${input.gate?.decision ?? "n/a"},`,
+    `utility ${input.utility ?? "n/a"}, ratio ${input.gate?.ratio ?? "n/a"}).`,
+    "",
+    "Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>",
+  ].join("\n");
+}
+
+function formatPrTitleAndBody(
+  input: OpenLocalClaudePrInput,
+  commitMsg: string,
+): { title: string; body: string } {
+  const subject = commitMsg.split("\n")[0];
+  const utilityLine =
+    input.utility !== undefined ? `\n- predictedUtility: ${input.utility}` : "";
+  const gateLine = input.gate
+    ? `\n- L2 gate: decision=${input.gate.decision}, costScore=${input.gate.costScore.toFixed(3)}, threshold=${input.gate.threshold.toFixed(3)}, ratio=${input.gate.ratio}`
+    : "";
+  const body = [
+    "## Summary",
+    "",
+    `Promoting a project-wide lesson the summarizer flagged via \`<!-- promote-candidate:@local-claude -->\` and the operator-side L2 utility gate accepted.`,
+    "",
+    "## Provenance",
+    `- source agent: \`${input.sourceAgentId}\``,
+    `- timestamp: \`${input.ts}\``,
+    utilityLine + gateLine,
+    "",
+    "🤖 Auto-PR via `vp-dev lessons review --pr`",
+  ].join("\n");
+  return { title: subject, body };
+}
+
+async function defaultPrCreator(input: PrCreatorInput): Promise<{ prUrl: string }> {
+  const { stdout } = await execFile(
+    "gh",
+    ["pr", "create", "--title", input.title, "--body", input.body],
+    { cwd: input.workdir },
+  );
+  // gh pr create prints the PR URL on stdout (last non-empty line).
+  const lines = stdout.split("\n").map((l) => l.trim()).filter(Boolean);
+  const last = lines[lines.length - 1] ?? "";
+  if (!/^https?:\/\/.+/.test(last)) {
+    throw new Error(`unexpected gh pr create output: ${stdout}`);
+  }
+  return { prUrl: last };
+}

--- a/src/agent/localClaudeQueue.test.ts
+++ b/src/agent/localClaudeQueue.test.ts
@@ -1,0 +1,223 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  DEFAULT_LOCAL_CLAUDE_UTILITY_RATIO,
+  appendToLocalClaudeQueue,
+  evaluateLocalClaudeUtilityGate,
+  resolveLocalClaudeUtilityRatio,
+} from "./localClaudeQueue.js";
+
+// Use unique tmp paths per test so this file's tests don't race with
+// `promotion.test.ts` (which writes to the real LOCAL_CLAUDE_QUEUE_FILE)
+// when node:test runs files in parallel.
+async function withTmpQueue<T>(
+  fn: (filePath: string) => Promise<T>,
+): Promise<T> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "local-claude-queue-test-"));
+  const filePath = path.join(dir, "pending.md");
+  try {
+    return await fn(filePath);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------
+// resolveLocalClaudeUtilityRatio
+// ---------------------------------------------------------------------
+
+test("resolveLocalClaudeUtilityRatio: defaults + valid + invalid env", () => {
+  assert.equal(resolveLocalClaudeUtilityRatio({}), DEFAULT_LOCAL_CLAUDE_UTILITY_RATIO);
+  assert.equal(
+    resolveLocalClaudeUtilityRatio({ VP_DEV_LOCAL_CLAUDE_UTILITY_RATIO: "3.0" }),
+    3.0,
+  );
+  assert.equal(
+    resolveLocalClaudeUtilityRatio({ VP_DEV_LOCAL_CLAUDE_UTILITY_RATIO: "0" }),
+    0,
+  );
+  assert.equal(
+    resolveLocalClaudeUtilityRatio({ VP_DEV_LOCAL_CLAUDE_UTILITY_RATIO: "abc" }),
+    DEFAULT_LOCAL_CLAUDE_UTILITY_RATIO,
+  );
+  assert.equal(
+    resolveLocalClaudeUtilityRatio({ VP_DEV_LOCAL_CLAUDE_UTILITY_RATIO: "-1" }),
+    DEFAULT_LOCAL_CLAUDE_UTILITY_RATIO,
+  );
+});
+
+test("DEFAULT_LOCAL_CLAUDE_UTILITY_RATIO is 2.0 (stricter than per-agent)", () => {
+  // Documented in the plan and prompt: bytes added to local CLAUDE.md are
+  // amplified across every dispatch; the bar is higher than the per-agent
+  // gate's 1.0 default.
+  assert.equal(DEFAULT_LOCAL_CLAUDE_UTILITY_RATIO, 2.0);
+});
+
+// ---------------------------------------------------------------------
+// evaluateLocalClaudeUtilityGate
+// ---------------------------------------------------------------------
+
+test("evaluateLocalClaudeUtilityGate: undefined utility → no-utility", () => {
+  const r = evaluateLocalClaudeUtilityGate({
+    utility: undefined,
+    currentLocalClaudeMdBytes: 10_000,
+    candidateBytes: 500,
+  });
+  assert.equal(r.decision, "no-utility");
+});
+
+test("evaluateLocalClaudeUtilityGate: empty local CLAUDE.md (cost=0) lets through any utility", () => {
+  const r = evaluateLocalClaudeUtilityGate({
+    utility: 0.0,
+    currentLocalClaudeMdBytes: 0,
+    candidateBytes: 500,
+  });
+  assert.equal(r.decision, "let-through");
+});
+
+test("evaluateLocalClaudeUtilityGate: high utility passes mid-size cost at default ratio 2.0", () => {
+  // At ~25 KB the costScore is ~0.36 (per the curve). With ratio=2.0,
+  // threshold ≈ 0.72. utility=0.85 passes.
+  const r = evaluateLocalClaudeUtilityGate({
+    utility: 0.85,
+    currentLocalClaudeMdBytes: 25_000,
+    candidateBytes: 500,
+  });
+  assert.equal(r.decision, "let-through");
+});
+
+test("evaluateLocalClaudeUtilityGate: 0.5 utility skipped at mid-size with default ratio 2.0", () => {
+  // Same costScore ≈ 0.36, threshold ≈ 0.72; utility=0.5 < 0.72 → skip.
+  const r = evaluateLocalClaudeUtilityGate({
+    utility: 0.5,
+    currentLocalClaudeMdBytes: 25_000,
+    candidateBytes: 500,
+  });
+  assert.equal(r.decision, "skip");
+});
+
+test("evaluateLocalClaudeUtilityGate: ratio override drops the bar", () => {
+  // Same utility 0.5 + costScore 0.36; with ratio=1.0 (per-agent ratio),
+  // threshold = 0.36 → utility 0.5 passes.
+  const r = evaluateLocalClaudeUtilityGate({
+    utility: 0.5,
+    currentLocalClaudeMdBytes: 25_000,
+    candidateBytes: 500,
+    ratio: 1.0,
+  });
+  assert.equal(r.decision, "let-through");
+});
+
+test("evaluateLocalClaudeUtilityGate: result fields are populated and finite", () => {
+  const r = evaluateLocalClaudeUtilityGate({
+    utility: 0.7,
+    currentLocalClaudeMdBytes: 15_000,
+    candidateBytes: 800,
+  });
+  assert.ok(Number.isFinite(r.costScore));
+  assert.ok(Number.isFinite(r.threshold));
+  assert.equal(typeof r.ratio, "number");
+});
+
+// ---------------------------------------------------------------------
+// appendToLocalClaudeQueue
+// ---------------------------------------------------------------------
+
+test("appendToLocalClaudeQueue: writes provenance header + body to a fresh queue", async () => {
+  await withTmpQueue(async (filePath) => {
+    const out = await appendToLocalClaudeQueue({
+      sourceAgentId: "agent-test",
+      ts: "2026-05-06T15:00:00.000Z",
+      utility: 0.85,
+      gate: {
+        decision: "let-through",
+        costScore: 0.4,
+        threshold: 0.8,
+        ratio: 2.0,
+      },
+      body: "## Project-wide rule\n\nBody content here.",
+      filePathOverride: filePath,
+    });
+    assert.equal(out.filePath, filePath);
+    assert.ok(out.bytesAppended > 0);
+    const content = await fs.readFile(filePath, "utf-8");
+    assert.match(content, /<!-- queued source=agent-test/);
+    assert.match(content, /utility=0\.85/);
+    assert.match(content, /gate=let-through/);
+    assert.match(content, /## Project-wide rule/);
+    assert.match(content, /Body content here\./);
+  });
+});
+
+test("appendToLocalClaudeQueue: utility absent omits the field from header", async () => {
+  await withTmpQueue(async (filePath) => {
+    await appendToLocalClaudeQueue({
+      sourceAgentId: "agent-x",
+      ts: "2026-05-06T15:00:00.000Z",
+      body: "no-utility body",
+      filePathOverride: filePath,
+    });
+    const content = await fs.readFile(filePath, "utf-8");
+    assert.doesNotMatch(content, /utility=/);
+    assert.match(content, /<!-- queued source=agent-x/);
+  });
+});
+
+test("appendToLocalClaudeQueue: appends to existing file (multiple entries)", async () => {
+  await withTmpQueue(async (filePath) => {
+    await appendToLocalClaudeQueue({
+      sourceAgentId: "agent-a",
+      ts: "2026-05-06T15:00:00.000Z",
+      body: "first",
+      filePathOverride: filePath,
+    });
+    await appendToLocalClaudeQueue({
+      sourceAgentId: "agent-b",
+      ts: "2026-05-06T15:01:00.000Z",
+      body: "second",
+      filePathOverride: filePath,
+    });
+    const content = await fs.readFile(filePath, "utf-8");
+    assert.match(content, /source=agent-a/);
+    assert.match(content, /source=agent-b/);
+    assert.match(content, /first/);
+    assert.match(content, /second/);
+  });
+});
+
+test("appendToLocalClaudeQueue: concurrent writes serialize via the lock", async () => {
+  await withTmpQueue(async (filePath) => {
+    await Promise.all([
+      appendToLocalClaudeQueue({
+        sourceAgentId: "agent-1",
+        ts: "T1",
+        body: "body-1",
+        filePathOverride: filePath,
+      }),
+      appendToLocalClaudeQueue({
+        sourceAgentId: "agent-2",
+        ts: "T2",
+        body: "body-2",
+        filePathOverride: filePath,
+      }),
+      appendToLocalClaudeQueue({
+        sourceAgentId: "agent-3",
+        ts: "T3",
+        body: "body-3",
+        filePathOverride: filePath,
+      }),
+    ]);
+    const content = await fs.readFile(filePath, "utf-8");
+    // All three sources should land. Order depends on lock acquisition;
+    // we don't assert order, just that nothing was lost to a race.
+    assert.match(content, /source=agent-1/);
+    assert.match(content, /source=agent-2/);
+    assert.match(content, /source=agent-3/);
+    assert.match(content, /body-1/);
+    assert.match(content, /body-2/);
+    assert.match(content, /body-3/);
+  });
+});

--- a/src/agent/localClaudeQueue.ts
+++ b/src/agent/localClaudeQueue.ts
@@ -1,0 +1,163 @@
+// Project-local CLAUDE.md candidate queue (#179 Phase 2 follow-up to PR #190 + #193).
+//
+// Operator-side L2 of the lesson cost/benefit pipeline. When `vp-dev lessons
+// review` accepts a `<!-- promote-candidate:@local-claude utility=N.M -->`
+// block, the body is appended here (under withFileLock) instead of the
+// shared-pool. The operator periodically reads this file and opens a chore
+// PR appending selected sections to the project-local CLAUDE.md. No
+// automatic writes to the tracked file; the queue is the staging surface.
+//
+// The L2 gate (`evaluateLocalClaudeUtilityGate`) compares the candidate's
+// utility (from `utility=N.M` in the marker, or a caller-supplied fallback)
+// against the cost score derived from `normalizedAccuracyFactor` at the
+// projected post-append local-CLAUDE.md size. Default ratio 2.0 (stricter
+// than the per-agent gate's 1.0 default) because bytes added to local
+// CLAUDE.md are loaded into every dispatch's prompt by every agent, so
+// marginal cost is amplified. Override via `VP_DEV_LOCAL_CLAUDE_UTILITY_RATIO`.
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { STATE_DIR } from "../state/runState.js";
+import { ensureDir, withFileLock } from "../state/locks.js";
+import { normalizedAccuracyFactor } from "../util/contextCostCurve.js";
+
+export const LOCAL_CLAUDE_QUEUE_FILE = path.join(
+  STATE_DIR,
+  "local-claude-md-pending.md",
+);
+
+export const DEFAULT_LOCAL_CLAUDE_UTILITY_RATIO = 2.0;
+
+export function resolveLocalClaudeUtilityRatio(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = env.VP_DEV_LOCAL_CLAUDE_UTILITY_RATIO;
+  if (raw == null || raw === "") return DEFAULT_LOCAL_CLAUDE_UTILITY_RATIO;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return DEFAULT_LOCAL_CLAUDE_UTILITY_RATIO;
+  return n;
+}
+
+export interface LocalClaudeUtilityGateInput {
+  /** Utility 0..1 emitted by the LLM (or undefined → no signal to act on). */
+  utility?: number;
+  /** Current byte size of the project-local CLAUDE.md. */
+  currentLocalClaudeMdBytes: number;
+  /** Length of the candidate body in bytes (heading + body content). */
+  candidateBytes: number;
+  /** Override env-resolved ratio (testability + per-call adjustment). */
+  ratio?: number;
+}
+
+export type LocalClaudeUtilityGateResult = {
+  /** Final advisory: skip = utility below threshold; let-through otherwise. */
+  decision: "let-through" | "skip" | "no-utility";
+  /** Cost score in [0, 1] derived from normalizedAccuracyFactor at the projected size. */
+  costScore: number;
+  /** ratio × costScore — what the utility had to clear. */
+  threshold: number;
+  /** Resolved ratio (env or override). */
+  ratio: number;
+};
+
+/**
+ * Pure compute. Returns the gate's advisory decision + the numbers the
+ * operator-side review UI displays. The caller decides whether to act on
+ * "skip" (typically: surface a warning and require an explicit accept) or
+ * "let-through" (typically: accept silently).
+ */
+export function evaluateLocalClaudeUtilityGate(
+  input: LocalClaudeUtilityGateInput,
+): LocalClaudeUtilityGateResult {
+  const ratio = input.ratio ?? resolveLocalClaudeUtilityRatio();
+  const projectedBytes = input.currentLocalClaudeMdBytes + input.candidateBytes;
+  const factor = normalizedAccuracyFactor(projectedBytes);
+  const costScore = Number.isFinite(factor)
+    ? Math.max(0, Math.min(1, factor - 1))
+    : 0;
+  const threshold = costScore * ratio;
+  if (input.utility === undefined) {
+    return { decision: "no-utility", costScore, threshold, ratio };
+  }
+  return {
+    decision: input.utility >= threshold ? "let-through" : "skip",
+    costScore,
+    threshold,
+    ratio,
+  };
+}
+
+export interface AppendLocalClaudeQueueInput {
+  sourceAgentId: string;
+  ts: string;
+  /** From `<!-- promote-candidate:@local-claude utility=N.M -->` marker. */
+  utility?: number;
+  /** L2 gate result captured at accept time (informational, recorded in header). */
+  gate?: LocalClaudeUtilityGateResult;
+  /** The wrapped block's body content. */
+  body: string;
+  /** Override target file (testability; defaults to LOCAL_CLAUDE_QUEUE_FILE). */
+  filePathOverride?: string;
+}
+
+export interface AppendLocalClaudeQueueOutcome {
+  filePath: string;
+  bytesAppended: number;
+  totalBytes: number;
+}
+
+/**
+ * Append a queue entry under withFileLock. Provenance header records source,
+ * timestamp, utility, gate decision + costScore. Body follows verbatim.
+ *
+ * Concurrent appends serialize via the same lock pattern used by appendBlock
+ * for per-agent CLAUDE.md.
+ */
+export async function appendToLocalClaudeQueue(
+  input: AppendLocalClaudeQueueInput,
+): Promise<AppendLocalClaudeQueueOutcome> {
+  const filePath = input.filePathOverride ?? LOCAL_CLAUDE_QUEUE_FILE;
+  await ensureDir(path.dirname(filePath));
+  return withFileLock(filePath, async () => {
+    let current = "";
+    try {
+      current = await fs.readFile(filePath, "utf-8");
+    } catch {
+      current = "";
+    }
+    const block = formatQueueEntry(input);
+    const next =
+      current.length === 0 || current.endsWith("\n")
+        ? current + block
+        : current + "\n" + block;
+    const tmp = `${filePath}.tmp.${process.pid}.${process.hrtime.bigint()}`;
+    await fs.writeFile(tmp, next);
+    await fs.rename(tmp, filePath);
+    return {
+      filePath,
+      bytesAppended: Buffer.byteLength(block, "utf-8"),
+      totalBytes: Buffer.byteLength(next, "utf-8"),
+    };
+  });
+}
+
+function formatQueueEntry(input: AppendLocalClaudeQueueInput): string {
+  const provenance: string[] = [
+    `source=${input.sourceAgentId}`,
+    `ts=${input.ts}`,
+  ];
+  if (input.utility !== undefined && Number.isFinite(input.utility)) {
+    provenance.push(`utility=${input.utility}`);
+  }
+  if (input.gate) {
+    provenance.push(
+      `gate=${input.gate.decision}`,
+      `costScore=${input.gate.costScore.toFixed(4)}`,
+      `threshold=${input.gate.threshold.toFixed(4)}`,
+      `ratio=${input.gate.ratio}`,
+    );
+  }
+  const header = `<!-- queued ${provenance.join(" ")} -->`;
+  // Trailing blank line separates entries cleanly when concatenated.
+  return `\n${header}\n${input.body.trim()}\n`;
+}

--- a/src/agent/promotion.test.ts
+++ b/src/agent/promotion.test.ts
@@ -1,0 +1,177 @@
+// Integration test for #179 Phase 2 follow-up: acceptCandidate dispatches
+// `@local-claude` candidates to the queue file and rewrites the source
+// marker, while regular domains continue to land in the shared-pool.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { acceptCandidate, collectPendingCandidates } from "./promotion.js";
+import { agentClaudeMdPath, agentDir } from "./specialization.js";
+import { LOCAL_CLAUDE_QUEUE_FILE } from "./localClaudeQueue.js";
+import type { AgentRecord } from "../types.js";
+
+let testCounter = 0;
+function makeAgentId(): string {
+  return `agent-promotion-test-${process.pid}-${++testCounter}`;
+}
+
+function makeAgentRecord(agentId: string): AgentRecord {
+  return {
+    agentId,
+    createdAt: "2026-05-06T00:00:00.000Z",
+    tags: [],
+    issuesHandled: 0,
+    implementCount: 0,
+    pushbackCount: 0,
+    errorCount: 0,
+    lastActiveAt: "2026-05-06T00:00:00.000Z",
+  };
+}
+
+async function withTestAgent<T>(
+  initialClaudeMd: string,
+  fn: (agentId: string, agent: AgentRecord) => Promise<T>,
+): Promise<T> {
+  const agentId = makeAgentId();
+  const dir = agentDir(agentId);
+  await fs.mkdir(dir, { recursive: true });
+  const claudeMdPath = agentClaudeMdPath(agentId);
+  await fs.writeFile(claudeMdPath, initialClaudeMd);
+  try {
+    return await fn(agentId, makeAgentRecord(agentId));
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+    await fs.rm(`${claudeMdPath}.lock`, { force: true });
+  }
+}
+
+async function withCleanQueueFile<T>(fn: () => Promise<T>): Promise<T> {
+  let backup: string | null = null;
+  try {
+    backup = await fs.readFile(LOCAL_CLAUDE_QUEUE_FILE, "utf-8");
+  } catch {
+    backup = null;
+  }
+  try {
+    await fs.rm(LOCAL_CLAUDE_QUEUE_FILE, { force: true });
+    await fs.rm(`${LOCAL_CLAUDE_QUEUE_FILE}.lock`, { force: true });
+    return await fn();
+  } finally {
+    if (backup !== null) {
+      await fs.writeFile(LOCAL_CLAUDE_QUEUE_FILE, backup);
+    } else {
+      await fs.rm(LOCAL_CLAUDE_QUEUE_FILE, { force: true });
+    }
+    await fs.rm(`${LOCAL_CLAUDE_QUEUE_FILE}.lock`, { force: true });
+  }
+}
+
+test("acceptCandidate: @local-claude routes to queue file (not pool)", async () => {
+  const md = [
+    "# Test agent",
+    "",
+    "<!-- promote-candidate:@local-claude utility=0.7 -->",
+    "Project-wide rule about pre-dispatch checks.",
+    "<!-- /promote-candidate -->",
+  ].join("\n");
+  await withCleanQueueFile(async () => {
+    await withTestAgent(md, async (agentId, agent) => {
+      const pending = await collectPendingCandidates([agent]);
+      assert.equal(pending.length, 1);
+      assert.equal(pending[0].candidate.domain, "@local-claude");
+      assert.equal(pending[0].candidate.utility, 0.7);
+
+      const result = await acceptCandidate({
+        pending: pending[0],
+        tier: "target",
+      });
+      assert.equal(result.rewroteSource, true);
+      assert.ok(result.localQueueOutcome);
+      assert.equal(result.appendOutcome, undefined);
+
+      // Queue file gained the entry.
+      const queueContent = await fs.readFile(LOCAL_CLAUDE_QUEUE_FILE, "utf-8");
+      assert.match(queueContent, new RegExp(`source=${agentId}`));
+      assert.match(queueContent, /utility=0\.7/);
+      assert.match(queueContent, /Project-wide rule about pre-dispatch checks\./);
+
+      // Source marker got rewritten so the candidate doesn't resurface.
+      const after = await fs.readFile(agentClaudeMdPath(agentId), "utf-8");
+      assert.match(after, /<!-- promoted:@local-claude:/);
+      assert.doesNotMatch(after, /<!-- promote-candidate:@local-claude/);
+    });
+  });
+});
+
+test("acceptCandidate: @local-claude with localGate records gate fields in queue header", async () => {
+  const md = [
+    "<!-- promote-candidate:@local-claude utility=0.85 -->",
+    "body",
+    "<!-- /promote-candidate -->",
+  ].join("\n");
+  await withCleanQueueFile(async () => {
+    await withTestAgent(md, async (_agentId, agent) => {
+      const pending = await collectPendingCandidates([agent]);
+      await acceptCandidate({
+        pending: pending[0],
+        tier: "target",
+        localGate: {
+          decision: "let-through",
+          costScore: 0.45,
+          threshold: 0.9,
+          ratio: 2.0,
+        },
+      });
+      const queueContent = await fs.readFile(LOCAL_CLAUDE_QUEUE_FILE, "utf-8");
+      assert.match(queueContent, /gate=let-through/);
+      assert.match(queueContent, /costScore=0\.4500/);
+      assert.match(queueContent, /threshold=0\.9000/);
+      assert.match(queueContent, /ratio=2/);
+    });
+  });
+});
+
+test("acceptCandidate: regular domain still goes to shared-pool path (back-compat)", async () => {
+  // The pool-write isn't tested here (it would touch agents/.shared/lessons/);
+  // we just confirm the dispatch shape: appendOutcome is set, localQueueOutcome
+  // is undefined, regardless of pool-write success.
+  const md = [
+    "<!-- promote-candidate:solana -->",
+    "Solana RPC fact.",
+    "<!-- /promote-candidate -->",
+  ].join("\n");
+  await withCleanQueueFile(async () => {
+    await withTestAgent(md, async (_agentId, agent) => {
+      const pending = await collectPendingCandidates([agent]);
+      assert.equal(pending[0].candidate.domain, "solana");
+      const result = await acceptCandidate({
+        pending: pending[0],
+        tier: "target",
+      });
+      // Pool-write may or may not succeed depending on filesystem state
+      // (tier="target" writes under agents/.shared/lessons/), but the
+      // shape contract is: localQueueOutcome is NEVER set for non-@-domain.
+      assert.equal(result.localQueueOutcome, undefined);
+      assert.ok(result.appendOutcome);
+
+      // Queue file should NOT have a new entry from this run.
+      let queueContent = "";
+      try {
+        queueContent = await fs.readFile(LOCAL_CLAUDE_QUEUE_FILE, "utf-8");
+      } catch {
+        queueContent = "";
+      }
+      // No agent-promotion-test source ID should appear.
+      assert.doesNotMatch(queueContent, /agent-promotion-test/);
+
+      // Cleanup the pool file the accept created (to keep tests clean).
+      const poolPath = path.resolve(
+        process.cwd(),
+        "agents/.shared/lessons/solana.md",
+      );
+      await fs.rm(poolPath, { force: true }).catch(() => {});
+      await fs.rm(`${poolPath}.lock`, { force: true }).catch(() => {});
+    });
+  });
+});

--- a/src/agent/promotion.ts
+++ b/src/agent/promotion.ts
@@ -11,12 +11,18 @@ import {
   type AppendLessonOutcome,
   type LessonTier,
 } from "./sharedLessons.js";
+import {
+  appendToLocalClaudeQueue,
+  type AppendLocalClaudeQueueOutcome,
+  type LocalClaudeUtilityGateResult,
+} from "./localClaudeQueue.js";
 import { agentClaudeMdPath } from "./specialization.js";
 import { withFileLock } from "../state/locks.js";
 import {
   findPromoteCandidates,
   formatNotPromotedSentinel,
   formatPromotedSentinel,
+  isLocalClaudeCandidate,
   rewriteCandidateWrapping,
   validateEntry,
   type PromoteCandidate,
@@ -61,9 +67,12 @@ export async function collectPendingCandidates(
 }
 
 export interface AcceptResult {
-  appendOutcome: AppendLessonOutcome;
+  /** Set when domain is a regular shared-pool target (existing path). */
+  appendOutcome?: AppendLessonOutcome;
+  /** Set when domain is `@local-claude` (queue-file path; new in #194 follow-up). */
+  localQueueOutcome?: AppendLocalClaudeQueueOutcome;
   /** True only when the source CLAUDE.md was rewritten — i.e. the entry was
-   * appended successfully AND the marker was rewritten. */
+   * appended/queued successfully AND the marker was rewritten. */
   rewroteSource: boolean;
 }
 
@@ -76,6 +85,12 @@ export interface AcceptResult {
  * acceptable: humans resolve duplicates by editing the pool by hand). The
  * inverse failure (rewrite without append) is impossible because we only
  * touch the source after the pool append commits.
+ *
+ * For `@local-claude` domain (#179 Phase 2 follow-up to PR #190 + #193): the
+ * write goes to `state/local-claude-md-pending.md` (queue file) instead of
+ * the shared-pool. Operator reads the queue, opens a chore PR appending
+ * selected sections to project-local CLAUDE.md by hand. `tier` is ignored
+ * for this branch.
  */
 export async function acceptCandidate(input: {
   pending: PendingCandidate;
@@ -83,18 +98,38 @@ export async function acceptCandidate(input: {
    * Destination tier for the accepted entry. "target" appends to
    * `agents/.shared/lessons/<domain>.md`; "global" appends to the
    * cross-target-repo pool under `~/.vaultpilot/shared-lessons/<domain>.md`.
-   * The source-CLAUDE.md sentinel rewrite is the same for both — only the
-   * write target differs (#101).
+   * Ignored when `pending.candidate.domain === "@local-claude"` — that path
+   * routes to the local-CLAUDE.md queue file regardless of tier (#101).
    */
   tier: LessonTier;
   ts?: string;
   issueId?: number;
+  /** Optional L2 gate result captured at accept time, recorded in the queue header. */
+  localGate?: LocalClaudeUtilityGateResult;
 }): Promise<AcceptResult> {
   const ts = input.ts ?? new Date().toISOString();
+  const candidate = input.pending.candidate;
+
+  if (isLocalClaudeCandidate(candidate.domain)) {
+    const localQueueOutcome = await appendToLocalClaudeQueue({
+      sourceAgentId: input.pending.agentId,
+      ts,
+      utility: candidate.utility,
+      gate: input.localGate,
+      body: candidate.body,
+    });
+    await rewriteSourceMarker({
+      agentId: input.pending.agentId,
+      candidate,
+      replacement: formatPromotedSentinel(candidate.domain, ts),
+    });
+    return { localQueueOutcome, rewroteSource: true };
+  }
+
   const appendOutcome = await appendLessonToPool({
     tier: input.tier,
-    domain: input.pending.candidate.domain,
-    body: input.pending.candidate.body,
+    domain: candidate.domain,
+    body: candidate.body,
     sourceAgentId: input.pending.agentId,
     issueId: input.issueId ?? 0,
     ts,
@@ -104,8 +139,8 @@ export async function acceptCandidate(input: {
   }
   await rewriteSourceMarker({
     agentId: input.pending.agentId,
-    candidate: input.pending.candidate,
-    replacement: formatPromotedSentinel(input.pending.candidate.domain, ts),
+    candidate,
+    replacement: formatPromotedSentinel(candidate.domain, ts),
   });
   return { appendOutcome, rewroteSource: true };
 }

--- a/src/agent/summarizer.ts
+++ b/src/agent/summarizer.ts
@@ -256,6 +256,15 @@ Cross-agent promotion (optional, gated by human review):
 - Cap the wrapped content at ~40 non-empty lines / ~1500 chars. Anything longer is too coarse to share.
 - Promote-candidates are queued for human review; they do NOT auto-promote. Use sparingly — most lessons stay agent-local.
 
+Project-wide promotion (rare, gated by stricter review):
+- If a piece of the lesson would help EVERY agent dispatched on this repo — a process habit, a pre-dispatch check, a harness gotcha, a build/CI rule — wrap that piece with the special domain \`@local-claude\` and an explicit utility self-rating:
+    <!-- promote-candidate:@local-claude utility=0.X -->
+    <descriptive observation, multiple lines OK>
+    <!-- /promote-candidate -->
+- Reserve for genuine project-tooling discipline. NOT for crypto specialties or domain-specific facts (those use the regular \`<domain>\` form above) — those have a per-domain audience, not project-wide.
+- The \`utility=0.X\` value (in [0, 1]) MUST be present for \`@local-claude\` candidates. The harness gates these against project-local CLAUDE.md cost at a stricter ratio (default 2.0 vs 1.0 for personal lessons), because bytes added there are loaded into every dispatch's prompt by every agent. Calibrate honestly: 0.7+ for genuinely project-wide rules with concrete tells, 0.4–0.6 for borderline (likely to be rejected by the L2 gate), below that don't bother wrapping.
+- Same descriptive-observation voice rule as cross-agent promotion above.
+
 Hard rules:
 - If there is no GENERALIZABLE lesson — only a one-off fix, a routine implementation, a trivial pushback — return {"skip": true, "skipReason": "<one short sentence>"}. Empty learnings beat noisy ones.
 - If the agent failed (decision="error"), default to skip unless there's a clear lesson about the failure mode itself.
@@ -297,6 +306,13 @@ Cross-agent promotion (optional, gated by human review):
 - The wrapped content must read as a DESCRIPTIVE OBSERVATION, not an instruction to other agents. Avoid "you must / should", "the agent must" — use indicative voice.
 - Cap the wrapped content at ~40 non-empty lines / ~1500 chars.
 - Promote-candidates are queued for human review; they do NOT auto-promote. The human reviewer rejects noise.
+
+Project-wide promotion (rare, gated by stricter review):
+- If the failure mode is a project-tooling habit that EVERY agent dispatched on this repo would benefit from (pre-dispatch checks, harness gotchas, dispatch-flow rules), wrap that piece with the special domain \`@local-claude\` and an explicit utility self-rating:
+    <!-- promote-candidate:@local-claude utility=0.X -->
+    <descriptive observation, multiple lines OK>
+    <!-- /promote-candidate -->
+- Reserve for genuine project-tooling discipline — NOT for SDK/protocol/specialty facts (those use the regular \`<domain>\` form). The harness gates these against project-local CLAUDE.md cost at a stricter ratio (default 2.0 vs 1.0 for personal). Calibrate honestly: 0.7+ for genuinely project-wide rules with concrete tells, 0.4–0.6 for borderline. Same descriptive-observation voice rule.
 
 Predicted-utility self-rating (issue #179, half-ready-curve probe):
 - For every non-skip failure-lesson emission, ALSO emit \`predictedUtility\` — a number in [0, 1] estimating how much future-leverage the lesson carries. Failure lessons skew higher than success lessons because they capture signal that's normally lost; calibration:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -120,6 +120,10 @@ import {
   evaluateLocalClaudeUtilityGate,
   type LocalClaudeUtilityGateResult,
 } from "./agent/localClaudeQueue.js";
+import {
+  openLocalClaudePr,
+  type OpenLocalClaudePrOutcome,
+} from "./agent/localClaudePr.js";
 import { isLocalClaudeCandidate } from "./util/promotionMarkers.js";
 import {
   applyTrimProposal,
@@ -437,6 +441,10 @@ export function buildCli(): Command {
         .option("--json", "Print machine-readable JSON listing of pending candidates and exit (no mutation)")
         .option("--yes", "Auto-accept every candidate that passes validation (non-interactive use only)")
         .option("--global", "Append accepted entries to the global pool (~/.vaultpilot/shared-lessons/) instead of the per-target pool")
+        .option(
+          "--pr",
+          "For `@local-claude` candidates: open a chore PR appending the lesson to project-local CLAUDE.md instead of staging to the queue file. With --yes, autonomous: gate=let-through → PR; gate=skip → queue. PR failures fall back to the queue so data isn't lost. Operator-invoked CLI flow — exempt from the in-run write-side-effect rule.",
+        )
         .action(async (opts) => {
           await cmdLessonsReview(opts);
         }),
@@ -2856,6 +2864,7 @@ interface LessonsReviewOpts {
   json?: boolean;
   yes?: boolean;
   global?: boolean;
+  pr?: boolean;
 }
 
 async function cmdLessonsReview(opts: LessonsReviewOpts): Promise<void> {
@@ -2899,7 +2908,7 @@ async function cmdLessonsReview(opts: LessonsReviewOpts): Promise<void> {
   );
 
   if (opts.yes) {
-    await runAutoAcceptLoop(pending, tier);
+    await runAutoAcceptLoop(pending, tier, !!opts.pr);
     return;
   }
 
@@ -2910,7 +2919,7 @@ async function cmdLessonsReview(opts: LessonsReviewOpts): Promise<void> {
     process.exit(2);
   }
 
-  await runInteractiveReview(pending, tier);
+  await runInteractiveReview(pending, tier, !!opts.pr);
 }
 
 /**
@@ -2937,7 +2946,31 @@ async function computeLocalClaudeGate(
   });
 }
 
-async function runAutoAcceptLoop(pending: PendingCandidate[], tier: LessonTier): Promise<void> {
+/**
+ * Try to open a PR for an accepted @local-claude candidate. On any failure,
+ * caller falls back to the queue path so the lesson isn't lost. Returns the
+ * outcome (with PR URL on success) or null when the path doesn't apply.
+ */
+async function tryOpenLocalClaudePr(
+  p: PendingCandidate,
+  ts: string,
+  gate: LocalClaudeUtilityGateResult | null,
+): Promise<OpenLocalClaudePrOutcome | null> {
+  if (!isLocalClaudeCandidate(p.candidate.domain)) return null;
+  return openLocalClaudePr({
+    sourceAgentId: p.agentId,
+    ts,
+    utility: p.candidate.utility,
+    gate: gate ?? undefined,
+    body: p.candidate.body,
+  });
+}
+
+async function runAutoAcceptLoop(
+  pending: PendingCandidate[],
+  tier: LessonTier,
+  usePr: boolean,
+): Promise<void> {
   let acceptedCount = 0;
   let rejectedCount = 0;
   let skippedCount = 0;
@@ -2958,6 +2991,32 @@ async function runAutoAcceptLoop(pending: PendingCandidate[], tier: LessonTier):
       );
       skippedCount += 1;
       continue;
+    }
+    // Autonomous PR path (#196 Phase 2): when --pr is set AND the local
+    // gate is let-through, open a chore PR directly. Failure falls back to
+    // the queue path so the lesson isn't lost.
+    if (usePr && localGate && localGate.decision === "let-through") {
+      const ts = new Date().toISOString();
+      const prOutcome = await tryOpenLocalClaudePr(p, ts, localGate);
+      if (prOutcome && prOutcome.kind === "pr-opened") {
+        // Rewrite the source marker so the candidate doesn't resurface.
+        await rejectCandidate({
+          pending: p,
+          reason: `promoted-local via PR ${prOutcome.prUrl}`,
+          ts,
+        }).catch(() => {});
+        process.stdout.write(
+          `accepted [@local-claude] ${p.agentId} -> PR ${prOutcome.prUrl} (branch ${prOutcome.branchName})\n`,
+        );
+        acceptedCount += 1;
+        continue;
+      }
+      if (prOutcome && prOutcome.kind === "pr-failed") {
+        process.stdout.write(
+          `PR-creation failed (${prOutcome.reason}); falling back to queue.\n`,
+        );
+      }
+      // fall through to queue
     }
     const result = await acceptCandidate({
       pending: p,
@@ -2994,7 +3053,11 @@ async function runAutoAcceptLoop(pending: PendingCandidate[], tier: LessonTier):
   );
 }
 
-async function runInteractiveReview(pending: PendingCandidate[], tier: LessonTier): Promise<void> {
+async function runInteractiveReview(
+  pending: PendingCandidate[],
+  tier: LessonTier,
+  usePr: boolean,
+): Promise<void> {
   const { createInterface } = await import("node:readline/promises");
   const rl = createInterface({ input: process.stdin, output: process.stdout });
   let acceptedCount = 0;
@@ -3038,6 +3101,31 @@ async function runInteractiveReview(pending: PendingCandidate[], tier: LessonTie
           process.stdout.write("Cannot accept — validation failed. Treating as skip.\n");
           skippedCount += 1;
           continue;
+        }
+        // Interactive --pr: try to open a PR for an accepted @local-claude
+        // candidate (operator's accept overrides the L2 gate). On PR
+        // failure, fall back to the queue path.
+        if (usePr && isLocalClaudeCandidate(p.candidate.domain)) {
+          const ts = new Date().toISOString();
+          const prOutcome = await tryOpenLocalClaudePr(p, ts, localGate);
+          if (prOutcome && prOutcome.kind === "pr-opened") {
+            await rejectCandidate({
+              pending: p,
+              reason: `promoted-local via PR ${prOutcome.prUrl}`,
+              ts,
+            }).catch(() => {});
+            process.stdout.write(
+              `Accepted [@local-claude]: opened PR ${prOutcome.prUrl} (branch ${prOutcome.branchName}).\n`,
+            );
+            acceptedCount += 1;
+            continue;
+          }
+          if (prOutcome && prOutcome.kind === "pr-failed") {
+            process.stdout.write(
+              `PR-creation failed (${prOutcome.reason}); falling back to queue.\n`,
+            );
+          }
+          // fall through to queue
         }
         const result = await acceptCandidate({
           pending: p,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -117,6 +117,11 @@ import {
   type LessonTier,
 } from "./agent/sharedLessons.js";
 import {
+  evaluateLocalClaudeUtilityGate,
+  type LocalClaudeUtilityGateResult,
+} from "./agent/localClaudeQueue.js";
+import { isLocalClaudeCandidate } from "./util/promotionMarkers.js";
+import {
   applyTrimProposal,
   formatTrimProposal,
   proposeTrim,
@@ -2908,6 +2913,30 @@ async function cmdLessonsReview(opts: LessonsReviewOpts): Promise<void> {
   await runInteractiveReview(pending, tier);
 }
 
+/**
+ * Read the project-local CLAUDE.md size (cwd-relative) and run the L2 gate
+ * for an `@local-claude` candidate. Returns `null` for non-local domains so
+ * the caller skips this branch cleanly.
+ */
+async function computeLocalClaudeGate(
+  p: PendingCandidate,
+): Promise<LocalClaudeUtilityGateResult | null> {
+  if (!isLocalClaudeCandidate(p.candidate.domain)) return null;
+  let currentBytes = 0;
+  try {
+    const content = await fs.readFile("CLAUDE.md", "utf-8");
+    currentBytes = Buffer.byteLength(content, "utf-8");
+  } catch {
+    // No project CLAUDE.md → treat as zero-cost; gate will let through.
+  }
+  const candidateBytes = Buffer.byteLength(p.candidate.body, "utf-8");
+  return evaluateLocalClaudeUtilityGate({
+    utility: p.candidate.utility,
+    currentLocalClaudeMdBytes: currentBytes,
+    candidateBytes,
+  });
+}
+
 async function runAutoAcceptLoop(pending: PendingCandidate[], tier: LessonTier): Promise<void> {
   let acceptedCount = 0;
   let rejectedCount = 0;
@@ -2920,15 +2949,37 @@ async function runAutoAcceptLoop(pending: PendingCandidate[], tier: LessonTier):
       rejectedCount += 1;
       continue;
     }
-    const result = await acceptCandidate({ pending: p, tier });
-    if (result.appendOutcome.kind === "appended") {
+    const localGate = await computeLocalClaudeGate(p);
+    if (localGate && localGate.decision === "skip") {
+      // Auto-accept: respect the L2 gate and skip — the operator can re-run
+      // interactively to override.
       process.stdout.write(
-        `accepted [${tier}] ${p.agentId} -> ${p.candidate.domain} (${result.appendOutcome.totalLines}/${MAX_POOL_LINES} lines)\n`,
+        `skipped (local-gate: utility=${p.candidate.utility ?? "n/a"} < threshold=${localGate.threshold.toFixed(3)}) ${p.agentId} -> ${p.candidate.domain}\n`,
+      );
+      skippedCount += 1;
+      continue;
+    }
+    const result = await acceptCandidate({
+      pending: p,
+      tier,
+      localGate: localGate ?? undefined,
+    });
+    if (result.localQueueOutcome) {
+      process.stdout.write(
+        `accepted [@local-claude] ${p.agentId} -> queued at ${result.localQueueOutcome.filePath} (${result.localQueueOutcome.totalBytes} bytes total)\n`,
       );
       acceptedCount += 1;
-    } else if (result.appendOutcome.kind === "rejected-pool-full") {
+      continue;
+    }
+    const ao = result.appendOutcome;
+    if (ao && ao.kind === "appended") {
       process.stdout.write(
-        `skipped (pool full) [${tier}] ${p.agentId} -> ${p.candidate.domain}: ${result.appendOutcome.totalLines}/${MAX_POOL_LINES} lines. Trim the pool by hand and re-run review.\n`,
+        `accepted [${tier}] ${p.agentId} -> ${p.candidate.domain} (${ao.totalLines}/${MAX_POOL_LINES} lines)\n`,
+      );
+      acceptedCount += 1;
+    } else if (ao && ao.kind === "rejected-pool-full") {
+      process.stdout.write(
+        `skipped (pool full) [${tier}] ${p.agentId} -> ${p.candidate.domain}: ${ao.totalLines}/${MAX_POOL_LINES} lines. Trim the pool by hand and re-run review.\n`,
       );
       skippedCount += 1;
     } else {
@@ -2957,6 +3008,18 @@ async function runInteractiveReview(pending: PendingCandidate[], tier: LessonTie
       process.stdout.write(`source:  ${sourceLabel}\n`);
       process.stdout.write(`domain:  ${p.candidate.domain}\n`);
       process.stdout.write(`source CLAUDE.md lines ${p.candidate.startLine + 1}..${p.candidate.endLine + 1}\n`);
+      const localGate = await computeLocalClaudeGate(p);
+      if (localGate) {
+        const utility = p.candidate.utility ?? undefined;
+        process.stdout.write(
+          `local-gate: utility=${utility ?? "n/a"} costScore=${localGate.costScore.toFixed(3)} threshold=${localGate.threshold.toFixed(3)} ratio=${localGate.ratio} decision=${localGate.decision}\n`,
+        );
+        if (localGate.decision === "skip") {
+          process.stdout.write(
+            `WARNING: utility below threshold — accept anyway only if the lesson is genuinely project-wide.\n`,
+          );
+        }
+      }
       if (p.validation.errors.length > 0) {
         process.stdout.write(`errors:  ${p.validation.errors.join("; ")}\n`);
       }
@@ -2976,19 +3039,35 @@ async function runInteractiveReview(pending: PendingCandidate[], tier: LessonTie
           skippedCount += 1;
           continue;
         }
-        const result = await acceptCandidate({ pending: p, tier });
-        if (result.appendOutcome.kind === "appended") {
+        const result = await acceptCandidate({
+          pending: p,
+          tier,
+          localGate: localGate ?? undefined,
+        });
+        if (result.localQueueOutcome) {
           process.stdout.write(
-            `Accepted [${tier}]: appended to ${result.appendOutcome.filePath} (${result.appendOutcome.totalLines}/${MAX_POOL_LINES} lines).\n`,
+            `Accepted [@local-claude]: queued to ${result.localQueueOutcome.filePath} (${result.localQueueOutcome.totalBytes} bytes total).\n` +
+              `Read the queue and open a chore PR appending the section(s) to project-local CLAUDE.md.\n`,
           );
           acceptedCount += 1;
-        } else if (result.appendOutcome.kind === "rejected-pool-full") {
+          continue;
+        }
+        const ao = result.appendOutcome;
+        if (ao && ao.kind === "appended") {
           process.stdout.write(
-            `POOL FULL: ${result.appendOutcome.filePath} reached ${result.appendOutcome.totalLines}/${MAX_POOL_LINES} lines. Trim the pool file by hand and re-run review for this candidate. (Marker left in source CLAUDE.md.)\n`,
+            `Accepted [${tier}]: appended to ${ao.filePath} (${ao.totalLines}/${MAX_POOL_LINES} lines).\n`,
+          );
+          acceptedCount += 1;
+        } else if (ao && ao.kind === "rejected-pool-full") {
+          process.stdout.write(
+            `POOL FULL: ${ao.filePath} reached ${ao.totalLines}/${MAX_POOL_LINES} lines. Trim the pool file by hand and re-run review for this candidate. (Marker left in source CLAUDE.md.)\n`,
           );
           skippedCount += 1;
+        } else if (ao) {
+          process.stdout.write(`Append refused (validation): ${ao.validation.errors.join("; ")}\n`);
+          skippedCount += 1;
         } else {
-          process.stdout.write(`Append refused (validation): ${result.appendOutcome.validation.errors.join("; ")}\n`);
+          process.stdout.write(`Append refused: no outcome returned (unexpected).\n`);
           skippedCount += 1;
         }
         continue;

--- a/src/util/promotionMarkers.test.ts
+++ b/src/util/promotionMarkers.test.ts
@@ -1,11 +1,13 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
+  LOCAL_CLAUDE_DOMAIN,
   MAX_ENTRY_CHARS,
   MAX_ENTRY_LINES,
   findPromoteCandidates,
   formatNotPromotedSentinel,
   formatPromotedSentinel,
+  isLocalClaudeCandidate,
   isValidDomain,
   rewriteCandidateWrapping,
   validateEntry,
@@ -206,4 +208,99 @@ test("formatPromotedSentinel and formatNotPromotedSentinel produce stable shapes
     formatNotPromotedSentinel("imperative phrasing", "2026-05-04T00:00:00.000Z"),
     "<!-- not-promoted:imperative phrasing:2026-05-04T00:00:00.000Z -->",
   );
+});
+
+// ---------------------------------------------------------------------
+// #179 Phase 2 follow-up: @local-claude domain + utility=N.M parsing
+// ---------------------------------------------------------------------
+
+test("LOCAL_CLAUDE_DOMAIN is the literal @local-claude string", () => {
+  assert.equal(LOCAL_CLAUDE_DOMAIN, "@local-claude");
+});
+
+test("isValidDomain: accepts @local-claude", () => {
+  assert.equal(isValidDomain("@local-claude"), true);
+});
+
+test("isValidDomain: rejects other @-prefixed domains", () => {
+  assert.equal(isValidDomain("@solana"), false);
+  assert.equal(isValidDomain("@local"), false);
+  assert.equal(isValidDomain("@"), false);
+});
+
+test("isLocalClaudeCandidate: matches only @local-claude", () => {
+  assert.equal(isLocalClaudeCandidate("@local-claude"), true);
+  assert.equal(isLocalClaudeCandidate("solana"), false);
+  assert.equal(isLocalClaudeCandidate("@solana"), false);
+});
+
+test("findPromoteCandidates: parses @local-claude with utility=0.85", () => {
+  const md = [
+    "<!-- promote-candidate:@local-claude utility=0.85 -->",
+    "Project-wide rule body.",
+    "<!-- /promote-candidate -->",
+  ].join("\n");
+  const found = findPromoteCandidates(md);
+  assert.equal(found.length, 1);
+  assert.equal(found[0].domain, "@local-claude");
+  assert.equal(found[0].utility, 0.85);
+});
+
+test("findPromoteCandidates: @local-claude without utility parses with utility undefined", () => {
+  const md = [
+    "<!-- promote-candidate:@local-claude -->",
+    "body",
+    "<!-- /promote-candidate -->",
+  ].join("\n");
+  const found = findPromoteCandidates(md);
+  assert.equal(found.length, 1);
+  assert.equal(found[0].domain, "@local-claude");
+  assert.equal(found[0].utility, undefined);
+});
+
+test("findPromoteCandidates: utility=0 and utility=1 are accepted boundary values", () => {
+  const md = [
+    "<!-- promote-candidate:@local-claude utility=0 -->",
+    "low-utility body",
+    "<!-- /promote-candidate -->",
+    "intermezzo",
+    "<!-- promote-candidate:@local-claude utility=1 -->",
+    "high-utility body",
+    "<!-- /promote-candidate -->",
+  ].join("\n");
+  const found = findPromoteCandidates(md);
+  assert.equal(found.length, 2);
+  assert.equal(found[0].utility, 0);
+  assert.equal(found[1].utility, 1);
+});
+
+test("findPromoteCandidates: regular domain with utility= is also parsed (back-compat)", () => {
+  // The marker grammar allows utility on any domain; the L2 gate only
+  // applies it for @local-claude. Regular domains carrying utility just
+  // ignore the field. Accept-and-ignore is more forgiving than reject.
+  const md = [
+    "<!-- promote-candidate:solana utility=0.5 -->",
+    "body",
+    "<!-- /promote-candidate -->",
+  ].join("\n");
+  const found = findPromoteCandidates(md);
+  assert.equal(found.length, 1);
+  assert.equal(found[0].domain, "solana");
+  assert.equal(found[0].utility, 0.5);
+});
+
+test("rewriteCandidateWrapping: still works for @local-claude", () => {
+  const md = [
+    "<!-- promote-candidate:@local-claude utility=0.7 -->",
+    "rule body",
+    "<!-- /promote-candidate -->",
+  ].join("\n");
+  const [c] = findPromoteCandidates(md);
+  const rewritten = rewriteCandidateWrapping(
+    md,
+    c,
+    formatPromotedSentinel("@local-claude", "T"),
+  );
+  assert.match(rewritten, /<!-- promoted:@local-claude:T -->/);
+  assert.deepEqual(findPromoteCandidates(rewritten), []);
 });

--- a/src/util/promotionMarkers.ts
+++ b/src/util/promotionMarkers.ts
@@ -20,14 +20,35 @@
 // reads like instructions to a sibling agent.
 
 const DOMAIN_RE = /^[a-z][a-z0-9-]*$/;
-const PROMOTE_OPEN_RE = /^\s*<!--\s*promote-candidate:([a-z][a-z0-9-]*)\s*-->\s*$/;
+
+/**
+ * Special domain reserved for project-local CLAUDE.md candidates (#179
+ * Phase 2 follow-up). The summarizer wraps a project-wide rule with this
+ * domain when the lesson should land in the repo's tracked CLAUDE.md
+ * rather than the per-domain shared-lessons pool. Operator-side
+ * `vp-dev lessons review` routes accepted entries to a queue file
+ * (`state/local-claude-md-pending.md`) instead of the pool, applying a
+ * stricter utility-vs-cost gate against the local CLAUDE.md size.
+ *
+ * Reserves the `@`-prefix character class for future special domains.
+ * Today only `@local-claude` is accepted.
+ */
+export const LOCAL_CLAUDE_DOMAIN = "@local-claude";
+
+const PROMOTE_OPEN_RE =
+  /^\s*<!--\s*promote-candidate:(@local-claude|[a-z][a-z0-9-]*)(?:\s+utility=([0-9](?:\.[0-9]+)?))?\s*-->\s*$/;
 const PROMOTE_CLOSE_RE = /^\s*<!--\s*\/promote-candidate\s*-->\s*$/;
 
 export const MAX_ENTRY_LINES = 40;
 export const MAX_ENTRY_CHARS = 1500;
 
 export function isValidDomain(s: string): boolean {
+  if (s === LOCAL_CLAUDE_DOMAIN) return true;
   return DOMAIN_RE.test(s);
+}
+
+export function isLocalClaudeCandidate(domain: string): boolean {
+  return domain === LOCAL_CLAUDE_DOMAIN;
 }
 
 export interface PromoteCandidate {
@@ -37,6 +58,14 @@ export interface PromoteCandidate {
   startLine: number;
   /** 0-based line index of the closing `<!-- /promote-candidate -->` (inclusive). */
   endLine: number;
+  /**
+   * Optional `utility=N.M` value parsed from the marker. Used by the
+   * operator-side L2 gate for `@local-claude` candidates (utility vs
+   * local-CLAUDE.md cost). Absent when the summarizer didn't emit it; the
+   * gate then falls back to the outer `SummarizerOutput.predictedUtility`
+   * recorded elsewhere, or skips the gate if neither is available.
+   */
+  utility?: number;
 }
 
 /**
@@ -55,6 +84,11 @@ export function findPromoteCandidates(content: string): PromoteCandidate[] {
       continue;
     }
     const domain = open[1];
+    const utilityRaw = open[2];
+    const utility =
+      utilityRaw !== undefined && utilityRaw !== ""
+        ? Number(utilityRaw)
+        : undefined;
     let close = -1;
     for (let j = i + 1; j < lines.length; j++) {
       // Reject nested opens — treat as malformed and skip the outer.
@@ -74,7 +108,11 @@ export function findPromoteCandidates(content: string): PromoteCandidate[] {
       continue;
     }
     const body = lines.slice(i + 1, close).join("\n");
-    out.push({ domain, body, startLine: i, endLine: close });
+    const candidate: PromoteCandidate = { domain, body, startLine: i, endLine: close };
+    if (utility !== undefined && Number.isFinite(utility)) {
+      candidate.utility = utility;
+    }
+    out.push(candidate);
     i = close + 1;
   }
   return out;


### PR DESCRIPTION
## Summary

Lets the summarizer flag lessons that should land in the **project-local** `CLAUDE.md` (loaded LIVE into every dispatch by `buildAgentSystemPrompt`) rather than the per-agent file or the per-domain shared-pool. Operator-side `vp-dev lessons review` runs an **L2 cost-vs-utility gate** against the local CLAUDE.md size and stages accepted candidates in `state/local-claude-md-pending.md` (gitignored). Operator opens a chore PR from the queue — same workflow as [PR #194](https://github.com/szhygulin/vaultpilot-development-agents/pull/194), but the transcription step from agent output to PR body is now automated.

Builds on [PR #190](https://github.com/szhygulin/vaultpilot-development-agents/pull/190) (per-agent F+G+C+J pipeline) and [PR #193](https://github.com/szhygulin/vaultpilot-development-agents/pull/193) (per-agent B gate).

## Marker format

Reuses the existing `<!-- promote-candidate:<domain> -->` infrastructure with a special domain `@local-claude` (the only `@`-prefixed domain authorized today; reserves `@`-prefix for future special domains):

```
<!-- promote-candidate:@local-claude utility=0.85 -->
**When the issue body mentions a bake-window**, treat elapsed time since the predecessor PR merged as a separate hard gate.

**Tells:** "do not dispatch until #X has run for at least N months", "mirroring the #X → #Y deferral".
<!-- /promote-candidate -->
```

`utility=N.M` is parsed from the marker; required for `@local-claude` per the prompt instruction.

## Two-layer gating (same shape as personal lessons)

| Layer | When | Cost target | Default ratio |
|---|---|---|---|
| **L1 — agent-side** (existing) | Summarizer emit time, before per-agent `appendBlock` | per-agent CLAUDE.md size | 1.0 |
| **L2 — operator-side** (new) | `vp-dev lessons review` accept time | **local CLAUDE.md size** (amplified across every dispatch) | **2.0** (`VP_DEV_LOCAL_CLAUDE_UTILITY_RATIO` overrides) |

L2 is stricter because bytes added to local CLAUDE.md are loaded into every dispatch's prompt by every agent — marginal cost is amplified.

## Operator UX

```
$ vp-dev lessons review
--- candidate 1/1 ---
source:  Joseph (agent-916a-trim-6000-s8026)
domain:  @local-claude
source CLAUDE.md lines 5..14
local-gate: utility=0.85 costScore=0.412 threshold=0.823 ratio=2 decision=let-through

--- body ---
**When the issue body mentions a bake-window**, treat elapsed time since...
--- /body ---

Action [a]ccept / [r]eject / [s]kip? a
Accepted [@local-claude]: queued to state/local-claude-md-pending.md (1234 bytes total).
Read the queue and open a chore PR appending the section(s) to project-local CLAUDE.md.
```

When the L2 gate would skip (`utility < threshold`), the UI prints a WARNING but still allows manual accept.

## Files

| File | Change |
|---|---|
| `src/util/promotionMarkers.ts` | Widen regex to accept `@local-claude` + parse optional `utility=N.M` |
| `src/agent/localClaudeQueue.ts` (NEW) | `appendToLocalClaudeQueue` + `evaluateLocalClaudeUtilityGate` + ratio resolver |
| `src/agent/promotion.ts` `acceptCandidate` | Branch on `isLocalClaudeCandidate(domain)` |
| `src/agent/summarizer.ts` | "Project-wide promotion (rare)" sub-section in both system prompts |
| `src/cli.ts` `cmdLessonsReview` | Compute L2 gate for `@local-claude`; render in UI; branch accept by domain |

## Phase 2 deferred

- Auto-open chore PR via `vp-dev lessons review --pr` (shell out to `gh pr create`).
- Body-level Jaccard dedup against existing local CLAUDE.md sections (heading-only via the read-side dedup in `buildAgentSystemPrompt` is sufficient for now).
- `vp-dev lessons clear-local-queue --merged` to drop already-merged entries.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm test` — **598/598 pass** (574 baseline + 24 new)

Coverage:
- `promotionMarkers`: `@local-claude` accepted; `utility=0/1` boundary parsed; missing-utility leaves field undefined; non-`@local-claude` `@`-prefixed domains rejected; `rewriteCandidateWrapping` works for the new domain (8 tests).
- `localClaudeQueue`: gate paths (no-utility / let-through / skip / ratio override / fields populated); env resolver (default / valid / invalid); queue writer (provenance header / missing utility / multi-entry / concurrent serialize via lock — uses tmp-path override for parallel test isolation; 13 tests).
- `promotion`: end-to-end acceptCandidate dispatch (3 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)