### PR TITLE
feat(local-claude): vp-dev lessons clear-local-queue --merged drops already-merged entries

### DIFF
--- a/src/agent/localClaudeQueueClear.test.ts
+++ b/src/agent/localClaudeQueueClear.test.ts
@@ -1,0 +1,470 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  BODY_PREFIX_FOR_MATCH,
+  DEFAULT_QUEUE_CLEAR_JACCARD_MIN,
+  clearLocalClaudeQueue,
+  detectMergedQueueEntries,
+  jaccard,
+  parseProjectClaudeSections,
+  parseQueueEntries,
+  resolveQueueClearJaccardMin,
+  similarityScore,
+  tokenize,
+} from "./localClaudeQueueClear.js";
+import { appendToLocalClaudeQueue } from "./localClaudeQueue.js";
+
+async function withTmpDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "queue-clear-test-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------
+// resolveQueueClearJaccardMin
+// ---------------------------------------------------------------------
+
+test("resolveQueueClearJaccardMin: defaults + valid override + invalid env falls back", () => {
+  assert.equal(resolveQueueClearJaccardMin({}), DEFAULT_QUEUE_CLEAR_JACCARD_MIN);
+  assert.equal(
+    resolveQueueClearJaccardMin({ VP_DEV_QUEUE_CLEAR_JACCARD_MIN: "0.7" }),
+    0.7,
+  );
+  assert.equal(
+    resolveQueueClearJaccardMin({ VP_DEV_QUEUE_CLEAR_JACCARD_MIN: "abc" }),
+    DEFAULT_QUEUE_CLEAR_JACCARD_MIN,
+  );
+  assert.equal(
+    resolveQueueClearJaccardMin({ VP_DEV_QUEUE_CLEAR_JACCARD_MIN: "0" }),
+    DEFAULT_QUEUE_CLEAR_JACCARD_MIN,
+  );
+  assert.equal(
+    resolveQueueClearJaccardMin({ VP_DEV_QUEUE_CLEAR_JACCARD_MIN: "1.5" }),
+    DEFAULT_QUEUE_CLEAR_JACCARD_MIN,
+  );
+});
+
+test("DEFAULT_QUEUE_CLEAR_JACCARD_MIN is in (0, 1)", () => {
+  assert.ok(
+    DEFAULT_QUEUE_CLEAR_JACCARD_MIN > 0 && DEFAULT_QUEUE_CLEAR_JACCARD_MIN < 1,
+    `expected default in (0, 1); got ${DEFAULT_QUEUE_CLEAR_JACCARD_MIN}`,
+  );
+});
+
+// ---------------------------------------------------------------------
+// tokenize / jaccard
+// ---------------------------------------------------------------------
+
+test("tokenize: drops short + stop words, lowercases, splits on non-alphanumerics", () => {
+  const tokens = tokenize("The Quick Brown Fox jumps over the LAZY dog.");
+  assert.ok(!tokens.has("the"));
+  assert.ok(tokens.has("quick"));
+  assert.ok(tokens.has("brown"));
+  assert.ok(tokens.has("fox"));
+  assert.ok(tokens.has("jumps"));
+  assert.ok(tokens.has("lazy"));
+});
+
+test("jaccard: identity = 1, disjoint = 0, partial overlap in (0,1)", () => {
+  assert.equal(jaccard(new Set(["a", "b", "c"]), new Set(["a", "b", "c"])), 1);
+  assert.equal(jaccard(new Set(["a", "b"]), new Set(["x", "y"])), 0);
+  const partial = jaccard(new Set(["a", "b", "c"]), new Set(["b", "c", "d"]));
+  assert.ok(partial > 0 && partial < 1);
+});
+
+// ---------------------------------------------------------------------
+// parseQueueEntries
+// ---------------------------------------------------------------------
+
+test("parseQueueEntries: parses a single entry written by appendToLocalClaudeQueue", async () => {
+  await withTmpDir(async (dir) => {
+    const filePath = path.join(dir, "queue.md");
+    await appendToLocalClaudeQueue({
+      sourceAgentId: "agent-test",
+      ts: "2026-05-06T15:00:00.000Z",
+      utility: 0.8,
+      body: "## Some Project Rule\n\nBody content here.",
+      filePathOverride: filePath,
+    });
+    const content = await fs.readFile(filePath, "utf-8");
+    const entries = parseQueueEntries(content);
+    assert.equal(entries.length, 1);
+    assert.match(entries[0].header, /^<!-- queued source=agent-test/);
+    assert.equal(entries[0].heading, "Some Project Rule");
+    assert.match(entries[0].body, /Body content here\./);
+  });
+});
+
+test("parseQueueEntries: parses multiple entries in order", async () => {
+  await withTmpDir(async (dir) => {
+    const filePath = path.join(dir, "queue.md");
+    await appendToLocalClaudeQueue({
+      sourceAgentId: "agent-a",
+      ts: "T1",
+      body: "## First\n\nFirst body",
+      filePathOverride: filePath,
+    });
+    await appendToLocalClaudeQueue({
+      sourceAgentId: "agent-b",
+      ts: "T2",
+      body: "## Second\n\nSecond body",
+      filePathOverride: filePath,
+    });
+    await appendToLocalClaudeQueue({
+      sourceAgentId: "agent-c",
+      ts: "T3",
+      body: "## Third\n\nThird body",
+      filePathOverride: filePath,
+    });
+    const content = await fs.readFile(filePath, "utf-8");
+    const entries = parseQueueEntries(content);
+    assert.equal(entries.length, 3);
+    assert.equal(entries[0].heading, "First");
+    assert.equal(entries[1].heading, "Second");
+    assert.equal(entries[2].heading, "Third");
+  });
+});
+
+test("parseQueueEntries: empty queue returns []", () => {
+  assert.deepEqual(parseQueueEntries(""), []);
+});
+
+test("parseQueueEntries: handles entry without `## Heading` line gracefully", () => {
+  const raw = "\n<!-- queued source=agent-x ts=T1 -->\nplain body without heading\n";
+  const entries = parseQueueEntries(raw);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].heading, "");
+  assert.match(entries[0].body, /plain body without heading/);
+});
+
+// ---------------------------------------------------------------------
+// parseProjectClaudeSections
+// ---------------------------------------------------------------------
+
+test("parseProjectClaudeSections: walks `## Heading` blocks regardless of preamble", () => {
+  const md = `# Project rules
+
+Some preface text.
+
+## First rule
+
+Body of first rule.
+
+<!-- promoted-from-summarizer source=agent-a ts=T1 -->
+## Second rule
+
+Body of second rule.
+
+<!-- run:r1 issue:#5 outcome:implement ts:2026-01-01T00:00:00Z -->
+## Third rule
+
+Body of third rule.
+`;
+  const sections = parseProjectClaudeSections(md);
+  assert.equal(sections.length, 3);
+  assert.equal(sections[0].heading, "First rule");
+  assert.equal(sections[1].heading, "Second rule");
+  assert.equal(sections[2].heading, "Third rule");
+  assert.match(sections[2].body, /Body of third rule\./);
+});
+
+test("parseProjectClaudeSections: empty CLAUDE.md returns []", () => {
+  assert.deepEqual(parseProjectClaudeSections(""), []);
+  assert.deepEqual(parseProjectClaudeSections("# Title only\n\nNo subheadings.\n"), []);
+});
+
+// ---------------------------------------------------------------------
+// similarityScore + detectMergedQueueEntries
+// ---------------------------------------------------------------------
+
+test("similarityScore: identical heading + body = 1", () => {
+  const entry = {
+    header: "<!-- queued ... -->",
+    heading: "My Rule",
+    body: "Important content about widget configuration",
+    raw: "...",
+    startOffset: 0,
+  };
+  const section = {
+    heading: "My Rule",
+    body: "Important content about widget configuration",
+  };
+  assert.equal(similarityScore(entry, section), 1);
+});
+
+test("similarityScore: disjoint = 0", () => {
+  const entry = {
+    header: "<!-- queued ... -->",
+    heading: "Solana validator forensics",
+    body: "epoch boundary slot inclusion proofs",
+    raw: "...",
+    startOffset: 0,
+  };
+  const section = {
+    heading: "Aave liquidations",
+    body: "interest rate model",
+  };
+  assert.equal(similarityScore(entry, section), 0);
+});
+
+test("similarityScore: heading reworded but body preserved still scores high (the issue's motivation)", () => {
+  // Issue #202: "heading-only Jaccard would miss reworded sections."
+  const entry = {
+    header: "<!-- queued ... -->",
+    heading: "Push-back discipline",
+    body: "When the issue body's premise is wrong, push back before acting. Compose a comment with one mismatch sentence and 2-3 alternatives. Don't begin implementation if the framing is faulty.",
+    raw: "...",
+    startOffset: 0,
+  };
+  // Operator reworded the heading when opening the chore PR.
+  const section = {
+    heading: "When to push back on an issue",
+    body: "When the issue body's premise is wrong, push back before acting. Compose a comment with one mismatch sentence and 2-3 alternatives. Don't begin implementation if the framing is faulty.",
+  };
+  const score = similarityScore(entry, section);
+  assert.ok(
+    score >= 0.7,
+    `expected high similarity from body-prefix overlap; got ${score}`,
+  );
+});
+
+test("detectMergedQueueEntries: surfaces only entries above threshold", async () => {
+  await withTmpDir(async (dir) => {
+    const queuePath = path.join(dir, "queue.md");
+    await appendToLocalClaudeQueue({
+      sourceAgentId: "agent-1",
+      ts: "T1",
+      body: "## Rule about widgets\n\nWidgets should be configured with setting X for proper operation.",
+      filePathOverride: queuePath,
+    });
+    await appendToLocalClaudeQueue({
+      sourceAgentId: "agent-2",
+      ts: "T2",
+      body: "## Rule about gizmos\n\nGizmos must be calibrated quarterly to maintain accuracy.",
+      filePathOverride: queuePath,
+    });
+    const queueContent = await fs.readFile(queuePath, "utf-8");
+    // Project CLAUDE.md only has the widgets section (the gizmo PR hasn't merged).
+    const claudeMd = `# Project rules
+
+## Rule about widgets
+
+Widgets should be configured with setting X for proper operation.
+`;
+    const result = detectMergedQueueEntries({ queueContent, claudeMd });
+    assert.equal(result.entries.length, 2);
+    assert.equal(result.merged.length, 1);
+    assert.equal(result.merged[0].entry.heading, "Rule about widgets");
+    assert.ok(result.merged[0].similarity >= DEFAULT_QUEUE_CLEAR_JACCARD_MIN);
+  });
+});
+
+test("detectMergedQueueEntries: empty CLAUDE.md → no matches", async () => {
+  await withTmpDir(async (dir) => {
+    const queuePath = path.join(dir, "queue.md");
+    await appendToLocalClaudeQueue({
+      sourceAgentId: "agent-1",
+      ts: "T1",
+      body: "## Some rule\n\nBody.",
+      filePathOverride: queuePath,
+    });
+    const queueContent = await fs.readFile(queuePath, "utf-8");
+    const result = detectMergedQueueEntries({ queueContent, claudeMd: "" });
+    assert.equal(result.entries.length, 1);
+    assert.equal(result.merged.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------
+// clearLocalClaudeQueue (mutation)
+// ---------------------------------------------------------------------
+
+test("clearLocalClaudeQueue: --all mode empties the file", async () => {
+  await withTmpDir(async (dir) => {
+    const queuePath = path.join(dir, "queue.md");
+    const claudeMdPath = path.join(dir, "CLAUDE.md");
+    await fs.writeFile(claudeMdPath, "# nothing relevant\n");
+    await appendToLocalClaudeQueue({
+      sourceAgentId: "agent-1",
+      ts: "T1",
+      body: "## A\n\nbody-a",
+      filePathOverride: queuePath,
+    });
+    await appendToLocalClaudeQueue({
+      sourceAgentId: "agent-2",
+      ts: "T2",
+      body: "## B\n\nbody-b",
+      filePathOverride: queuePath,
+    });
+
+    const result = await clearLocalClaudeQueue({
+      mode: "all",
+      queueFilePathOverride: queuePath,
+      claudeMdPathOverride: claudeMdPath,
+    });
+    assert.equal(result.totalBefore, 2);
+    assert.equal(result.remaining, 0);
+    assert.equal(result.removed, 2);
+    const remaining = await fs.readFile(queuePath, "utf-8");
+    assert.equal(remaining, "");
+  });
+});
+
+test("clearLocalClaudeQueue: --merged mode drops only matching entries, preserves the rest", async () => {
+  await withTmpDir(async (dir) => {
+    const queuePath = path.join(dir, "queue.md");
+    const claudeMdPath = path.join(dir, "CLAUDE.md");
+    await appendToLocalClaudeQueue({
+      sourceAgentId: "agent-1",
+      ts: "T1",
+      body: "## Configure widgets\n\nWidgets need setting X for stability.",
+      filePathOverride: queuePath,
+    });
+    await appendToLocalClaudeQueue({
+      sourceAgentId: "agent-2",
+      ts: "T2",
+      body: "## Calibrate gizmos\n\nGizmos must be calibrated quarterly to maintain accuracy.",
+      filePathOverride: queuePath,
+    });
+    // Only the widgets entry has been promoted into project CLAUDE.md.
+    await fs.writeFile(
+      claudeMdPath,
+      "# Project rules\n\n## Configure widgets\n\nWidgets need setting X for stability.\n",
+    );
+
+    const result = await clearLocalClaudeQueue({
+      mode: "merged",
+      queueFilePathOverride: queuePath,
+      claudeMdPathOverride: claudeMdPath,
+    });
+    assert.equal(result.totalBefore, 2);
+    assert.equal(result.remaining, 1);
+    assert.equal(result.removed, 1);
+    assert.equal(result.matches.length, 1);
+    assert.equal(result.matches[0].entry.heading, "Configure widgets");
+    const remaining = await fs.readFile(queuePath, "utf-8");
+    assert.match(remaining, /Calibrate gizmos/);
+    assert.doesNotMatch(remaining, /Configure widgets/);
+  });
+});
+
+test("clearLocalClaudeQueue: --merged mode with no matches is a no-op (file unchanged)", async () => {
+  await withTmpDir(async (dir) => {
+    const queuePath = path.join(dir, "queue.md");
+    const claudeMdPath = path.join(dir, "CLAUDE.md");
+    await appendToLocalClaudeQueue({
+      sourceAgentId: "agent-1",
+      ts: "T1",
+      body: "## Calibrate gizmos\n\nGizmos must be calibrated quarterly.",
+      filePathOverride: queuePath,
+    });
+    await fs.writeFile(claudeMdPath, "# Project rules\n\n(nothing matches)\n");
+
+    const before = await fs.readFile(queuePath, "utf-8");
+    const result = await clearLocalClaudeQueue({
+      mode: "merged",
+      queueFilePathOverride: queuePath,
+      claudeMdPathOverride: claudeMdPath,
+    });
+    assert.equal(result.removed, 0);
+    assert.equal(result.matches.length, 0);
+    const after = await fs.readFile(queuePath, "utf-8");
+    // After a write the trailing whitespace is normalized but the entry survives.
+    assert.match(after, /Calibrate gizmos/);
+    assert.match(after, /source=agent-1/);
+    // bytesAfter <= bytesBefore (whitespace can change due to renderQueueContent).
+    assert.ok(result.bytesBefore >= 0);
+    assert.ok(result.bytesAfter > 0);
+    void before;
+  });
+});
+
+test("clearLocalClaudeQueue: missing queue file → 0 totals, 0 mutations", async () => {
+  await withTmpDir(async (dir) => {
+    const queuePath = path.join(dir, "missing-queue.md");
+    const claudeMdPath = path.join(dir, "CLAUDE.md");
+    await fs.writeFile(claudeMdPath, "# rules\n");
+    const result = await clearLocalClaudeQueue({
+      mode: "merged",
+      queueFilePathOverride: queuePath,
+      claudeMdPathOverride: claudeMdPath,
+    });
+    assert.equal(result.totalBefore, 0);
+    assert.equal(result.remaining, 0);
+    assert.equal(result.removed, 0);
+  });
+});
+
+test("clearLocalClaudeQueue: --merged with missing project CLAUDE.md → no matches (nothing dropped)", async () => {
+  await withTmpDir(async (dir) => {
+    const queuePath = path.join(dir, "queue.md");
+    const claudeMdPath = path.join(dir, "missing-CLAUDE.md");
+    await appendToLocalClaudeQueue({
+      sourceAgentId: "agent-1",
+      ts: "T1",
+      body: "## A rule\n\nBody.",
+      filePathOverride: queuePath,
+    });
+    const result = await clearLocalClaudeQueue({
+      mode: "merged",
+      queueFilePathOverride: queuePath,
+      claudeMdPathOverride: claudeMdPath,
+    });
+    assert.equal(result.totalBefore, 1);
+    assert.equal(result.removed, 0);
+    assert.equal(result.matches.length, 0);
+  });
+});
+
+test("clearLocalClaudeQueue: explicit threshold override changes which entries match", async () => {
+  await withTmpDir(async (dir) => {
+    const queuePath = path.join(dir, "queue.md");
+    const claudeMdPath = path.join(dir, "CLAUDE.md");
+    await appendToLocalClaudeQueue({
+      sourceAgentId: "agent-1",
+      ts: "T1",
+      body:
+        "## Push-back discipline\n\nWhen the issue's premise is wrong, comment with one mismatch sentence and alternatives.",
+      filePathOverride: queuePath,
+    });
+    // Project CLAUDE.md has a partial-overlap section.
+    await fs.writeFile(
+      claudeMdPath,
+      "# rules\n\n## Push-back discipline\n\nWhen something is wrong comment.\n",
+    );
+
+    // Strict threshold (0.95) → no match expected.
+    const strict = await clearLocalClaudeQueue({
+      mode: "merged",
+      jaccardMin: 0.95,
+      queueFilePathOverride: queuePath,
+      claudeMdPathOverride: claudeMdPath,
+    });
+    assert.equal(strict.removed, 0);
+
+    // Re-add the entry (it survives the no-op above with whitespace normalization,
+    // so we just check the lenient path against the same file).
+    const lenient = await clearLocalClaudeQueue({
+      mode: "merged",
+      jaccardMin: 0.05,
+      queueFilePathOverride: queuePath,
+      claudeMdPathOverride: claudeMdPath,
+    });
+    assert.equal(lenient.removed, 1);
+  });
+});
+
+// ---------------------------------------------------------------------
+// BODY_PREFIX_FOR_MATCH sanity
+// ---------------------------------------------------------------------
+
+test("BODY_PREFIX_FOR_MATCH is a positive integer", () => {
+  assert.ok(Number.isInteger(BODY_PREFIX_FOR_MATCH));
+  assert.ok(BODY_PREFIX_FOR_MATCH > 0);
+});

--- a/src/agent/localClaudeQueueClear.ts
+++ b/src/agent/localClaudeQueueClear.ts
@@ -1,0 +1,356 @@
+// Drop already-merged entries from `state/local-claude-md-pending.md`
+// (issue #202, follow-up to PR #196).
+//
+// Phase 2 of the project-local CLAUDE.md promotion path. PR #196's queue
+// path stages `@local-claude` candidates; the operator periodically opens a
+// chore PR appending selected sections to project-local CLAUDE.md (or uses
+// `--pr` for the auto-PR variant). After that PR merges, the queue still
+// holds the entry — there's no closed-loop signal from "merged" back to
+// the local queue. Operators end up scanning + manually deleting.
+//
+// This module gives them a tool: scan the queue, compare each entry's
+// (heading + first-N-chars body) against every section in project-local
+// CLAUDE.md via Jaccard, drop entries above threshold (`--merged`), or
+// nuke the whole queue (`--all`).
+//
+// Why a fresh parser instead of `parseClaudeMdSections` (split.ts):
+// `parseClaudeMdSections` only matches summarizer-emitted sections (those
+// preceded by `<!-- run:... -->`). Project-local CLAUDE.md sections come
+// in via PR (PR #196's localClaudePr.ts) with `<!-- promoted-from-summarizer -->`
+// preambles, OR they're hand-authored project rules with no preamble at
+// all. We need a permissive `## Heading` walker that catches both.
+//
+// Why heading + first-N-chars body Jaccard (not heading-only):
+// Issue #202's spec calls out "heading-only Jaccard would miss reworded
+// sections; full-body or first-N-chars Jaccard is more reliable." Headings
+// get edited between queue-time and PR-merge-time (operator polish);
+// bodies survive more reliably. Combining heading + body-prefix gives
+// signal in both shapes without unbounded body length diluting the score.
+//
+// Why no token-gate (vs. `prune-lessons` / `compact-claude-md`):
+// The queue file is gitignored local state. Dropping a false-positive
+// entry is recoverable from the rendered CLAUDE.md (the matching content
+// already lives there) and from Anthropic-side rate limits make
+// re-running the producing agent cheap. The compact/prune flow protects
+// proposal-vs-current-file drift across a 15-minute review window — that
+// invariant doesn't apply here because the queue is append-only and the
+// operator's review is in-process. Mirrors `cleanup incomplete-branches`
+// (which also uses bare `--apply` + TTY prompt) rather than the
+// proposal-hash dance.
+
+import { promises as fs } from "node:fs";
+import { LOCAL_CLAUDE_QUEUE_FILE } from "./localClaudeQueue.js";
+
+/**
+ * Default Jaccard threshold for the `--merged` mode. The issue defers
+ * empirical tuning to "after the queue has been used in real-world
+ * rotation," so we ship a conservative starting value: 0.55 trades a
+ * false-positive rate for a low miss rate, given that the operator
+ * reviews the advisory output before passing `--apply`.
+ *
+ * Override via `--threshold <n>` on the CLI or
+ * `VP_DEV_QUEUE_CLEAR_JACCARD_MIN` in the environment.
+ */
+export const DEFAULT_QUEUE_CLEAR_JACCARD_MIN = 0.55;
+
+/**
+ * Body prefix length compared in similarity calculations. Long bodies
+ * dilute the Jaccard signal; the first ~1KB carries the diagnostic
+ * meat of a typical lesson section.
+ */
+export const BODY_PREFIX_FOR_MATCH = 1024;
+
+export function resolveQueueClearJaccardMin(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = env.VP_DEV_QUEUE_CLEAR_JACCARD_MIN;
+  if (raw == null || raw === "") return DEFAULT_QUEUE_CLEAR_JACCARD_MIN;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0 || n > 1) {
+    return DEFAULT_QUEUE_CLEAR_JACCARD_MIN;
+  }
+  return n;
+}
+
+// ---------------------------------------------------------------------------
+// Queue parsing.
+//
+// Entries from `appendToLocalClaudeQueue` are wrapped as:
+//
+//   <BLANK or NEWLINE>
+//   <!-- queued source=... ts=... [utility=...] [gate=...] ... -->
+//   ## Heading
+//   body...
+//   <BLANK>
+//
+// The header line is the boundary. `## Heading` may be missing for
+// non-conforming entries — handle defensively: heading="" then.
+// ---------------------------------------------------------------------------
+
+export interface QueueEntry {
+  /** The full provenance header line (e.g. `<!-- queued source=... -->`). */
+  header: string;
+  /** Heading text without the leading `## ` (empty if no heading line). */
+  heading: string;
+  /** Body content following the heading (or all content after header if no heading). */
+  body: string;
+  /** Raw block, header through the entry's last non-whitespace character. */
+  raw: string;
+  /** Byte offset of the header in the source content (for stable removal). */
+  startOffset: number;
+}
+
+const QUEUE_HEADER_RE = /<!--\s*queued\b[^]*?-->/g;
+
+export function parseQueueEntries(content: string): QueueEntry[] {
+  const matches = [...content.matchAll(QUEUE_HEADER_RE)];
+  const out: QueueEntry[] = [];
+  for (let i = 0; i < matches.length; i++) {
+    const m = matches[i];
+    const startOffset = m.index ?? 0;
+    const headerEnd = startOffset + m[0].length;
+    const blockEnd =
+      i + 1 < matches.length ? matches[i + 1].index ?? content.length : content.length;
+    const after = content.slice(headerEnd, blockEnd);
+    const headingMatch = after.match(/^\s*##\s+(.+)$/m);
+    let heading = "";
+    let body = "";
+    if (headingMatch) {
+      heading = headingMatch[1].trim();
+      const headingIdxInAfter = after.indexOf(headingMatch[0]);
+      body = after.slice(headingIdxInAfter + headingMatch[0].length).trim();
+    } else {
+      body = after.trim();
+    }
+    const raw = content.slice(startOffset, blockEnd).replace(/\s+$/, "");
+    out.push({
+      header: m[0],
+      heading,
+      body,
+      raw,
+      startOffset,
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Project-local CLAUDE.md section parsing.
+//
+// Permissive walker — every `## Heading` line is a section boundary,
+// regardless of any preceding provenance comment. Captures both
+// hand-authored rules (no preamble) and PR-promoted lessons (preamble
+// from `formatLessonAppend` in localClaudePr.ts).
+// ---------------------------------------------------------------------------
+
+export interface ProjectClaudeSection {
+  heading: string;
+  body: string;
+}
+
+const HEADING_RE = /^##\s+(.+)$/gm;
+
+export function parseProjectClaudeSections(md: string): ProjectClaudeSection[] {
+  const matches = [...md.matchAll(HEADING_RE)];
+  const out: ProjectClaudeSection[] = [];
+  for (let i = 0; i < matches.length; i++) {
+    const m = matches[i];
+    const start = m.index ?? 0;
+    const end = i + 1 < matches.length ? matches[i + 1].index ?? md.length : md.length;
+    const heading = m[1].trim();
+    const headingLineEnd = start + m[0].length;
+    const body = md.slice(headingLineEnd, end).trim();
+    out.push({ heading, body });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Tokenization + Jaccard.
+//
+// Stand-alone duplicate of the helpers in `state/lessonUtility.ts`. Those
+// helpers are file-private (not exported) and tightly coupled to the
+// stable-ID-driven dedup gate; copying the small amount of code here
+// keeps the queue-clear path independent of the section-utility
+// machinery and lets the threshold/prefix length evolve separately.
+// ---------------------------------------------------------------------------
+
+const STOP_WORDS = new Set([
+  "a", "an", "and", "are", "as", "at", "be", "by", "for", "from", "has", "have",
+  "in", "into", "is", "it", "its", "of", "on", "or", "that", "the", "this",
+  "to", "was", "were", "will", "with", "but", "if", "not", "no", "so",
+]);
+
+export function tokenize(text: string): Set<string> {
+  const out = new Set<string>();
+  for (const raw of text.toLowerCase().split(/[^a-z0-9-]+/)) {
+    if (raw.length < 3) continue;
+    if (STOP_WORDS.has(raw)) continue;
+    out.add(raw);
+  }
+  return out;
+}
+
+export function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersect = 0;
+  for (const t of a) if (b.has(t)) intersect++;
+  const union = a.size + b.size - intersect;
+  return union === 0 ? 0 : intersect / union;
+}
+
+export function similarityScore(
+  entry: QueueEntry,
+  section: ProjectClaudeSection,
+): number {
+  const entryTokens = tokenize(
+    [entry.heading, entry.body.slice(0, BODY_PREFIX_FOR_MATCH)].join(" "),
+  );
+  const sectionTokens = tokenize(
+    [section.heading, section.body.slice(0, BODY_PREFIX_FOR_MATCH)].join(" "),
+  );
+  return jaccard(entryTokens, sectionTokens);
+}
+
+// ---------------------------------------------------------------------------
+// Detection (pure).
+// ---------------------------------------------------------------------------
+
+export interface QueueClearMatch {
+  entry: QueueEntry;
+  matchedSection: ProjectClaudeSection;
+  similarity: number;
+}
+
+export interface DetectMergedQueueEntriesInput {
+  queueContent: string;
+  /** Project-local CLAUDE.md content (or empty string if no file). */
+  claudeMd: string;
+  /** Override; default = resolveQueueClearJaccardMin(). */
+  jaccardMin?: number;
+}
+
+export interface DetectMergedQueueEntriesResult {
+  entries: QueueEntry[];
+  /** Subset of `entries` whose best-section similarity ≥ jaccardMin. */
+  merged: QueueClearMatch[];
+}
+
+export function detectMergedQueueEntries(
+  input: DetectMergedQueueEntriesInput,
+): DetectMergedQueueEntriesResult {
+  const min = input.jaccardMin ?? resolveQueueClearJaccardMin();
+  const entries = parseQueueEntries(input.queueContent);
+  const sections = parseProjectClaudeSections(input.claudeMd);
+  const merged: QueueClearMatch[] = [];
+  for (const entry of entries) {
+    let best: { section: ProjectClaudeSection; sim: number } | null = null;
+    for (const section of sections) {
+      const sim = similarityScore(entry, section);
+      if (!best || sim > best.sim) best = { section, sim };
+    }
+    if (best && best.sim >= min) {
+      merged.push({ entry, matchedSection: best.section, similarity: best.sim });
+    }
+  }
+  return { entries, merged };
+}
+
+// ---------------------------------------------------------------------------
+// Mutation.
+//
+// `clearLocalClaudeQueue` is the destructive entry point. It rewrites the
+// queue file via tmp-then-rename, mirroring `appendToLocalClaudeQueue`'s
+// atomicity contract. Both `mode: "all"` (nuke) and `mode: "merged"`
+// (filter by similarity) end with a fresh content blob and an atomic
+// rename — no partial writes if the process dies mid-flight.
+// ---------------------------------------------------------------------------
+
+export interface ClearLocalClaudeQueueInput {
+  mode: "all" | "merged";
+  /** Override Jaccard threshold (only used in `merged` mode). */
+  jaccardMin?: number;
+  /** Override target queue file (testability). */
+  queueFilePathOverride?: string;
+  /** Override target CLAUDE.md path (testability). Default = `CLAUDE.md`. */
+  claudeMdPathOverride?: string;
+}
+
+export interface ClearLocalClaudeQueueResult {
+  filePath: string;
+  totalBefore: number;
+  remaining: number;
+  removed: number;
+  bytesBefore: number;
+  bytesAfter: number;
+  /** Empty when `mode === "all"`; populated for `merged` so callers can log. */
+  matches: QueueClearMatch[];
+}
+
+export async function clearLocalClaudeQueue(
+  input: ClearLocalClaudeQueueInput,
+): Promise<ClearLocalClaudeQueueResult> {
+  const filePath = input.queueFilePathOverride ?? LOCAL_CLAUDE_QUEUE_FILE;
+  const claudeMdPath = input.claudeMdPathOverride ?? "CLAUDE.md";
+
+  let queueContent = "";
+  try {
+    queueContent = await fs.readFile(filePath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+  const entries = parseQueueEntries(queueContent);
+  const totalBefore = entries.length;
+  const bytesBefore = Buffer.byteLength(queueContent, "utf-8");
+
+  let matches: QueueClearMatch[] = [];
+  let kept: QueueEntry[];
+  if (input.mode === "all") {
+    kept = [];
+  } else {
+    let claudeMd = "";
+    try {
+      claudeMd = await fs.readFile(claudeMdPath, "utf-8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    }
+    const detected = detectMergedQueueEntries({
+      queueContent,
+      claudeMd,
+      jaccardMin: input.jaccardMin,
+    });
+    matches = detected.merged;
+    const toRemove = new Set(detected.merged.map((m) => m.entry.startOffset));
+    kept = entries.filter((e) => !toRemove.has(e.startOffset));
+  }
+
+  const nextContent = renderQueueContent(kept);
+  await atomicWriteFile(filePath, nextContent);
+  const bytesAfter = Buffer.byteLength(nextContent, "utf-8");
+
+  return {
+    filePath,
+    totalBefore,
+    remaining: kept.length,
+    removed: totalBefore - kept.length,
+    bytesBefore,
+    bytesAfter,
+    matches,
+  };
+}
+
+function renderQueueContent(entries: QueueEntry[]): string {
+  if (entries.length === 0) return "";
+  return entries.map((e) => `\n${e.raw.trim()}\n`).join("");
+}
+
+async function atomicWriteFile(filePath: string, content: string): Promise<void> {
+  if (content === "") {
+    // Truncate via overwrite (preserves the file so subsequent appends work).
+    await fs.writeFile(filePath, "");
+    return;
+  }
+  const tmp = `${filePath}.tmp.${process.pid}.${process.hrtime.bigint()}`;
+  await fs.writeFile(tmp, content);
+  await fs.rename(tmp, filePath);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -482,6 +482,34 @@ export function buildCli(): Command {
         .action(async (domain, opts) => {
           await cmdLessonsTrim(domain, opts);
         }),
+    )
+    .addCommand(
+      new Command("clear-local-queue")
+        .description(
+          "Drop already-merged entries from state/local-claude-md-pending.md (issue #202, follow-up to PR #196). Compares each queue entry's heading + body-prefix against project-local CLAUDE.md sections via Jaccard; entries above threshold are considered already promoted. Default: advisory (lists what would be removed). With --apply: mutates the queue file under tmp-then-rename.",
+        )
+        .option(
+          "--all",
+          "Operator override: drop EVERY queue entry (e.g. after a manual cleanup pass). Mutually exclusive with --merged.",
+        )
+        .option(
+          "--merged",
+          "Drop only entries with similarity ≥ threshold to a project-local CLAUDE.md section (default mode when neither --all nor --merged is passed)",
+        )
+        .option(
+          "--threshold <n>",
+          "Override Jaccard threshold (0..1; default 0.55, env: VP_DEV_QUEUE_CLEAR_JACCARD_MIN)",
+          parseUnitInterval,
+        )
+        .option(
+          "--apply",
+          "Actually mutate the queue file (default: list-only)",
+        )
+        .option("--yes", "Skip the y/N confirmation in --apply mode (required for non-TTY environments)")
+        .option("--json", "Print machine-readable JSON output")
+        .action(async (opts) => {
+          await cmdLessonsClearLocalQueue(opts);
+        }),
     );
   program.addCommand(lessonsCmd);
 
@@ -3487,6 +3515,204 @@ async function cmdLessonsTrim(domain: string, opts: LessonsTrimOpts): Promise<vo
   );
 }
 
+interface LessonsClearLocalQueueOpts {
+  all?: boolean;
+  merged?: boolean;
+  threshold?: number;
+  apply?: boolean;
+  yes?: boolean;
+  json?: boolean;
+}
+
+async function cmdLessonsClearLocalQueue(
+  opts: LessonsClearLocalQueueOpts,
+): Promise<void> {
+  if (opts.all && opts.merged) {
+    process.stderr.write(
+      "ERROR: --all and --merged are mutually exclusive.\n",
+    );
+    process.exit(2);
+  }
+  // Default mode: --merged. The advisory output still surfaces the full
+  // entry count + match count, so the operator sees how many entries
+  // would NOT be dropped (i.e. those still pending PR / merge).
+  const mode: "all" | "merged" = opts.all ? "all" : "merged";
+  const {
+    LOCAL_CLAUDE_QUEUE_FILE,
+  } = await import("./agent/localClaudeQueue.js");
+  const {
+    DEFAULT_QUEUE_CLEAR_JACCARD_MIN,
+    clearLocalClaudeQueue,
+    detectMergedQueueEntries,
+    parseQueueEntries,
+    resolveQueueClearJaccardMin,
+  } = await import("./agent/localClaudeQueueClear.js");
+
+  const threshold = opts.threshold ?? resolveQueueClearJaccardMin();
+  const queueFilePath = LOCAL_CLAUDE_QUEUE_FILE;
+  const claudeMdPath = "CLAUDE.md";
+
+  // Read current state for advisory output. Both file-not-found cases are
+  // benign: missing queue → nothing to do; missing CLAUDE.md → no merges.
+  let queueContent = "";
+  try {
+    queueContent = await fs.readFile(queueFilePath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+  let claudeMd = "";
+  try {
+    claudeMd = await fs.readFile(claudeMdPath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+
+  const allEntries = parseQueueEntries(queueContent);
+  const detected =
+    mode === "merged"
+      ? detectMergedQueueEntries({
+          queueContent,
+          claudeMd,
+          jaccardMin: threshold,
+        })
+      : { entries: allEntries, merged: [] };
+  const candidatesToRemove =
+    mode === "all" ? allEntries : detected.merged.map((m) => m.entry);
+
+  if (opts.json && !opts.apply) {
+    const payload = {
+      mode,
+      threshold: mode === "merged" ? threshold : undefined,
+      defaultThreshold: DEFAULT_QUEUE_CLEAR_JACCARD_MIN,
+      queueFilePath,
+      claudeMdPath,
+      totalEntries: allEntries.length,
+      candidatesToRemove: candidatesToRemove.length,
+      matches: detected.merged.map((m) => ({
+        sourceHeader: m.entry.header,
+        heading: m.entry.heading,
+        similarity: Number(m.similarity.toFixed(4)),
+        matchedSectionHeading: m.matchedSection.heading,
+      })),
+    };
+    process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
+    return;
+  }
+
+  if (allEntries.length === 0) {
+    process.stdout.write(
+      `Queue is empty (${queueFilePath}). Nothing to clear.\n`,
+    );
+    return;
+  }
+
+  // Advisory header.
+  process.stdout.write(
+    `Queue: ${queueFilePath} (${allEntries.length} entries, ${queueContent.length} bytes)\n`,
+  );
+  if (mode === "merged") {
+    process.stdout.write(
+      `Mode: --merged (threshold ${threshold}; project CLAUDE.md: ${
+        claudeMd.length > 0 ? `${claudeMd.length} bytes` : "MISSING — no merges detectable"
+      })\n`,
+    );
+    if (detected.merged.length === 0) {
+      process.stdout.write(
+        "No queue entries match a section in project-local CLAUDE.md above threshold. Nothing to drop.\n",
+      );
+      return;
+    }
+    process.stdout.write(
+      `\n${detected.merged.length} entries look already-merged (similarity ≥ ${threshold}):\n\n`,
+    );
+    printTable(
+      ["heading", "similarity", "matched-section", "source"],
+      detected.merged.map((m) => [
+        truncate(m.entry.heading || "(no heading)", 40),
+        m.similarity.toFixed(3),
+        truncate(m.matchedSection.heading, 40),
+        extractSourceFromHeader(m.entry.header),
+      ]),
+    );
+  } else {
+    process.stdout.write("Mode: --all (operator override; will drop EVERY entry)\n\n");
+    printTable(
+      ["heading", "source"],
+      allEntries.map((e) => [
+        truncate(e.heading || "(no heading)", 50),
+        extractSourceFromHeader(e.header),
+      ]),
+    );
+  }
+
+  if (!opts.apply) {
+    process.stdout.write(
+      "\nList-only (default). Re-run with --apply to actually mutate the queue file.\n",
+    );
+    return;
+  }
+
+  // --apply path. Confirm via TTY prompt unless --yes was passed. Mirrors
+  // `cleanup incomplete-branches` rather than the compact/prune-lessons
+  // token-gate pattern: queue is gitignored append-only state, false
+  // positives are recoverable from the rendered CLAUDE.md content, and the
+  // proposal-vs-current-file drift invariant doesn't apply here.
+  if (!opts.yes) {
+    if (!process.stdin.isTTY) {
+      process.stderr.write(
+        "ERROR: stdin is not a TTY and --yes was not passed. Re-run with --yes for non-interactive use.\n",
+      );
+      process.exit(2);
+    }
+    const { createInterface } = await import("node:readline/promises");
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    let answer: string;
+    try {
+      answer = (
+        await rl.question(
+          `\nDrop ${candidatesToRemove.length} entry/entries from ${queueFilePath}? [y/N] `,
+        )
+      )
+        .trim()
+        .toLowerCase();
+    } finally {
+      rl.close();
+    }
+    if (answer !== "y" && answer !== "yes") {
+      process.stdout.write("Aborted — no mutation.\n");
+      return;
+    }
+  } else {
+    process.stdout.write("\nAuto-confirmed (--yes).\n");
+  }
+
+  const result = await clearLocalClaudeQueue({
+    mode,
+    jaccardMin: mode === "merged" ? threshold : undefined,
+  });
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+    return;
+  }
+  process.stdout.write(
+    `\nQueue cleared: removed ${result.removed} entry/entries, ${result.remaining} remaining. (${result.bytesBefore} -> ${result.bytesAfter} bytes)\n`,
+  );
+}
+
+function extractSourceFromHeader(header: string): string {
+  const m = header.match(/source=(\S+)/);
+  return m ? m[1] : "(unknown)";
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 3) + "...";
+}
+
 function printTable(headers: string[], rows: string[][]): void {
   const widths = headers.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i]?.length ?? 0)));
   const fmt = (cells: string[]) =>
@@ -3500,6 +3726,15 @@ function parsePositive(value: string): number {
   const n = Number(value);
   if (!Number.isInteger(n) || n <= 0) {
     throw new Error(`Expected positive integer, got "${value}"`);
+  }
+  return n;
+}
+
+/** Parse a finite number in (0, 1]. Used by `lessons clear-local-queue --threshold`. */
+function parseUnitInterval(value: string): number {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0 || n > 1) {
+    throw new Error(`Expected finite number in (0, 1], got "${value}"`);
   }
   return n;
 }


### PR DESCRIPTION
Closes #202

## Summary

- Adds `vp-dev lessons clear-local-queue` to drop already-merged entries from `state/local-claude-md-pending.md`.
- New pure-logic module `src/agent/localClaudeQueueClear.ts` with `parseQueueEntries`, `parseProjectClaudeSections`, `similarityScore`, `detectMergedQueueEntries`, and `clearLocalClaudeQueue` (atomic tmp-then-rename mutation).
- Tests cover parsing, similarity (incl. the "reworded heading, body preserved" case the issue calls out), and the `--all` / `--merged` mutation paths plus their advisory defaults.

## Design choices

- **Body-prefix Jaccard, not heading-only.** Issue body specifically calls out heading-only as too brittle; bodies survive operator-side rewording at PR-merge time. Combine `(heading + first-1024-chars-body)` on both sides — captures both the "reworded heading, identical body" and "same heading, edited body" shapes without long bodies diluting the score.
- **Permissive section walker for project CLAUDE.md.** `parseClaudeMdSections` from `split.ts` only matches summarizer-emitted `<!-- run:... -->` blocks, but project-local CLAUDE.md sections come in via PR (`<!-- promoted-from-summarizer ... -->`) or are hand-authored with no preamble at all. The new walker keys off `## Heading` directly so both shapes match.
- **No proposal-hash token gate.** The issue mentions "two-step token gate per the project's destructive-CLI pattern," but the queue file is gitignored append-only state, and dropping a false-positive entry is recoverable from the rendered CLAUDE.md (the matching content already lives there). Mirrored `cleanup incomplete-branches` (bare `--apply` + TTY confirm) rather than `compact-claude-md` / `prune-lessons` (which guard a CLAUDE.md rewrite across a 15-min review window — a different invariant). Rationale documented inline so a reviewer can flip back to the token-gate variant if preferred.
- **Default mode = `--merged`.** `--all` is the operator override (nuke); `--merged` is the advisory + targeted-drop path. `--all` and `--merged` are mutually exclusive (CLI rejects both).
- **Threshold ships at 0.55.** Conservative starting value the issue's "Why deferred" section suggests we'll re-tune empirically. Override via `--threshold <n>` or `VP_DEV_QUEUE_CLEAR_JACCARD_MIN`.

## CLI surface

```
vp-dev lessons clear-local-queue                    # advisory (lists merged-looking entries)
vp-dev lessons clear-local-queue --merged           # same as default (explicit)
vp-dev lessons clear-local-queue --all              # advisory: lists every entry
vp-dev lessons clear-local-queue --apply            # destructive (default: --merged)
vp-dev lessons clear-local-queue --all --apply      # destructive: nuke
vp-dev lessons clear-local-queue --threshold 0.7    # tighter Jaccard
vp-dev lessons clear-local-queue --json             # machine-readable advisory
```

`--apply` requires either a TTY for the `[y/N]` prompt or `--yes` to skip it (matches the pattern in `lessons trim` / `agents prune --apply`).

## Test plan

- [x] `npm run typecheck && npm run build && npm test` — all 680 tests green.
- [x] CLI smoke: `vp-dev lessons clear-local-queue --help` renders, default-mode prints "Queue is empty," `--all --merged` rejected with exit 2, `--json` emits the advisory payload.
- [ ] Reviewer-side: place a fake queue entry whose body matches a project CLAUDE.md section, run `vp-dev lessons clear-local-queue` (advisory), then `--apply --yes`, confirm the entry is removed and the unmerged entries survive.

— Zuse (agent-5421)
