### PR TITLE
fix(gh): retry transient `gh issue view` failures with 2s/5s backoff

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "typecheck": "tsc --noEmit",
-    "test": "tsc && node --test dist/src/util/*.test.js dist/src/git/*.test.js dist/src/orchestrator/*.test.js dist/src/agent/*.test.js dist/src/state/*.test.js dist/src/research/curveStudy/*.test.js dist/src/research/specialistBench/*.test.js",
+    "test": "tsc && node --test dist/src/util/*.test.js dist/src/git/*.test.js dist/src/orchestrator/*.test.js dist/src/agent/*.test.js dist/src/state/*.test.js dist/src/research/curveStudy/*.test.js dist/src/research/specialistBench/*.test.js dist/src/github/*.test.js",
     "vp-dev": "node dist/bin/vp-dev.js"
   },
   "dependencies": {

--- a/src/github/gh.test.ts
+++ b/src/github/gh.test.ts
@@ -1,0 +1,106 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { getIssue } from "./gh.js";
+
+// Stub-shaped issue record that `fetchIssueRecord` would return on a
+// successful `gh issue view` call. The retry tests inject a fake fetcher
+// via the `_fetch` test seam so no real `gh` shell-out happens.
+const FIXTURE_RECORD = {
+  number: 204,
+  title: "fix(curve-study): transient gh issue view 404 should retry",
+  state: "OPEN",
+  labels: [{ name: "bug" }],
+};
+
+test("getIssue: first-attempt success returns issue, no retries fired", async () => {
+  let calls = 0;
+  const sleeps: number[] = [];
+  const result = await getIssue("owner/repo", 204, {
+    sleep: async (ms) => { sleeps.push(ms); },
+    _fetch: async () => {
+      calls += 1;
+      return FIXTURE_RECORD;
+    },
+  });
+  assert.equal(calls, 1);
+  assert.deepEqual(sleeps, []);
+  assert.equal(result?.id, 204);
+  assert.equal(result?.title, FIXTURE_RECORD.title);
+  assert.equal(result?.state, "open");
+  assert.deepEqual(result?.labels, ["bug"]);
+});
+
+test("getIssue: transient failure then success returns issue after retry", async () => {
+  let calls = 0;
+  const sleeps: number[] = [];
+  const onRetryAttempts: number[] = [];
+  const result = await getIssue("owner/repo", 172, {
+    retryDelaysMs: [10, 20],
+    sleep: async (ms) => { sleeps.push(ms); },
+    onRetry: (attempt) => { onRetryAttempts.push(attempt); },
+    _fetch: async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("HTTP 404 transient");
+      return { ...FIXTURE_RECORD, number: 172, title: "transient ok" };
+    },
+  });
+  assert.equal(calls, 2);
+  assert.deepEqual(sleeps, [10]);
+  assert.deepEqual(onRetryAttempts, [1]);
+  assert.equal(result?.id, 172);
+});
+
+test("getIssue: persistent failure exhausts retries and returns null", async () => {
+  let calls = 0;
+  const sleeps: number[] = [];
+  const onRetryAttempts: number[] = [];
+  const result = await getIssue("owner/repo", 999, {
+    retryDelaysMs: [10, 20],
+    sleep: async (ms) => { sleeps.push(ms); },
+    onRetry: (attempt) => { onRetryAttempts.push(attempt); },
+    _fetch: async () => {
+      calls += 1;
+      throw new Error("HTTP 404: not found");
+    },
+  });
+  // delays.length + 1 = 3 total attempts; 2 retry sleeps fire between them.
+  assert.equal(calls, 3);
+  assert.deepEqual(sleeps, [10, 20]);
+  assert.deepEqual(onRetryAttempts, [1, 2]);
+  assert.equal(result, null);
+});
+
+test("getIssue: empty retryDelaysMs disables retries (legacy single-attempt path)", async () => {
+  let calls = 0;
+  const sleeps: number[] = [];
+  const result = await getIssue("owner/repo", 999, {
+    retryDelaysMs: [],
+    sleep: async (ms) => { sleeps.push(ms); },
+    _fetch: async () => {
+      calls += 1;
+      throw new Error("transient");
+    },
+  });
+  assert.equal(calls, 1);
+  assert.deepEqual(sleeps, []);
+  assert.equal(result, null);
+});
+
+test("getIssue: success on the LAST retry attempt still returns the issue (no off-by-one)", async () => {
+  // Three total attempts; first two fail, third succeeds. Verifies the
+  // loop doesn't accidentally bail on the last retry.
+  let calls = 0;
+  const sleeps: number[] = [];
+  const result = await getIssue("owner/repo", 180, {
+    retryDelaysMs: [5, 10],
+    sleep: async (ms) => { sleeps.push(ms); },
+    _fetch: async () => {
+      calls += 1;
+      if (calls < 3) throw new Error("hiccup");
+      return { ...FIXTURE_RECORD, number: 180, title: "ok" };
+    },
+  });
+  assert.equal(calls, 3);
+  assert.deepEqual(sleeps, [5, 10]);
+  assert.equal(result?.id, 180);
+});

--- a/src/github/gh.ts
+++ b/src/github/gh.ts
@@ -51,24 +51,89 @@ export async function listOpenIssues(targetRepo: string): Promise<IssueSummary[]
   return records.map(toSummary);
 }
 
