### PR TITLE
feat(audit-lessons): per-section intrinsic quality audit (advisory Phase 1)

### DIFF
--- a/src/agent/auditLessons.test.ts
+++ b/src/agent/auditLessons.test.ts
@@ -1,0 +1,299 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  DEFAULT_MAX_COST_USD,
+  formatAuditProposal,
+  proposeAudit,
+  utilityToVerdict,
+  VERDICT_THRESHOLDS,
+  type AuditClient,
+} from "./auditLessons.js";
+
+// Build a sentinel-bearing CLAUDE.md so parseClaudeMdSections finds the
+// sections (only summarizer-emitted blocks are attributable; sections in
+// a plain markdown file with no provenance comment are silently skipped).
+function makeAttributableClaudeMd(
+  blocks: ReadonlyArray<{
+    runId: string;
+    issueId: number;
+    heading: string;
+    body: string;
+    ts: string;
+  }>,
+): string {
+  const out: string[] = ["# Test agent\n"];
+  for (const b of blocks) {
+    out.push(
+      `<!-- run:${b.runId} issue:#${b.issueId} outcome:implement ts:${b.ts} -->`,
+    );
+    out.push(`## ${b.heading}`);
+    out.push("");
+    out.push(b.body);
+    out.push("");
+  }
+  return out.join("\n");
+}
+
+async function withTempClaudeMd<T>(
+  initialContent: string,
+  fn: (filePath: string) => Promise<T>,
+): Promise<T> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "audit-lessons-test-"));
+  const filePath = path.join(dir, "CLAUDE.md");
+  await fs.writeFile(filePath, initialContent);
+  try {
+    return await fn(filePath);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------
+// utilityToVerdict
+// ---------------------------------------------------------------------
+
+test("utilityToVerdict: < drop threshold → drop", () => {
+  assert.equal(utilityToVerdict(0), "drop");
+  assert.equal(utilityToVerdict(0.1), "drop");
+  assert.equal(utilityToVerdict(0.29), "drop");
+});
+
+test("utilityToVerdict: between thresholds → weak-keep", () => {
+  assert.equal(utilityToVerdict(0.3), "weak-keep");
+  assert.equal(utilityToVerdict(0.5), "weak-keep");
+  assert.equal(utilityToVerdict(0.59), "weak-keep");
+});
+
+test("utilityToVerdict: ≥ keep threshold → keep", () => {
+  assert.equal(utilityToVerdict(0.6), "keep");
+  assert.equal(utilityToVerdict(0.85), "keep");
+  assert.equal(utilityToVerdict(1.0), "keep");
+});
+
+test("VERDICT_THRESHOLDS constants match documented bands", () => {
+  assert.equal(VERDICT_THRESHOLDS.drop, 0.3);
+  assert.equal(VERDICT_THRESHOLDS.keep, 0.6);
+});
+
+// ---------------------------------------------------------------------
+// proposeAudit: empty agent CLAUDE.md
+// ---------------------------------------------------------------------
+
+test("proposeAudit: missing CLAUDE.md returns empty proposal (no LLM calls)", async () => {
+  const tmp = path.join(os.tmpdir(), `audit-missing-${Date.now()}.md`);
+  let calls = 0;
+  const client: AuditClient = {
+    scoreSection: async () => {
+      calls += 1;
+      return { intrinsicUtility: 0.5, rationale: "should not fire", costUsd: 0.01 };
+    },
+  };
+  const proposal = await proposeAudit({
+    agentId: "agent-missing",
+    client,
+    claudeMdPathOverride: tmp,
+  });
+  assert.equal(calls, 0);
+  assert.equal(proposal.scores.length, 0);
+  assert.equal(proposal.sectionCount, 0);
+  assert.equal(proposal.totalBytes, 0);
+  assert.ok(Number.isNaN(proposal.meanUtility));
+});
+
+test("proposeAudit: CLAUDE.md without attributable sections (no sentinels) returns empty scores", async () => {
+  await withTempClaudeMd("# Plain markdown\n\n## A heading\n\nA body without sentinel.\n", async (filePath) => {
+    let calls = 0;
+    const client: AuditClient = {
+      scoreSection: async () => {
+        calls += 1;
+        return { intrinsicUtility: 0.5, rationale: "x", costUsd: 0.01 };
+      },
+    };
+    const proposal = await proposeAudit({
+      agentId: "agent-no-sentinels",
+      client,
+      claudeMdPathOverride: filePath,
+    });
+    assert.equal(calls, 0);
+    assert.equal(proposal.sectionCount, 0);
+  });
+});
+
+// ---------------------------------------------------------------------
+// proposeAudit: scoring + verdict mapping
+// ---------------------------------------------------------------------
+
+test("proposeAudit: scores every section and aggregates verdicts/cost", async () => {
+  const md = makeAttributableClaudeMd([
+    { runId: "r1", issueId: 1, heading: "Generic platitude", body: "Always test things.", ts: "2026-04-01T00:00:00Z" },
+    { runId: "r2", issueId: 2, heading: "Borderline rule", body: "Use the right tool.", ts: "2026-04-02T00:00:00Z" },
+    { runId: "r3", issueId: 3, heading: "Specific rule with file", body: "src/foo.ts:42 throws on null.", ts: "2026-04-03T00:00:00Z" },
+    { runId: "r4", issueId: 4, heading: "Anchored to past incident", body: "2026-03-01: PR #100 broke X. Use Y.", ts: "2026-04-04T00:00:00Z" },
+  ]);
+  await withTempClaudeMd(md, async (filePath) => {
+    // Synthetic ratings keyed by heading substring. Cost: $0.05 per call.
+    const client: AuditClient = {
+      scoreSection: async ({ heading }) => {
+        if (heading.includes("Generic")) return { intrinsicUtility: 0.15, rationale: "platitude", costUsd: 0.05 };
+        if (heading.includes("Borderline")) return { intrinsicUtility: 0.45, rationale: "borderline", costUsd: 0.05 };
+        if (heading.includes("Specific")) return { intrinsicUtility: 0.7, rationale: "names file path", costUsd: 0.05 };
+        return { intrinsicUtility: 0.95, rationale: "dated past incident + PR ref", costUsd: 0.05 };
+      },
+    };
+    const proposal = await proposeAudit({
+      agentId: "agent-test",
+      client,
+      claudeMdPathOverride: filePath,
+      maxCostUsd: 1,
+      concurrency: 2,
+    });
+    assert.equal(proposal.scores.length, 4);
+    assert.equal(proposal.sectionCount, 4);
+    assert.equal(proposal.unscoredSectionIds.length, 0);
+    assert.equal(proposal.cost.totalUsd, 0.2);
+    assert.equal(proposal.cost.budgetExhausted, false);
+    assert.equal(proposal.verdictCounts.drop, 1);
+    assert.equal(proposal.verdictCounts.weakKeep, 1);
+    assert.equal(proposal.verdictCounts.keep, 2);
+    assert.ok(Math.abs(proposal.meanUtility - 0.5625) < 1e-9);
+    // Median of [0.15, 0.45, 0.7, 0.95] = (0.45 + 0.7) / 2 = 0.575
+    assert.ok(Math.abs(proposal.medianUtility - 0.575) < 1e-9);
+  });
+});
+
+// ---------------------------------------------------------------------
+// proposeAudit: budget exhaustion stops scoring
+// ---------------------------------------------------------------------
+
+test("proposeAudit: budget exhaustion halts further scoring + reports unscored sections", async () => {
+  const blocks = Array.from({ length: 10 }, (_, i) => ({
+    runId: `r${i}`,
+    issueId: i + 100,
+    heading: `Heading ${i}`,
+    body: `Body ${i}.`,
+    ts: `2026-04-${String(i + 1).padStart(2, "0")}T00:00:00Z`,
+  }));
+  const md = makeAttributableClaudeMd(blocks);
+  await withTempClaudeMd(md, async (filePath) => {
+    // Each call costs $0.30; budget is $1.00 → only ~3 calls fit before
+    // the next worker observes totalUsd ≥ budgetUsd and halts.
+    const client: AuditClient = {
+      scoreSection: async () => ({ intrinsicUtility: 0.5, rationale: "x", costUsd: 0.3 }),
+    };
+    const proposal = await proposeAudit({
+      agentId: "agent-budget",
+      client,
+      claudeMdPathOverride: filePath,
+      maxCostUsd: 1,
+      concurrency: 1, // single-worker → strict ordering
+    });
+    assert.ok(proposal.cost.budgetExhausted, "expected budgetExhausted");
+    assert.ok(proposal.scores.length < 10, `expected partial scoring, got ${proposal.scores.length}/10`);
+    assert.equal(
+      proposal.scores.length + proposal.unscoredSectionIds.length,
+      10,
+      "scored + unscored should cover all sections",
+    );
+  });
+});
+
+test("proposeAudit: defaults max-cost=5 + concurrency=3 when not provided", async () => {
+  // Just confirm the defaults are picked up (not full numeric assertion).
+  const blocks = [{ runId: "r1", issueId: 1, heading: "h", body: "b", ts: "2026-04-01T00:00:00Z" }];
+  const md = makeAttributableClaudeMd(blocks);
+  await withTempClaudeMd(md, async (filePath) => {
+    let observedConcurrency = 0;
+    let inFlight = 0;
+    const client: AuditClient = {
+      scoreSection: async () => {
+        inFlight += 1;
+        if (inFlight > observedConcurrency) observedConcurrency = inFlight;
+        await new Promise((r) => setTimeout(r, 5));
+        inFlight -= 1;
+        return { intrinsicUtility: 0.5, rationale: "x", costUsd: 0.01 };
+      },
+    };
+    const proposal = await proposeAudit({
+      agentId: "agent-defaults",
+      client,
+      claudeMdPathOverride: filePath,
+    });
+    assert.equal(proposal.cost.budgetUsd, DEFAULT_MAX_COST_USD);
+  });
+});
+
+// ---------------------------------------------------------------------
+// proposeAudit: per-section error is absorbed (section reported unscored,
+// other sections still get scored)
+// ---------------------------------------------------------------------
+
+test("proposeAudit: per-section client error is captured as unscored, doesn't kill the run", async () => {
+  const md = makeAttributableClaudeMd([
+    { runId: "r1", issueId: 1, heading: "first", body: "ok", ts: "2026-04-01T00:00:00Z" },
+    { runId: "r2", issueId: 2, heading: "fails", body: "oh no", ts: "2026-04-02T00:00:00Z" },
+    { runId: "r3", issueId: 3, heading: "third", body: "ok", ts: "2026-04-03T00:00:00Z" },
+  ]);
+  await withTempClaudeMd(md, async (filePath) => {
+    const client: AuditClient = {
+      scoreSection: async ({ heading }) => {
+        if (heading === "fails") throw new Error("simulated llm error");
+        return { intrinsicUtility: 0.7, rationale: "ok", costUsd: 0.05 };
+      },
+    };
+    const proposal = await proposeAudit({
+      agentId: "agent-partial",
+      client,
+      claudeMdPathOverride: filePath,
+      maxCostUsd: 5,
+      concurrency: 1,
+    });
+    assert.equal(proposal.scores.length, 2);
+    assert.equal(proposal.unscoredSectionIds.length, 1);
+  });
+});
+
+// ---------------------------------------------------------------------
+// formatAuditProposal: rendering
+// ---------------------------------------------------------------------
+
+test("formatAuditProposal: empty case", async () => {
+  const tmp = path.join(os.tmpdir(), `audit-empty-${Date.now()}.md`);
+  const proposal = await proposeAudit({
+    agentId: "agent-empty",
+    client: { scoreSection: async () => ({ intrinsicUtility: 0, rationale: "x", costUsd: 0 }) },
+    claudeMdPathOverride: tmp,
+  });
+  const rendered = formatAuditProposal(proposal);
+  assert.match(rendered, /No sections scored/);
+});
+
+test("formatAuditProposal: populated case sorts by utility ascending", async () => {
+  const md = makeAttributableClaudeMd([
+    { runId: "r1", issueId: 1, heading: "Mid section", body: "b1", ts: "2026-04-01T00:00:00Z" },
+    { runId: "r2", issueId: 2, heading: "Bottom section", body: "b2", ts: "2026-04-02T00:00:00Z" },
+    { runId: "r3", issueId: 3, heading: "Top section", body: "b3", ts: "2026-04-03T00:00:00Z" },
+  ]);
+  await withTempClaudeMd(md, async (filePath) => {
+    const client: AuditClient = {
+      scoreSection: async ({ heading }) => {
+        if (heading.includes("Bottom")) return { intrinsicUtility: 0.1, rationale: "low", costUsd: 0.01 };
+        if (heading.includes("Mid")) return { intrinsicUtility: 0.5, rationale: "mid", costUsd: 0.01 };
+        return { intrinsicUtility: 0.9, rationale: "high", costUsd: 0.01 };
+      },
+    };
+    const proposal = await proposeAudit({
+      agentId: "agent-format",
+      client,
+      claudeMdPathOverride: filePath,
+    });
+    const rendered = formatAuditProposal(proposal);
+    const bottomIdx = rendered.indexOf("Bottom section");
+    const midIdx = rendered.indexOf("Mid section");
+    const topIdx = rendered.indexOf("Top section");
+    assert.ok(bottomIdx > 0 && bottomIdx < midIdx && midIdx < topIdx);
+    assert.match(rendered, /verdicts: keep=1 weak-keep=1 drop=1/);
+  });
+});

--- a/src/agent/auditLessons.ts
+++ b/src/agent/auditLessons.ts
@@ -1,0 +1,308 @@
+// Per-section intrinsic-quality audit of an agent's CLAUDE.md (Phase 1
+// advisory; destructive Phase 2 deferred to a follow-up issue).
+//
+// Walks the agent's CLAUDE.md section-by-section. ONE LLM call per section
+// (not batched) — that's what honors the "in vacuum" constraint. If the
+// LLM saw siblings in the same prompt, it'd rate comparatively.
+//
+// Output: a scored proposal with per-section `intrinsicUtility` + verdict
+// + rationale. Operator runs `vp-dev agents audit-lessons <agentId>` to
+// see the table; combines with the reinforcement-based prune-lessons
+// signal manually for now.
+//
+// The 0.0–1.0 scale is shared with summarizer.ts's write-time
+// predictedUtility (via `src/util/utilityCalibration.ts`) so audit-time
+// scores remain comparable to write-time scores.
+
+import { z } from "zod";
+import { promises as fs } from "node:fs";
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { claudeBinPath } from "./sdkBinary.js";
+import { agentClaudeMdPath } from "./specialization.js";
+import { parseClaudeMdSections, type ParsedSection } from "./split.js";
+import { parseJsonEnvelope } from "../util/parseJsonEnvelope.js";
+import { ORCHESTRATOR_MODEL_SUMMARIZER } from "../orchestrator/models.js";
+import { UTILITY_CALIBRATION_ANCHOR } from "../util/utilityCalibration.js";
+
+export const AUDIT_MODEL = ORCHESTRATOR_MODEL_SUMMARIZER;
+
+export const DEFAULT_MAX_COST_USD = 5;
+export const DEFAULT_CONCURRENCY = 3;
+
+export const VERDICT_THRESHOLDS = {
+  drop: 0.3, // < drop = "drop"
+  keep: 0.6, // >= keep = "keep"; in between = "weak-keep"
+} as const;
+
+export type AuditVerdict = "keep" | "weak-keep" | "drop";
+
+export interface AuditScore {
+  sectionId: string;
+  runId?: string;
+  issueId?: number;
+  heading: string;
+  intrinsicUtility: number;
+  verdict: AuditVerdict;
+  rationale: string;
+  costUsd: number;
+}
+
+export interface AuditProposal {
+  agentId: string;
+  generatedAt: string;
+  /** Bytes of the agent's CLAUDE.md at audit time. */
+  totalBytes: number;
+  /** Number of sections parsed (only attributable, summarizer-emitted ones). */
+  sectionCount: number;
+  scores: AuditScore[];
+  /** Sections found via parseClaudeMdSections that were not scored due to budget exhaustion. */
+  unscoredSectionIds: string[];
+  cost: {
+    totalUsd: number;
+    budgetUsd: number;
+    budgetExhausted: boolean;
+  };
+  /** Mean intrinsicUtility across scored sections (NaN when no sections were scored). */
+  meanUtility: number;
+  /** Median intrinsicUtility across scored sections. */
+  medianUtility: number;
+  verdictCounts: { keep: number; weakKeep: number; drop: number };
+}
+
+const ScoreSchema = z.object({
+  intrinsicUtility: z.number().min(0).max(1),
+  rationale: z.string().min(1).max(500),
+});
+
+export interface AuditClient {
+  scoreSection(input: {
+    heading: string;
+    body: string;
+  }): Promise<{
+    intrinsicUtility: number;
+    rationale: string;
+    costUsd: number;
+  }>;
+}
+
+export interface ProposeAuditInput {
+  agentId: string;
+  maxCostUsd?: number;
+  concurrency?: number;
+  /** Override the LLM client (testability). Defaults to a sonnet-backed impl. */
+  client?: AuditClient;
+  /** Override the path of the agent's CLAUDE.md (testability). */
+  claudeMdPathOverride?: string;
+}
+
+export async function proposeAudit(input: ProposeAuditInput): Promise<AuditProposal> {
+  const generatedAt = new Date().toISOString();
+  const budgetUsd = input.maxCostUsd ?? DEFAULT_MAX_COST_USD;
+  const concurrency = Math.max(1, input.concurrency ?? DEFAULT_CONCURRENCY);
+  const client = input.client ?? defaultAuditClient();
+  const filePath = input.claudeMdPathOverride ?? agentClaudeMdPath(input.agentId);
+
+  let claudeMd = "";
+  try {
+    claudeMd = await fs.readFile(filePath, "utf-8");
+  } catch {
+    // Empty file → empty proposal; the operator sees "0 sections" rather
+    // than a crash.
+  }
+  const totalBytes = Buffer.byteLength(claudeMd, "utf-8");
+  const sections = parseClaudeMdSections(claudeMd);
+
+  const scores: AuditScore[] = [];
+  const unscoredSectionIds: string[] = [];
+  let totalUsd = 0;
+  let budgetExhausted = false;
+
+  // Concurrent worker loop with strict budget gating: any worker that
+  // observes totalUsd ≥ budgetUsd refuses to dispatch the next call. The
+  // shared totalUsd counter is mutated under the JS event-loop's
+  // single-thread guarantee — no lock needed.
+  const queue: ParsedSection[] = [...sections];
+  async function worker(): Promise<void> {
+    while (queue.length > 0) {
+      if (totalUsd >= budgetUsd) {
+        budgetExhausted = true;
+        break;
+      }
+      const section = queue.shift();
+      if (!section) break;
+      try {
+        const result = await client.scoreSection({
+          heading: section.heading,
+          body: section.body,
+        });
+        totalUsd += result.costUsd;
+        scores.push({
+          sectionId: section.sectionId,
+          runId: section.runId,
+          issueId: section.issueId,
+          heading: section.heading,
+          intrinsicUtility: result.intrinsicUtility,
+          verdict: utilityToVerdict(result.intrinsicUtility),
+          rationale: result.rationale,
+          costUsd: result.costUsd,
+        });
+      } catch {
+        // Per-section failures are absorbed — the section is left unscored
+        // (operator can re-run and only the missing ones get re-tried;
+        // existing scores aren't lost since output is per-call).
+        unscoredSectionIds.push(section.sectionId);
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: concurrency }, () => worker()));
+
+  // Anything still in the queue when the budget triggered counts as unscored.
+  for (const s of queue) {
+    unscoredSectionIds.push(s.sectionId);
+  }
+
+  // Stats.
+  const utilities = scores.map((s) => s.intrinsicUtility);
+  const meanUtility =
+    utilities.length > 0
+      ? utilities.reduce((a, b) => a + b, 0) / utilities.length
+      : Number.NaN;
+  const sortedUtils = [...utilities].sort((a, b) => a - b);
+  const medianUtility =
+    sortedUtils.length === 0
+      ? Number.NaN
+      : sortedUtils.length % 2 === 1
+        ? sortedUtils[(sortedUtils.length - 1) / 2]
+        : (sortedUtils[sortedUtils.length / 2 - 1] +
+            sortedUtils[sortedUtils.length / 2]) /
+          2;
+  const verdictCounts = {
+    keep: scores.filter((s) => s.verdict === "keep").length,
+    weakKeep: scores.filter((s) => s.verdict === "weak-keep").length,
+    drop: scores.filter((s) => s.verdict === "drop").length,
+  };
+
+  return {
+    agentId: input.agentId,
+    generatedAt,
+    totalBytes,
+    sectionCount: sections.length,
+    scores,
+    unscoredSectionIds,
+    cost: { totalUsd, budgetUsd, budgetExhausted },
+    meanUtility,
+    medianUtility,
+    verdictCounts,
+  };
+}
+
+export function utilityToVerdict(utility: number): AuditVerdict {
+  if (utility < VERDICT_THRESHOLDS.drop) return "drop";
+  if (utility >= VERDICT_THRESHOLDS.keep) return "keep";
+  return "weak-keep";
+}
+
+export function formatAuditProposal(p: AuditProposal): string {
+  const lines: string[] = [];
+  lines.push(`Audit proposal for ${p.agentId}`);
+  lines.push(
+    `  CLAUDE.md size: ${(p.totalBytes / 1024).toFixed(1)} KB; ${p.sectionCount} attributable section(s).`,
+  );
+  if (p.scores.length === 0) {
+    lines.push("  No sections scored.");
+    return lines.join("\n");
+  }
+  lines.push(
+    `  intrinsicUtility:  mean=${p.meanUtility.toFixed(3)}  median=${p.medianUtility.toFixed(3)}`,
+  );
+  lines.push(
+    `  verdicts: keep=${p.verdictCounts.keep} weak-keep=${p.verdictCounts.weakKeep} drop=${p.verdictCounts.drop}`,
+  );
+  lines.push(
+    `  cost: $${p.cost.totalUsd.toFixed(4)} of $${p.cost.budgetUsd.toFixed(2)} budget${p.cost.budgetExhausted ? " (EXHAUSTED — partial result)" : ""}`,
+  );
+  if (p.unscoredSectionIds.length > 0) {
+    lines.push(
+      `  unscored: ${p.unscoredSectionIds.length} section(s) (budget exhausted or per-section error)`,
+    );
+  }
+  // Sort by utility ascending so the operator sees worst-rated sections first.
+  const sorted = [...p.scores].sort((a, b) => a.intrinsicUtility - b.intrinsicUtility);
+  for (const s of sorted) {
+    const verdictTag = s.verdict === "drop" ? "drop  " : s.verdict === "weak-keep" ? "weak  " : "keep  ";
+    const headingPreview = s.heading.length > 80 ? s.heading.slice(0, 77) + "..." : s.heading;
+    lines.push(
+      `  [${verdictTag}] ${s.sectionId} (util=${s.intrinsicUtility.toFixed(2)}) "${headingPreview}"`,
+    );
+    lines.push(`    rationale: ${s.rationale}`);
+  }
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------
+// Default sonnet-backed AuditClient implementation
+// ---------------------------------------------------------------------
+
+const AUDIT_SYSTEM_PROMPT = `You are an audit agent. Given a single section from an agent's CLAUDE.md, rate its intrinsic utility on a 0.0–1.0 scale. The rating is IN VACUUM — you do not see other sections, run history, or whether the section ever fired in production. Score the section's text on its own merits.
+
+Calibration (same scale as the write-time predictedUtility self-rating):
+${UTILITY_CALIBRATION_ANCHOR}
+
+Be calibrated, not generous. A pile of 0.7s is useless. If the section is generic, mark it 0.1–0.3. If it cites a dated past incident with concrete file paths or function names, mark it 0.9–1.0.
+
+Output: a single JSON object, no fences, no prose. Schema:
+  {"intrinsicUtility": number, "rationale": string}
+
+The rationale must be ONE short sentence (≤ 200 chars) naming the specific evidence — what makes this section concrete or generic. Do NOT include "this section" / "this rule" — name the property directly: "no past incident anchor", "cites src/foo.ts:42", "tautological", etc.`;
+
+function buildAuditUserPrompt(input: { heading: string; body: string }): string {
+  return `Section heading: ${input.heading}
+
+Section body:
+${input.body}
+
+Rate it. Emit one JSON object.`;
+}
+
+export function defaultAuditClient(): AuditClient {
+  return {
+    async scoreSection(input) {
+      const userPrompt = buildAuditUserPrompt(input);
+      let raw = "";
+      let costUsd = 0;
+      const stream = query({
+        prompt: userPrompt,
+        options: {
+          model: AUDIT_MODEL,
+          systemPrompt: AUDIT_SYSTEM_PROMPT,
+          tools: [],
+          permissionMode: "default",
+          env: process.env,
+          maxTurns: 1,
+          settingSources: [],
+          persistSession: false,
+          pathToClaudeCodeExecutable: claudeBinPath(),
+        },
+      });
+      for await (const msg of stream) {
+        if (msg.type === "result") {
+          if (msg.subtype === "success") raw = msg.result;
+          else throw new Error(`audit query failed: ${msg.subtype}`);
+          // Pull cost when available (mirrors codingAgent.ts pattern).
+          const m = msg as { total_cost_usd?: number };
+          if (typeof m.total_cost_usd === "number") costUsd = m.total_cost_usd;
+        }
+      }
+      const parsed = parseJsonEnvelope(raw, ScoreSchema);
+      if (!parsed.ok) {
+        throw new Error(`audit output not valid: ${parsed.error}`);
+      }
+      return {
+        intrinsicUtility: parsed.value!.intrinsicUtility,
+        rationale: parsed.value!.rationale,
+        costUsd,
+      };
+    },
+  };
+}

--- a/src/agent/summarizer.ts
+++ b/src/agent/summarizer.ts
@@ -4,6 +4,7 @@ import { claudeBinPath } from "./sdkBinary.js";
 import { parseJsonEnvelope } from "../util/parseJsonEnvelope.js";
 import { ORCHESTRATOR_MODEL_SUMMARIZER } from "../orchestrator/models.js";
 import { accuracyDegradationFactor } from "../util/contextCostCurve.js";
+import { indentCalibration } from "../util/utilityCalibration.js";
 import type { AgentRecord, IssueSummary, ResultEnvelope } from "../types.js";
 import type { Logger } from "../log/logger.js";
 
@@ -276,10 +277,7 @@ Hard rules:
 Predicted-utility self-rating (issue #179, half-ready-curve probe):
 - For every non-skip emission, ALSO emit \`predictedUtility\` — a number in [0, 1] estimating how much future-leverage the lesson carries. The harness uses this to decide whether the lesson's expected benefit justifies the byte-cost in the cost-transparency line above; it gets persisted so the operator can later correlate self-ratings with whether the lesson actually fired (got reinforced by future runs).
 - Calibration:
-  - 0.0–0.2: restates an existing rule; generic platitude ("verify before merging"); applies-to-everything; adds little beyond rules already in the file.
-  - 0.3–0.5: useful but partially redundant or could be inferred from existing sections; modest sharpening of an already-known principle.
-  - 0.6–0.8: introduces a specific rule with a named failure mode the agent has hit before or would hit again; cites concrete files / tools / protocols.
-  - 0.9–1.0: names a specific past incident (date / PR / file path / function name) with a concrete failure mode the agent would otherwise repeat; high-leverage rule with narrow tells.
+${indentCalibration("  - ")}
 - Be calibrated, not generous. A field full of 0.8s is useless for tuning. If you'd skip the lesson under the cost-transparency line above, mark it 0.1–0.3 instead of inflating.
 
 Output: a single JSON object, no fences, no prose. The \`skip\` field is MANDATORY in every response. Use \`{"skip": false, "heading": "...", "body": "...", "predictedUtility": 0.X}\` when there is a lesson worth saving, and \`{"skip": true, "skipReason": "..."}\` otherwise. Schema:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -404,6 +404,29 @@ export function buildCli(): Command {
         }),
     )
     .addCommand(
+      new Command("audit-lessons")
+        .description(
+          "Score every section of an agent's CLAUDE.md by intrinsic quality (in vacuum — no run history, no comparison across sections). Per-section sonnet calls rate each lesson on the same 0-1 scale as write-time predictedUtility. Advisory only (Phase 1); destructive --apply / --confirm deferred. Combine with `vp-dev agents prune-lessons` for the historical-reinforcement signal.",
+        )
+        .argument("<agentId>", "Agent to audit (e.g. agent-916a)")
+        .option("--json", "Print machine-readable JSON")
+        .option(
+          "--max-cost-usd <usd>",
+          "Cumulative cost cap across all section scoring calls (default 5).",
+          parsePositive,
+          5,
+        )
+        .option(
+          "--concurrency <n>",
+          "Parallel scoring calls (default 3 — respects Anthropic rate limits while keeping audit walltime bounded).",
+          parsePositive,
+          3,
+        )
+        .action(async (agentId, opts) => {
+          await cmdAgentsAuditLessons(agentId, opts);
+        }),
+    )
+    .addCommand(
       new Command("stats")
         .description("Per-agent rollup of PR outcomes (merge rate, median rework, median CI cycles).")
         .option("--json", "Print machine-readable JSON")
@@ -2398,6 +2421,35 @@ async function cmdAgentsPruneLessons(
     `\nConfirm token: ${token} (15-min TTL, written to state/lesson-prune-confirm-${token}.json)\n` +
       `Apply with:    vp-dev agents prune-lessons ${agentId} --confirm ${token}\n`,
   );
+}
+
+interface AgentsAuditLessonsOpts {
+  json?: boolean;
+  maxCostUsd: number;
+  concurrency: number;
+}
+
+async function cmdAgentsAuditLessons(
+  agentId: string,
+  opts: AgentsAuditLessonsOpts,
+): Promise<void> {
+  const reg = await loadRegistry();
+  const agent = reg.agents.find((a) => a.agentId === agentId);
+  if (!agent) {
+    process.stderr.write(`ERROR: agent '${agentId}' not found in registry.\n`);
+    process.exit(2);
+  }
+  const { proposeAudit, formatAuditProposal } = await import("./agent/auditLessons.js");
+  const proposal = await proposeAudit({
+    agentId,
+    maxCostUsd: opts.maxCostUsd,
+    concurrency: opts.concurrency,
+  });
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(proposal, null, 2) + "\n");
+    return;
+  }
+  process.stdout.write(formatAuditProposal(proposal) + "\n");
 }
 
 interface AgentsTightenClaudeMdOpts {

--- a/src/util/utilityCalibration.test.ts
+++ b/src/util/utilityCalibration.test.ts
@@ -1,0 +1,35 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  UTILITY_CALIBRATION_ANCHOR,
+  UTILITY_CALIBRATION_BANDS,
+  indentCalibration,
+} from "./utilityCalibration.js";
+
+test("UTILITY_CALIBRATION_ANCHOR contains all four bands", () => {
+  assert.match(UTILITY_CALIBRATION_ANCHOR, /0\.0–0\.2/);
+  assert.match(UTILITY_CALIBRATION_ANCHOR, /0\.3–0\.5/);
+  assert.match(UTILITY_CALIBRATION_ANCHOR, /0\.6–0\.8/);
+  assert.match(UTILITY_CALIBRATION_ANCHOR, /0\.9–1\.0/);
+});
+
+test("UTILITY_CALIBRATION_BANDS lists all four bands with monotonically increasing boundaries", () => {
+  assert.equal(UTILITY_CALIBRATION_BANDS.length, 4);
+  for (let i = 1; i < UTILITY_CALIBRATION_BANDS.length; i++) {
+    assert.ok(UTILITY_CALIBRATION_BANDS[i].low > UTILITY_CALIBRATION_BANDS[i - 1].low);
+    assert.ok(UTILITY_CALIBRATION_BANDS[i].high > UTILITY_CALIBRATION_BANDS[i - 1].high);
+  }
+});
+
+test("indentCalibration applies the prefix to every line", () => {
+  const out = indentCalibration("  - ");
+  const lines = out.split("\n");
+  assert.equal(lines.length, 4);
+  for (const line of lines) {
+    assert.ok(line.startsWith("  - "), `line missing prefix: ${line}`);
+  }
+});
+
+test("indentCalibration with empty prefix returns the anchor unchanged", () => {
+  assert.equal(indentCalibration(""), UTILITY_CALIBRATION_ANCHOR);
+});

--- a/src/util/utilityCalibration.ts
+++ b/src/util/utilityCalibration.ts
@@ -1,0 +1,39 @@
+// Shared utility calibration anchor — the 0.0–1.0 scale that grounds both
+// (a) write-time `predictedUtility` self-rating in `summarizer.ts` (PR #193),
+// and (b) audit-time `intrinsicUtility` scoring in `auditLessons.ts`. Both
+// paths must use the same scale so scores remain comparable.
+//
+// If we ever tune the bands, update them HERE — both write-time and
+// audit-time prompts pick up the change without drift.
+
+export const UTILITY_CALIBRATION_ANCHOR = `0.0–0.2: restates an existing rule; generic platitude ("verify before merging"); applies-to-everything; adds little beyond rules already in the file.
+0.3–0.5: useful but partially redundant or could be inferred from existing sections; modest sharpening of an already-known principle.
+0.6–0.8: introduces a specific rule with a named failure mode the agent has hit before or would hit again; cites concrete files / tools / protocols.
+0.9–1.0: names a specific past incident (date / PR / file path / function name) with a concrete failure mode the agent would otherwise repeat; high-leverage rule with narrow tells.`;
+
+/**
+ * The four band labels keyed by the `[low, high]` boundary, useful for
+ * tests asserting all bands appear and for any future programmatic mapping
+ * (e.g., colorizing CLI output by band).
+ */
+export const UTILITY_CALIBRATION_BANDS: ReadonlyArray<{
+  low: number;
+  high: number;
+  label: string;
+}> = [
+  { low: 0.0, high: 0.2, label: "platitude" },
+  { low: 0.3, high: 0.5, label: "borderline" },
+  { low: 0.6, high: 0.8, label: "specific" },
+  { low: 0.9, high: 1.0, label: "past-incident-anchored" },
+];
+
+/**
+ * Render the calibration anchor with each line indented by `indent` spaces.
+ * Used by prompts that nest the anchor inside a bulleted list (the
+ * summarizer wraps each band line with "  - ", the audit prompt uses none).
+ */
+export function indentCalibration(indent: string): string {
+  return UTILITY_CALIBRATION_ANCHOR.split("\n")
+    .map((line) => indent + line)
+    .join("\n");
+}


### PR DESCRIPTION
## Summary

Adds `vp-dev agents audit-lessons <agentId>` — walks every section in the agent's CLAUDE.md and scores it **in vacuum** (no run history, no comparison to siblings). One sonnet call per section honors the in-vacuum constraint: if the LLM saw siblings in the same prompt, it'd rate comparatively. Output is a per-section verdict (drop / weak-keep / keep) + rationale.

Phase 2 (destructive `--apply` / `--confirm <token>`) is deferred to [#197](https://github.com/szhygulin/vaultpilot-development-agents/issues/197), following the established bake-window discipline (mirrors compact #158→#162 and tighten #172→#173).

## How it complements existing modules

| Module | Signal | Question answered |
|---|---|---|
| `prune-lessons` (PR #190) | Historical reinforcement | "Did this section get cited by later runs?" |
| `audit-lessons` (this PR) | Intrinsic quality | "Does this section's text look like a well-formed rule on its own merits?" |

Operator can run both and intersect for conservative drops; combined-signal sweep is sketched in #197.

## Shared calibration scale

Extracted the 0.0–1.0 scale from `summarizer.ts` into `src/util/utilityCalibration.ts`. Both write-time `predictedUtility` (PR #193) and audit-time `intrinsicUtility` use the same anchor — if we tune the bands later, both paths shift in lockstep, no drift.

The summarizer success-prompt was refactored to interpolate the constant. Pure refactor; `summarizer.test.ts` (15 tests) still pass unchanged. The failure-prompt has its own deliberately-different scale; left alone.

## CLI

```
vp-dev agents audit-lessons <agentId> [--json] [--max-cost-usd N] [--concurrency N]
```

Defaults: `--max-cost-usd 5`, `--concurrency 3`. Cost forecast ~$0.60/agent at ~30 sections. Workers gate on shared totalUsd counter; budget exhaustion halts further scoring and reports unscored section IDs.

## Verdict mapping

`intrinsicUtility < 0.3` → drop. `0.3 ≤ x < 0.6` → weak-keep. `≥ 0.6` → keep. Thresholds exported as `VERDICT_THRESHOLDS`.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm test` — **618/618 pass** (602 baseline + 16 new)

Coverage: utilityCalibration (4) + utilityToVerdict (4) + proposeAudit happy-path / empty / budget-exhaust / per-section-error / defaults / format (8). Plus regression: summarizer.test.ts still passes after the calibration-anchor refactor.

## Phase 2 (#197)

Destructive `--apply` / `--confirm <token>`, combined-signal sweep, batch mode, per-section operator override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)