### PR TITLE
feat(prompt): load user global ~/.claude/CLAUDE.md as Layer 1 of agent prompt

### DIFF
--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -1,6 +1,10 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-import { readAgentClaudeMd, readSeedClaudeMd } from "./specialization.js";
+import {
+  readAgentClaudeMd,
+  readSeedClaudeMd,
+  readUserGlobalClaudeMd,
+} from "./specialization.js";
 import { readSharedLessonsForDomains } from "./sharedLessons.js";
 import { renderWorkflow, type WorkflowVars } from "./workflow.js";
 import type { AgentRecord, ResumeContext } from "../types.js";
@@ -29,12 +33,30 @@ export async function buildAgentSystemPrompt(opts: {
    */
   suppressTargetClaudeMd?: boolean;
 }): Promise<string> {
-  const [perAgentClaudeMd, liveProjectClaudeMdRaw] = await Promise.all([
-    readAgentClaudeMd(opts.agent.agentId, opts.targetRepoPath),
-    readSeedClaudeMd(opts.targetRepoPath),
-  ]);
+  const [perAgentClaudeMd, liveProjectClaudeMdRaw, userGlobalClaudeMdRaw] =
+    await Promise.all([
+      readAgentClaudeMd(opts.agent.agentId, opts.targetRepoPath),
+      readSeedClaudeMd(opts.targetRepoPath),
+      readUserGlobalClaudeMd(),
+    ]);
+  // The suppress flag (issue #179 phase 3) is a context-size calibration
+  // knob: when true we drop both the target-repo and the global tiers so the
+  // effective seed size matches the per-agent CLAUDE.md size we're varying.
+  // Suppressing only the target tier while leaving the global on would
+  // distort the curve study by a per-operator amount.
   const liveProjectClaudeMd = opts.suppressTargetClaudeMd ? "" : liveProjectClaudeMdRaw;
-  const dedupedPerAgent = stripOverlappingSections(perAgentClaudeMd, liveProjectClaudeMd);
+  const userGlobalClaudeMd = opts.suppressTargetClaudeMd ? "" : userGlobalClaudeMdRaw;
+  // Dedup the per-agent layer against the union of upstream layers (global ∪
+  // live). The per-agent file is the most-specific layer but is also the
+  // most stale — forked at agent-mint time and possibly weeks old — so any
+  // ## heading that already appears in either upstream layer is dropped.
+  // The live and global layers themselves are NOT cross-deduped: when both
+  // carry the same heading, both are emitted and the more-specific (later
+  // in the prompt) section wins by attention-position.
+  const upstreamBaseline = [userGlobalClaudeMd, liveProjectClaudeMd]
+    .filter((s) => s.length > 0)
+    .join("\n");
+  const dedupedPerAgent = stripOverlappingSections(perAgentClaudeMd, upstreamBaseline);
 
   const workflow = renderWorkflow(opts.workflow);
 
@@ -63,6 +85,21 @@ export async function buildAgentSystemPrompt(opts: {
   ]);
 
   const sections: string[] = [];
+  if (userGlobalClaudeMd.trim().length > 0) {
+    sections.push(
+      "# User global CLAUDE.md (~/.claude/CLAUDE.md — operator's per-user process rules)",
+      "",
+      "These rules apply across every project the operator works on. They are",
+      "generic process habits (Git/PR conventions, push-back discipline, doc style)",
+      "and do NOT carry domain-specific scope — see the Project rules below for",
+      "target-repo specifics that override these.",
+      "",
+      userGlobalClaudeMd.trim(),
+      "",
+      "---",
+      "",
+    );
+  }
   if (!opts.suppressTargetClaudeMd) {
     sections.push(
       "# Project rules (live target-repo CLAUDE.md — current as of this dispatch)",

--- a/src/agent/specialization.ts
+++ b/src/agent/specialization.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { ensureDir, withFileLock } from "../state/locks.js";
 import {
@@ -53,6 +54,37 @@ export async function readSeedClaudeMd(targetRepoPath: string): Promise<string> 
     return await fs.readFile(candidate, "utf-8");
   } catch {
     return GENERIC_SEED;
+  }
+}
+
+/**
+ * Resolve the path to the user's global CLAUDE.md (`~/.claude/CLAUDE.md`).
+ * Lazy on `os.homedir()` so test harnesses can override `process.env.HOME`
+ * without monkey-patching the module — same pattern as `sharedLessonsDir`.
+ *
+ * Exported for testing; production callers go through `readUserGlobalClaudeMd`.
+ */
+export function userGlobalClaudeMdPath(): string {
+  return path.join(os.homedir(), ".claude", "CLAUDE.md");
+}
+
+/**
+ * Read the operator's per-user CLAUDE.md (`~/.claude/CLAUDE.md`). Returns the
+ * empty string when the file is missing — many operators won't have one and
+ * absence is not an error. Differs from `readSeedClaudeMd`, which substitutes
+ * a generic project-rules fallback when the target-repo file is absent: there
+ * is no analogous fallback for the global tier (a missing global CLAUDE.md
+ * means "operator hasn't opted in," and the prompt simply omits Layer 1).
+ *
+ * Read every dispatch (live), same as the live target-repo CLAUDE.md, so
+ * operators can iterate on the file and edits reach existing specialists
+ * immediately without re-forking.
+ */
+export async function readUserGlobalClaudeMd(): Promise<string> {
+  try {
+    return await fs.readFile(userGlobalClaudeMdPath(), "utf-8");
+  } catch {
+    return "";
   }
 }
 

--- a/src/util/prompt.test.ts
+++ b/src/util/prompt.test.ts
@@ -1,6 +1,20 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { renderResumeBlock, stripOverlappingSections } from "../agent/prompt.js";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  buildAgentSystemPrompt,
+  renderResumeBlock,
+  stripOverlappingSections,
+} from "../agent/prompt.js";
+import {
+  agentClaudeMdPath,
+  agentDir,
+  readUserGlobalClaudeMd,
+} from "../agent/specialization.js";
+import type { AgentRecord } from "../types.js";
+import type { WorkflowVars } from "../agent/workflow.js";
 
 test("stripOverlappingSections: drops perAgent ## sections whose heading also appears in live", () => {
   const live = `# Project rules
@@ -185,4 +199,262 @@ keep body
   const out = stripOverlappingSections(perAgent, live);
   assert.doesNotMatch(out, /drop body/);
   assert.match(out, /keep body/);
+});
+
+// ---- readUserGlobalClaudeMd + buildAgentSystemPrompt 3-layer (issue #186) --
+
+let testCounter = 0;
+function makeAgentId(): string {
+  return `agent-prompt-test-${process.pid}-${++testCounter}`;
+}
+
+function makeAgentRecord(agentId: string, name?: string): AgentRecord {
+  return {
+    agentId,
+    createdAt: "2026-05-07T00:00:00.000Z",
+    tags: [],
+    issuesHandled: 0,
+    implementCount: 0,
+    pushbackCount: 0,
+    errorCount: 0,
+    lastActiveAt: "2026-05-07T00:00:00.000Z",
+    name,
+  };
+}
+
+function makeWorkflow(agentId: string, worktreePath: string): WorkflowVars {
+  return {
+    issueId: 186,
+    targetRepo: "owner/repo",
+    worktreePath,
+    branchName: `vp-dev/${agentId}/issue-186`,
+    dryRun: false,
+    agentId,
+  };
+}
+
+async function withSandboxHome<T>(
+  fn: (homeDir: string) => Promise<T>,
+): Promise<T> {
+  const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "vp-prompt-home-"));
+  const prevHome = process.env.HOME;
+  process.env.HOME = homeDir;
+  try {
+    return await fn(homeDir);
+  } finally {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    await fs.rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+async function withTargetRepo<T>(
+  claudeMd: string | null,
+  fn: (targetRepoPath: string) => Promise<T>,
+): Promise<T> {
+  const targetRepoPath = await fs.mkdtemp(
+    path.join(os.tmpdir(), "vp-prompt-target-"),
+  );
+  if (claudeMd !== null) {
+    await fs.writeFile(path.join(targetRepoPath, "CLAUDE.md"), claudeMd);
+  }
+  try {
+    return await fn(targetRepoPath);
+  } finally {
+    await fs.rm(targetRepoPath, { recursive: true, force: true });
+  }
+}
+
+async function withPerAgentMd<T>(
+  agentId: string,
+  perAgentMd: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const dir = agentDir(agentId);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(agentClaudeMdPath(agentId), perAgentMd);
+  try {
+    return await fn();
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function writeGlobalClaudeMd(homeDir: string, content: string): Promise<void> {
+  await fs.mkdir(path.join(homeDir, ".claude"), { recursive: true });
+  await fs.writeFile(path.join(homeDir, ".claude", "CLAUDE.md"), content);
+}
+
+test("readUserGlobalClaudeMd: reads ~/.claude/CLAUDE.md when present, honoring HOME override", async () => {
+  await withSandboxHome(async (homeDir) => {
+    await writeGlobalClaudeMd(homeDir, "# Operator global rules\n\n## Push-Back Discipline\n- speak up early\n");
+    const out = await readUserGlobalClaudeMd();
+    assert.match(out, /Operator global rules/);
+    assert.match(out, /Push-Back Discipline/);
+  });
+});
+
+test("readUserGlobalClaudeMd: returns empty string when ~/.claude/CLAUDE.md is missing (graceful skip, not an error)", async () => {
+  await withSandboxHome(async () => {
+    const out = await readUserGlobalClaudeMd();
+    assert.equal(out, "");
+  });
+});
+
+test("buildAgentSystemPrompt: emits Layer 1 (global) before Layer 2 (live target) and Layer 3 (per-agent), in that order", async () => {
+  await withSandboxHome(async (homeDir) => {
+    await writeGlobalClaudeMd(
+      homeDir,
+      "# Operator global rules\n\n## Push-Back Discipline\n- speak up early\n",
+    );
+    await withTargetRepo(
+      "# Project rules\n\n## CI is a hard gate\n- typecheck + build + test must pass\n",
+      async (targetRepoPath) => {
+        const agentId = makeAgentId();
+        await withPerAgentMd(
+          agentId,
+          "# Per-agent\n\n## Crypto/DeFi Preflight\n- decode calldata before signing\n",
+          async () => {
+            const out = await buildAgentSystemPrompt({
+              agent: makeAgentRecord(agentId, "TestAgent"),
+              workflow: makeWorkflow(agentId, targetRepoPath),
+              targetRepoPath,
+            });
+            const globalIdx = out.indexOf("# User global CLAUDE.md");
+            const liveIdx = out.indexOf("# Project rules (live target-repo CLAUDE.md");
+            const perAgentIdx = out.indexOf("# Per-agent CLAUDE.md");
+            assert.ok(globalIdx >= 0, "global section must render");
+            assert.ok(liveIdx > globalIdx, "live section must follow global");
+            assert.ok(perAgentIdx > liveIdx, "per-agent section must follow live");
+            assert.match(out, /Push-Back Discipline/);
+            assert.match(out, /CI is a hard gate/);
+            assert.match(out, /Crypto\/DeFi Preflight/);
+          },
+        );
+      },
+    );
+  });
+});
+
+test("buildAgentSystemPrompt: omits Layer 1 (global) entirely when ~/.claude/CLAUDE.md is missing — backward-compatible with two-layer behavior", async () => {
+  await withSandboxHome(async () => {
+    await withTargetRepo(
+      "# Project rules\n\n## CI is a hard gate\n- pass\n",
+      async (targetRepoPath) => {
+        const agentId = makeAgentId();
+        await withPerAgentMd(
+          agentId,
+          "# Per-agent\n\n## Domain Lessons\n- something\n",
+          async () => {
+            const out = await buildAgentSystemPrompt({
+              agent: makeAgentRecord(agentId, "TestAgent"),
+              workflow: makeWorkflow(agentId, targetRepoPath),
+              targetRepoPath,
+            });
+            assert.doesNotMatch(out, /# User global CLAUDE\.md/);
+            assert.match(out, /# Project rules \(live target-repo CLAUDE\.md/);
+            assert.match(out, /# Per-agent CLAUDE\.md/);
+          },
+        );
+      },
+    );
+  });
+});
+
+test("buildAgentSystemPrompt: per-agent ## heading matching a global heading is dropped (per-agent dedups against global ∪ live)", async () => {
+  await withSandboxHome(async (homeDir) => {
+    await writeGlobalClaudeMd(
+      homeDir,
+      "# Global\n\n## Push-Back Discipline\n- canonical global version\n",
+    );
+    await withTargetRepo(
+      "# Project rules\n\n## CI is a hard gate\n- pass\n",
+      async (targetRepoPath) => {
+        const agentId = makeAgentId();
+        await withPerAgentMd(
+          agentId,
+          "## Push-Back Discipline\nstale duplicate of global\n\n## Domain Lessons\nkeep me\n",
+          async () => {
+            const out = await buildAgentSystemPrompt({
+              agent: makeAgentRecord(agentId, "TestAgent"),
+              workflow: makeWorkflow(agentId, targetRepoPath),
+              targetRepoPath,
+            });
+            // Global's section keeps its content.
+            assert.match(out, /canonical global version/);
+            // Per-agent's duplicate of the same heading is dropped.
+            assert.doesNotMatch(out, /stale duplicate of global/);
+            // Unique per-agent section survives.
+            assert.match(out, /Domain Lessons/);
+            assert.match(out, /keep me/);
+          },
+        );
+      },
+    );
+  });
+});
+
+test("buildAgentSystemPrompt: live target-repo heading matching a global heading is NOT dropped — both layers emit, more-specific wins by position", async () => {
+  await withSandboxHome(async (homeDir) => {
+    await writeGlobalClaudeMd(
+      homeDir,
+      "# Global\n\n## Git/PR Workflow\n- generic global rule\n",
+    );
+    await withTargetRepo(
+      "# Project rules\n\n## Git/PR Workflow\n- target-repo-specific override\n",
+      async (targetRepoPath) => {
+        const agentId = makeAgentId();
+        await withPerAgentMd(
+          agentId,
+          "## Domain\nspecialization\n",
+          async () => {
+            const out = await buildAgentSystemPrompt({
+              agent: makeAgentRecord(agentId, "TestAgent"),
+              workflow: makeWorkflow(agentId, targetRepoPath),
+              targetRepoPath,
+            });
+            // Both copies present.
+            assert.match(out, /generic global rule/);
+            assert.match(out, /target-repo-specific override/);
+            // The target-repo's "Git/PR Workflow" appears AFTER the global's,
+            // so attention-position favors it.
+            const globalRule = out.indexOf("generic global rule");
+            const targetRule = out.indexOf("target-repo-specific override");
+            assert.ok(globalRule >= 0 && targetRule > globalRule);
+          },
+        );
+      },
+    );
+  });
+});
+
+test("buildAgentSystemPrompt: suppressTargetClaudeMd suppresses BOTH target-repo and global tiers (#179 calibration parity)", async () => {
+  await withSandboxHome(async (homeDir) => {
+    await writeGlobalClaudeMd(
+      homeDir,
+      "# Global\n\n## Push-Back\n- global rule\n",
+    );
+    await withTargetRepo(
+      "# Project rules\n\n## CI\n- pass\n",
+      async (targetRepoPath) => {
+        const agentId = makeAgentId();
+        await withPerAgentMd(
+          agentId,
+          "## Domain\nspecialization\n",
+          async () => {
+            const out = await buildAgentSystemPrompt({
+              agent: makeAgentRecord(agentId, "TestAgent"),
+              workflow: makeWorkflow(agentId, targetRepoPath),
+              targetRepoPath,
+              suppressTargetClaudeMd: true,
+            });
+            assert.doesNotMatch(out, /# User global CLAUDE\.md/);
+            assert.doesNotMatch(out, /# Project rules \(live target-repo CLAUDE\.md/);
+            assert.match(out, /# Per-agent CLAUDE\.md/);
+            assert.match(out, /specialization/);
+          },
+        );
+      },
+    );
+  });
 });


### PR DESCRIPTION
Closes #186

## Summary

Adds the operator's global `~/.claude/CLAUDE.md` as a third layer of the coding-agent system prompt, sandwiched above the existing live target-repo CLAUDE.md and per-agent CLAUDE.md. Layer order is least-specific → most-specific (global → live → per-agent), and conflict resolution follows today's pattern: per-agent dedups against the union of upstream layers, while the upstream layers (global + live) both emit when they share a heading — the more-specific one wins by being later in the prompt (attention-position).

## Changes

- `src/agent/specialization.ts` — new `readUserGlobalClaudeMd()` (returns `""` on missing file — many operators won't have one) and `userGlobalClaudeMdPath()`. Lazy on `os.homedir()` so tests can sandbox via `process.env.HOME`, mirroring `sharedLessonsDir`.
- `src/agent/prompt.ts` — `buildAgentSystemPrompt` reads global alongside live + per-agent in `Promise.all`. Per-agent dedup baseline is `userGlobal ∪ live` (concatenated as the heading-source for `stripOverlappingSections`). New "# User global CLAUDE.md" section emits before the existing target-repo section when global content is non-empty. `suppressTargetClaudeMd` (issue #179 phase 3 flag) now suppresses both Layer 1 and Layer 2 so the curve-study size-axis isn't distorted by a per-operator amount.
- `src/util/prompt.test.ts` — 7 new tests cover: read present/absent, three-layer order, missing-global backward-compat, per-agent ↔ global dedup, live ↔ global non-dedup, suppress-flag parity.

## Test plan

- [x] `npm run build` — clean.
- [x] `npm test` — 665/665 pass locally.
- [x] Global file present + non-overlapping with target-repo + per-agent → all three sections rendered in order.
- [x] Global file present, target-repo `## Git/PR Workflow` matches a global heading → both kept; target-repo follows global so it dominates.
- [x] Global file present, per-agent `## Push-Back Discipline` matches global → per-agent section dropped.
- [x] Global file absent → output identical to today's two-layer behavior (no `# User global` block).
- [x] `suppressTargetClaudeMd: true` → both global and target-repo suppressed; per-agent emitted verbatim.

## Out of scope (as per the issue body)

- No mutation of `~/.claude/CLAUDE.md` from a coding-agent run (read-only, same as live target-repo).
- No change to summarizer / compact / tighten / assess paths — those remain per-agent only.
- No other dotfile loading.
- No per-target-repo override of the global path.

— Calldata Decode (agent-d0eb)