-export async function getIssue(targetRepo: string, number: number): Promise<IssueSummary | null> {
-  try {
-    const { stdout } = await execFile(
-      "gh",
-      [
-        "issue",
-        "view",
-        String(number),
-        "--repo",
-        targetRepo,
-        "--json",
-        "number,title,state,labels",
-      ],
-      { maxBuffer: 5 * 1024 * 1024 },
-    );
-    return toSummary(JSON.parse(stdout) as GhIssueRecord);
-  } catch {
-    return null;
+/**
+ * Default retry delays (ms) for `getIssue`. Two retries with a 2s/5s backoff —
+ * picked to ride out transient GitHub-side 404s / rate-limits / network
+ * hiccups without burning more than ~7s on a genuinely-missing issue.
+ *
+ * Issue #204: the curve-study leg-2 dispatch saw two cells exit `rc=2`
+ * with "issue not found" on issues that other cells in the same run had
+ * fetched successfully — a brief gh API hiccup. Without retries those
+ * cells were silently dropped from the scoring pass; with retries the
+ * `rc=2` outcome only fires on issues that genuinely cannot be fetched.
+ */
+const DEFAULT_GH_ISSUE_VIEW_RETRY_DELAYS_MS = [2000, 5000];
+
+export interface GetIssueOptions {
+  /**
+   * Per-attempt sleep durations (ms) between retries. The number of
+   * delays equals the number of retries; total attempts = `delays.length + 1`.
+   * Pass `[]` to disable retries (matches the legacy single-attempt
+   * behavior). Defaults to `DEFAULT_GH_ISSUE_VIEW_RETRY_DELAYS_MS`.
+   */
+  retryDelaysMs?: number[];
+  /**
+   * Sleep hook. Tests pass a synchronous-resolving stub so the retry
+   * loop runs at unit-test speed; production callers leave this unset.
+   */
+  sleep?: (ms: number) => Promise<void>;
+  /**
+   * Fired once per retry attempt (after the failure, before the sleep).
+   * Optional visibility hook for run-level loggers; the function also
+   * writes a one-line breadcrumb to stderr unconditionally.
+   */
+  onRetry?: (attempt: number, err: unknown) => void;
+  /**
+   * Test-only override for the underlying `gh issue view` shell-out.
+   * Default invokes the real `gh` CLI. Underscored to signal "test seam,
+   * do not use from production code".
+   */
+  _fetch?: (targetRepo: string, number: number) => Promise<GhIssueRecord>;
+}
+
+async function fetchIssueRecord(targetRepo: string, number: number): Promise<GhIssueRecord> {
+  const { stdout } = await execFile(
+    "gh",
+    [
+      "issue",
+      "view",
+      String(number),
+      "--repo",
+      targetRepo,
+      "--json",
+      "number,title,state,labels",
+    ],
+    { maxBuffer: 5 * 1024 * 1024 },
+  );
+  return JSON.parse(stdout) as GhIssueRecord;
+}
+
+export async function getIssue(
+  targetRepo: string,
+  number: number,
+  opts?: GetIssueOptions,
+): Promise<IssueSummary | null> {
+  const delays = opts?.retryDelaysMs ?? DEFAULT_GH_ISSUE_VIEW_RETRY_DELAYS_MS;
+  const sleep = opts?.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const fetchOnce = opts?._fetch ?? fetchIssueRecord;
+  const totalAttempts = delays.length + 1;
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      const rec = await fetchOnce(targetRepo, number);
+      return toSummary(rec);
+    } catch (err) {
+      if (attempt >= totalAttempts) return null;
+      const delay = delays[attempt - 1];
+      opts?.onRetry?.(attempt, err);
+      // Operator-visible breadcrumb so a mid-run gh hiccup shows up in
+      // the cell log instead of vanishing into the silent-null path.
+      // The issue (#204) traced two leg-2 `rc=2` cells back to exactly
+      // this gap — the retry is invisible without a log line here.
+      process.stderr.write(
+        `[gh] issue view ${targetRepo}#${number} failed (attempt ${attempt}/${totalAttempts}); retrying in ${delay}ms\n`,
+      );
+      await sleep(delay);
+    }
   }
 }
 


### PR DESCRIPTION
Closes #204.

## Summary

- `getIssue` now retries transient `gh issue view` failures with a 2s/5s backoff (2 retries → 3 total attempts). After exhausted retries it still returns `null`, so a genuinely-missing issue still exits `rc=2` with no infinite loop — matching the issue's acceptance criteria.
- Each retry writes a one-line breadcrumb to stderr so a transient hiccup shows up in the cell log instead of vanishing into the silent-null path that misled the leg-2 debug pass.
- The retry lives in the `getIssue` wrapper, so all three call sites benefit: `cmdSpawn` (the curve-study cell path that produced the symptom in #179), `cmdAgentsPick`, and `resolveRangeToIssues` (the `vp-dev run --issues N..M` path).

## Design notes

- **Why retry on all errors, not just 404/429**: gh's stderr formatting varies across versions and the user's repro inferred the transient nature from "other cells fetched the same issue successfully," not from inspecting stderr. A blanket "retry, then give up" is conservative against future flake shapes and the cost on a real not-found is bounded (~7s + 2 extra `gh` calls).
- **Why in the wrapper not the call site**: the same swallow-error-as-null pattern exists in every `getIssue` consumer; centralizing the retry means each consumer transparently inherits resilience.
- **Test seam**: `_fetch` and `sleep` hooks let unit tests exercise the loop deterministically without shelling out to `gh` or sleeping on real timers. Five cases cover first-attempt success, transient-then-success, persistent failure, the empty-delays legacy path, and a no-off-by-one check on the last retry.

## Test plan

- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (663 tests, +5 new in `src/github/gh.test.ts`)
- [x] New tests cover: success-no-retry, transient-then-success, persistent-failure-returns-null, empty-delays-legacy, last-retry-success (off-by-one guard)

— Sofia (agent-2a3d)
