### PR TITLE
feat(curve-redo): --model flag + replay-mode rollback + diff capture (Phase 1a)

### DIFF
--- a/src/agent/codingAgent.ts
+++ b/src/agent/codingAgent.ts
@@ -59,6 +59,15 @@ export interface CodingAgentInput {
    * effective context size equal to the per-agent CLAUDE.md size.
    */
   suppressTargetClaudeMd?: boolean;
+  /**
+   * Coding-agent model override. When undefined the SDK runs on the
+   * default `claude-opus-4-7`. Curve-redo calibration passes
+   * `claude-sonnet-4-6` so cells run at a uniform tier ~5× cheaper than
+   * the prior Opus-only experiments. Recovery passes (2a, 2b) inherit
+   * the same override so the recovery envelope matches the model that
+   * produced the truncated pass-1 output.
+   */
+  model?: string;
 }
 
 export interface CodingAgentResult {
@@ -452,7 +461,7 @@ async function runSdkPass(opts: SdkPassOpts): Promise<SdkPassResult> {
     const stream = query({
       prompt: makeUserStream(),
       options: {
-        model: "claude-opus-4-7",
+        model: input.model ?? "claude-opus-4-7",
         cwd: input.worktreePath,
         additionalDirectories: input.inspectPaths,
         systemPrompt: opts.systemPrompt,

--- a/src/agent/replay.test.ts
+++ b/src/agent/replay.test.ts
@@ -1,0 +1,116 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+import { applyReplayRollback, captureWorktreeDiff } from "./replay.js";
+
+const execFile = promisify(execFileCb);
+
+async function makeFixtureRepo(): Promise<{
+  repoRoot: string;
+  seedSha: string;
+  cleanup: () => Promise<void>;
+}> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "replay-test-"));
+  await execFile("git", ["init", "-q", "-b", "main", dir]);
+  await execFile("git", ["-C", dir, "config", "user.email", "test@example.com"]);
+  await execFile("git", ["-C", dir, "config", "user.name", "Test User"]);
+  await execFile("git", ["-C", dir, "config", "commit.gpgsign", "false"]);
+  await fs.writeFile(path.join(dir, "seed.txt"), "seed contents\n");
+  await execFile("git", ["-C", dir, "add", "seed.txt"]);
+  await execFile("git", ["-C", dir, "commit", "-q", "-m", "seed"]);
+  const { stdout } = await execFile("git", ["-C", dir, "rev-parse", "HEAD"]);
+  return {
+    repoRoot: dir,
+    seedSha: stdout.trim(),
+    cleanup: async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+test("applyReplayRollback: resets worktree HEAD to the supplied base SHA", async () => {
+  const { repoRoot, seedSha, cleanup } = await makeFixtureRepo();
+  try {
+    // Make a second commit on top of the seed so HEAD diverges.
+    await fs.writeFile(path.join(repoRoot, "seed.txt"), "post-seed contents\n");
+    await execFile("git", ["-C", repoRoot, "add", "seed.txt"]);
+    await execFile("git", ["-C", repoRoot, "commit", "-q", "-m", "second"]);
+    const { stdout: tipBefore } = await execFile("git", ["-C", repoRoot, "rev-parse", "HEAD"]);
+    assert.notEqual(tipBefore.trim(), seedSha);
+
+    await applyReplayRollback({ worktreePath: repoRoot, baseSha: seedSha });
+
+    const { stdout: tipAfter } = await execFile("git", ["-C", repoRoot, "rev-parse", "HEAD"]);
+    assert.equal(tipAfter.trim(), seedSha);
+    const seedFile = await fs.readFile(path.join(repoRoot, "seed.txt"), "utf-8");
+    assert.equal(seedFile, "seed contents\n");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("applyReplayRollback: throws on unknown SHA", async () => {
+  const { repoRoot, cleanup } = await makeFixtureRepo();
+  try {
+    await assert.rejects(
+      applyReplayRollback({
+        worktreePath: repoRoot,
+        baseSha: "0000000000000000000000000000000000000000",
+      }),
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+test("captureWorktreeDiff: writes a diff containing both modified and newly-created tracked files", async () => {
+  const { repoRoot, cleanup } = await makeFixtureRepo();
+  try {
+    // Modify the seed file + create a new untracked file.
+    await fs.writeFile(path.join(repoRoot, "seed.txt"), "modified contents\n");
+    await fs.writeFile(path.join(repoRoot, "new.txt"), "brand new file\n");
+
+    const outPath = path.join(repoRoot, "out", "captured.diff");
+    await captureWorktreeDiff({ worktreePath: repoRoot, outPath });
+
+    const diff = await fs.readFile(outPath, "utf-8");
+    // Modified file diff
+    assert.match(diff, /diff --git a\/seed\.txt b\/seed\.txt/);
+    assert.match(diff, /-seed contents/);
+    assert.match(diff, /\+modified contents/);
+    // New file diff (added because git add -A staged it)
+    assert.match(diff, /diff --git a\/new\.txt b\/new\.txt/);
+    assert.match(diff, /\+brand new file/);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("captureWorktreeDiff: writes an empty file when worktree is clean", async () => {
+  const { repoRoot, cleanup } = await makeFixtureRepo();
+  try {
+    const outPath = path.join(repoRoot, "out", "empty.diff");
+    await captureWorktreeDiff({ worktreePath: repoRoot, outPath });
+    const diff = await fs.readFile(outPath, "utf-8");
+    assert.equal(diff, "");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("captureWorktreeDiff: creates parent directory of outPath if missing", async () => {
+  const { repoRoot, cleanup } = await makeFixtureRepo();
+  try {
+    await fs.writeFile(path.join(repoRoot, "seed.txt"), "x\n");
+    const outPath = path.join(repoRoot, "deeply", "nested", "dir", "out.diff");
+    await captureWorktreeDiff({ worktreePath: repoRoot, outPath });
+    const stat = await fs.stat(outPath);
+    assert.ok(stat.isFile());
+  } finally {
+    await cleanup();
+  }
+});

--- a/src/agent/replay.ts
+++ b/src/agent/replay.ts
@@ -1,0 +1,65 @@
+// Per-cell rollback + diff capture for the curve-redo calibration flow
+// (Phase 1a of the curve-redo plan). Both helpers operate on a worktree
+// directory and shell out to git via `execFile`.
+//
+// `runIssueCore` calls these when its `replayMode` field is set:
+//   - applyReplayRollback runs BEFORE the coding agent so the worktree
+//     reflects the issue's pre-fix base SHA (closed-issue replay).
+//   - captureWorktreeDiff runs AFTER the agent finishes so the worktree's
+//     uncommitted edits are persisted before removeWorktree teardown.
+//
+// In `--dry-run` (used by the calibration flow), branch / push / PR-create
+// are intercepted at the SDK boundary, but the agent's file edits in the
+// worktree are real. Diff capture is the only way to retain those edits
+// for downstream scoring (test-runner + reasoning judge).
+
+import { execFile as execFileCb } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCb);
+
+/**
+ * Reset the worktree to a specific git SHA. Used for closed-issue replay so
+ * the coding agent encounters the codebase at the issue's pre-fix base SHA
+ * rather than current main (where the merged fix already landed).
+ *
+ * Throws if the SHA is unknown or the reset fails — callers let the
+ * orchestrator surface the error rather than swallowing it. Open-issue
+ * dispatches skip this helper entirely (no baseSha supplied).
+ */
+export async function applyReplayRollback(opts: {
+  worktreePath: string;
+  baseSha: string;
+}): Promise<void> {
+  await execFile("git", ["-C", opts.worktreePath, "reset", "--hard", opts.baseSha]);
+}
+
+/**
+ * Capture the worktree's diff (modified + new files) and write it to
+ * `outPath`. The output feeds the test-runner and reasoning judge in later
+ * phases.
+ *
+ * Approach: stage everything with `git add -A`, then emit `git diff --cached`.
+ * Staging first ensures newly-created tracked files (which `git diff HEAD`
+ * alone would miss) appear in the output. The worktree is about to be torn
+ * down by removeWorktree, so the index mutation has no lasting effect.
+ *
+ * Parent directory of `outPath` is created if missing. `maxBuffer` is set
+ * to 32 MiB — diffs from a 50-turn coding-agent run rarely exceed a few KB,
+ * but the cap protects against a runaway agent that touched many files.
+ */
+export async function captureWorktreeDiff(opts: {
+  worktreePath: string;
+  outPath: string;
+}): Promise<void> {
+  await fs.mkdir(path.dirname(opts.outPath), { recursive: true });
+  await execFile("git", ["-C", opts.worktreePath, "add", "-A"]);
+  const { stdout } = await execFile(
+    "git",
+    ["-C", opts.worktreePath, "diff", "--cached"],
+    { maxBuffer: 32 * 1024 * 1024 },
+  );
+  await fs.writeFile(opts.outPath, stdout);
+}

--- a/src/agent/runIssueCore.ts
+++ b/src/agent/runIssueCore.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "node:fs";
 import { ensureAgent, mutateRegistry } from "../state/registry.js";
 import { runCodingAgent } from "./codingAgent.js";
+import { applyReplayRollback, captureWorktreeDiff } from "./replay.js";
 import {
   agentClaudeMdPath,
   appendBlock,
@@ -84,6 +85,27 @@ export interface RunIssueCoreInput {
    * file's nominal size. Forwarded to runCodingAgent → buildAgentSystemPrompt.
    */
   suppressTargetClaudeMd?: boolean;
+  /**
+   * Coding-agent model override forwarded to runCodingAgent. Defaults to
+   * `claude-opus-4-7` when undefined. Curve-redo calibration passes
+   * `claude-sonnet-4-6` so every cell runs at a uniform tier.
+   */
+  model?: string;
+  /**
+   * Curve-redo calibration mode. When set:
+   *   - if `baseSha` is supplied, the worktree is `git reset --hard`'d to
+   *     that SHA after creation but before the coding agent runs (closed-
+   *     issue replay; open-issue cells omit baseSha and the worktree stays
+   *     at origin/main).
+   *   - after the coding agent finishes, the worktree's diff (modified +
+   *     newly-staged tracked files) is written to `captureDiffPath` so
+   *     downstream test-runner / reasoning-judge phases can score it.
+   * Undefined for normal callers — preserves pre-curve-redo behavior.
+   */
+  replayMode?: {
+    baseSha?: string;
+    captureDiffPath: string;
+  };
 }
 
 export interface RunIssueCoreResult {
@@ -141,6 +163,23 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
       resumedRunId: input.resumeContext?.runId,
     });
 
+    // Curve-redo replay-mode rollback: when a baseSha is supplied (closed-
+    // issue replay), reset the worktree HEAD to that SHA before the agent
+    // runs so it encounters the pre-fix codebase state. Open-issue cells
+    // omit baseSha and the worktree stays at origin/main. Throws on bad
+    // SHA — orchestrator surfaces it via the per-cell error envelope.
+    if (input.replayMode?.baseSha) {
+      await applyReplayRollback({
+        worktreePath: worktree.path,
+        baseSha: input.replayMode.baseSha,
+      });
+      input.logger.info("agent.replay_rollback", {
+        agentId: input.agent.agentId,
+        issueId: input.issue.id,
+        baseSha: input.replayMode.baseSha,
+      });
+    }
+
     const result = await runCodingAgent({
       agent: input.agent,
       issueId: input.issue.id,
@@ -156,7 +195,32 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
       autoPhaseFollowup: input.autoPhaseFollowup,
       issueBodyOnly: input.issueBodyOnly,
       suppressTargetClaudeMd: input.suppressTargetClaudeMd,
+      model: input.model,
     });
+
+    // Curve-redo replay-mode diff capture: persist the agent's worktree
+    // edits before any teardown. Best-effort — a capture failure must not
+    // mask a successful run, so we log + continue rather than throw.
+    if (input.replayMode?.captureDiffPath) {
+      try {
+        await captureWorktreeDiff({
+          worktreePath: worktree.path,
+          outPath: input.replayMode.captureDiffPath,
+        });
+        input.logger.info("agent.replay_diff_captured", {
+          agentId: input.agent.agentId,
+          issueId: input.issue.id,
+          path: input.replayMode.captureDiffPath,
+        });
+      } catch (err) {
+        input.logger.warn("agent.replay_diff_capture_failed", {
+          agentId: input.agent.agentId,
+          issueId: input.issue.id,
+          path: input.replayMode.captureDiffPath,
+          err: (err as Error).message,
+        });
+      }
+    }
 
     envelope = result.envelope;
     let appendOutcome: AppendOutcome | undefined;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -270,6 +270,18 @@ export function buildCli(): Command {
       "--no-target-claude-md",
       "Suppress the live target-repo CLAUDE.md prepend in the agent's system prompt. Default: prepend on (every dispatch's effective context = target-repo CLAUDE.md + per-agent CLAUDE.md). Used by curve-study calibration to keep the effective context size equal to the per-agent CLAUDE.md size we're varying.",
     )
+    .option(
+      "--model <name>",
+      "Coding-agent model override (default: claude-opus-4-7). Curve-redo calibration passes claude-sonnet-4-6 so every cell runs at a uniform tier ~5× cheaper than the prior Opus-only experiments. Recovery passes inherit this override.",
+    )
+    .option(
+      "--replay-base-sha <sha>",
+      "Curve-redo replay mode: reset the worktree HEAD to the supplied git SHA before the agent runs (closed-issue replay so the agent encounters the pre-fix codebase state). Open-issue cells omit this flag and stay at origin/main.",
+    )
+    .option(
+      "--capture-diff-path <path>",
+      "Curve-redo replay mode: after the agent finishes, write the worktree's diff (modified + newly-staged tracked files) to this path so downstream test-runner / reasoning-judge phases can score it.",
+    )
     .action(async (opts) => {
       await cmdSpawn(opts);
     });
@@ -2684,6 +2696,12 @@ interface SpawnOpts {
   issueBodyOnly?: boolean;
   /** commander's --no-target-claude-md sets `targetClaudeMd: false`. */
   targetClaudeMd?: boolean;
+  /** Curve-redo: model override threaded into runIssueCore → runCodingAgent. */
+  model?: string;
+  /** Curve-redo: optional base SHA for closed-issue replay. */
+  replayBaseSha?: string;
+  /** Curve-redo: optional path to write the post-run worktree diff. */
+  captureDiffPath?: string;
 }
 
 async function cmdSpawn(opts: SpawnOpts): Promise<void> {
@@ -2732,6 +2750,24 @@ async function cmdSpawn(opts: SpawnOpts): Promise<void> {
       ? opts.inspectPaths.split(",").map((s) => s.trim()).filter((s) => s.length > 0)
       : undefined;
 
+    const replayMode =
+      opts.replayBaseSha || opts.captureDiffPath
+        ? {
+            baseSha: opts.replayBaseSha,
+            // Capture path is required when replay mode is used at all —
+            // there's no point doing a rollback if we don't keep the diff.
+            // Mirror the flag absence as a friendly error rather than a
+            // type-system one.
+            captureDiffPath: opts.captureDiffPath ?? "",
+          }
+        : undefined;
+    if (replayMode && !replayMode.captureDiffPath) {
+      process.stderr.write(
+        "ERROR: --replay-base-sha was passed without --capture-diff-path. Replay-mode runs need a destination for the post-run diff or the rollback is wasted.\n",
+      );
+      process.exit(2);
+    }
+
     const result = await runIssueCore({
       agent,
       issue,
@@ -2744,6 +2780,8 @@ async function cmdSpawn(opts: SpawnOpts): Promise<void> {
       inspectPaths,
       issueBodyOnly: !!opts.issueBodyOnly,
       suppressTargetClaudeMd: opts.targetClaudeMd === false,
+      model: opts.model,
+      replayMode,
     });
 
     const out = {


### PR DESCRIPTION
## Summary

Phase 1a of the curve-redo experiment plan ([plan file](https://github.com/szhygulin/claude-md-global/blob/main/.claude/plans/how-the-proposed-plan-bubbly-peach.md) — local). Adds three primitives to `vp-dev spawn` that the redo needs in place before the test generator, test runner, and reasoning judge can be wired in:

- `--model <name>` — override the coding-agent SDK model. Default preserved as `claude-opus-4-7`; calibration cells will pass `claude-sonnet-4-6` so every cell runs at a uniform tier ~5× cheaper than the prior Opus-only runs. Recovery passes (2a, 2b) inherit the override.
- `--replay-base-sha <sha>` — closed-issue replay: `git reset --hard <sha>` on the worktree before the agent runs, so it encounters the pre-fix codebase rather than current main where the merged fix already landed. Open-issue cells omit the flag.
- `--capture-diff-path <p>` — after the agent finishes, persist the worktree's diff (modified + newly-staged tracked files) to `<p>` so downstream test-runner + reasoning-judge phases can score it. In `--dry-run` the SDK intercepts push / PR-create but file edits are real; capture is the only way to retain them across `removeWorktree` teardown.

The flags are gated by a new `RunIssueCoreInput.replayMode` field — undefined for normal callers, preserving pre-curve-redo behavior.

## Why

The shipped curve constants in `src/util/contextCostCurve.ts` are calibrated against a quality metric that grades cells off the agent's self-reported envelope label (`decision="implement"` → 1.0, `pushback` → 0.5). That label is set inside the agent's own narrative; in `--dry-run` it doesn't reflect whether the implementation actually solves the issue. Phase 2 of the original experiment produced uniform `quality=0.75` across every trim size — the curve's quality axis carries no signal.

The redo replaces label-grading with a 0-200 LLM-driven metric:

```
quality_per_cell =
  A + B   if decision == "implement"   (range 0..200)
  2 × A   if decision == "pushback"    (range 0..200)
  0       if decision == "error" / parse failure / test apply failed

A — reasoning judge (0-100): blinded Opus K=3 on the diff or pushback comment
B — hidden-test pass rate (0-100): Opus pre-generates 100 fail-on-baseline tests
    per issue; agents don't see them; each cell's diff is tested against the set
```

This PR is just the plumbing for replay-mode dispatch. Later phases land separately.

## Files

- `src/agent/replay.ts` (new) — `applyReplayRollback` + `captureWorktreeDiff` helpers
- `src/agent/replay.test.ts` (new) — 5 tests against a tempdir git fixture (rollback success, rollback throws on bad SHA, diff captures modified + new files, empty-clean case, parent-dir creation)
- `src/agent/codingAgent.ts` — `model?: string` on `CodingAgentInput`; `input.model ?? "claude-opus-4-7"` at the SDK call site
- `src/agent/runIssueCore.ts` — `model?` and `replayMode?` on `RunIssueCoreInput`; rollback after `createWorktree`, capture after `runCodingAgent` (both gated, both fail-soft on capture)
- `src/cli.ts` — three new `vp-dev spawn` flags + `SpawnOpts` fields + plumbing into `runIssueCore`

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 663 / 663 pass (5 new replay tests included)
- [x] `vp-dev spawn --help` shows the three new flags with the documented descriptions
- [ ] Smoke an end-to-end `vp-dev spawn --replay-base-sha <sha> --capture-diff-path /tmp/foo.diff --model claude-sonnet-4-6 ...` against one open issue once the corpus exists (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)