### PR TITLE
feat: pre-dispatch dependency check (#185)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,10 @@ import {
 import { pickAgents, runOrchestrator } from "./orchestrator/orchestrator.js";
 import { detectDuplicates } from "./orchestrator/dedup.js";
 import {
+  checkDependencies,
+  type DeferredByDependency,
+} from "./orchestrator/dependencies.js";
+import {
   approveSetup,
   buildSetupPreview,
   formatSetupPreview,
@@ -210,6 +214,10 @@ export function buildCli(): Command {
     .option(
       "--skip-dedup",
       "Phase 2b of #133 (#148): bypass the pre-dispatch dedup pass entirely (no Opus call, no `dedupCostUsd` line in the gate, no clusters surfaced). Useful for cost-sensitive runs against issue sets known to have no overlap. Mutually exclusive with --apply-dedup.",
+    )
+    .option(
+      "--include-blocked",
+      "Issue #185: force-dispatch issues whose body declares an open / unknown / closed-not-planned prerequisite. The dependency check still runs and surfaces the would-be-deferred set as a WARNING block in the gate, but the orchestrator dispatches anyway. Useful when the operator plans to merge a prerequisite mid-run, when the dependency is soft (mention rather than hard prerequisite), or when the dep is on a sibling repo we can't query reliably. Bound into the --plan/--confirm previewHash so a token written without the flag cannot be confirmed with it.",
     )
     .option(
       "--no-report",
@@ -682,6 +690,13 @@ interface RunOpts {
   // model call, no cost line, no clusters surfaced). Mutually exclusive
   // with `applyDedup`.
   skipDedup?: boolean;
+  // Issue #185: pre-dispatch dependency check override. When set, the
+  // dep check still runs and the would-be-deferred candidates render
+  // in a WARNING block in the gate, but they dispatch anyway. Bound
+  // into the --plan/--confirm previewHash via the rendered preview
+  // text — a token written without the flag cannot be confirmed with
+  // it.
+  includeBlocked?: boolean;
   // Commander `--no-report` auto-generates `report: boolean` on opts: true
   // by default, false when `--no-report` is passed. Issue #136.
   report?: boolean;
@@ -767,6 +782,12 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     // operator authorized at plan time.
     opts.applyDedup = p.applyDedup;
     opts.skipDedup = p.skipDedup;
+    // #185: same plan→confirm carry for the dependency-check override.
+    // The previewHash already binds the deferred / force-included
+    // sections rendered in the gate, but the flag itself must persist so
+    // the confirm-side launch dispatches the same set the operator
+    // authorized at plan time.
+    opts.includeBlocked = p.includeBlocked;
   }
 
   if (opts.agents === undefined || !opts.targetRepo) {
@@ -868,6 +889,66 @@ async function cmdRun(opts: RunOpts): Promise<void> {
   if (dispatchIssues.length === 0) {
     console.error(
       `ERROR: all ${open.length} open issue(s) filtered by triage as not-ready. Re-run with --include-non-ready to dispatch them anyway.`,
+    );
+    process.exit(2);
+  }
+
+  // Issue #185: pre-dispatch dependency check. After triage but BEFORE
+  // dedup (so dedup operates on the post-deferral set; deferred issues
+  // don't waste an Opus call). Fetches the body of each triage-passed
+  // candidate, parses any `## Dependencies` (or alias) section / inline
+  // `Dependencies:` line, and checks each referenced issue's GitHub
+  // state. Candidates with at least one open / unknown / closed-not-
+  // planned dep are deferred unless `--include-blocked` is set, in
+  // which case they dispatch but render in a WARNING block in the gate.
+  // Same-batch deps short-circuit the gh round-trip — we can't wait for
+  // them to land mid-run anyway.
+  const depsLogger = new Logger({
+    runId: `deps-${new Date().toISOString().replace(/[:.]/g, "-")}`,
+    verbose: !!opts.verbose,
+  });
+  await depsLogger.open();
+  let dependencyDeferred: DeferredByDependency[] = [];
+  let dependencyForceIncluded: DeferredByDependency[] = [];
+  try {
+    const targetRepo = opts.targetRepo;
+    const detailResults = await Promise.all(
+      dispatchIssues.map((i) => getIssueDetail(targetRepo, i.id)),
+    );
+    const candidates = dispatchIssues.map((i, idx) => {
+      const detail = detailResults[idx];
+      return {
+        summary: i,
+        // Empty string when fetch failed (404, network) — parseDependencyRefs
+        // returns [] for that, so the issue dispatches normally. The dep
+        // check is best-effort: a transient gh failure must never block
+        // the run by side-effect.
+        body: detail?.body ?? "",
+      };
+    });
+    const depResult = await checkDependencies({
+      repo: targetRepo,
+      candidates,
+      includeBlocked: !!opts.includeBlocked,
+      logger: depsLogger,
+    });
+    dispatchIssues = depResult.dispatchIssues;
+    dependencyDeferred = depResult.deferred;
+    dependencyForceIncluded = depResult.forceIncluded;
+    depsLogger.info("deps.batch_completed", {
+      total: candidates.length,
+      dispatched: dispatchIssues.length,
+      deferred: dependencyDeferred.length,
+      forceIncluded: dependencyForceIncluded.length,
+      includeBlocked: !!opts.includeBlocked,
+    });
+  } finally {
+    await depsLogger.close();
+  }
+
+  if (dispatchIssues.length === 0) {
+    console.error(
+      `ERROR: all ${dependencyDeferred.length} candidate issue(s) deferred by the pre-dispatch dependency check. Land the prerequisite(s) first or re-run with --include-blocked.`,
     );
     process.exit(2);
   }
@@ -1095,6 +1176,8 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     incompleteBranchesAvailable,
     duplicateClusters,
     dedupCostUsd,
+    dependencyDeferred,
+    dependencyForceIncluded,
   });
 
   if (opts.plan) {
@@ -1136,6 +1219,11 @@ async function cmdRun(opts: RunOpts): Promise<void> {
         // preview, so the same hash protection holds.
         applyDedup: opts.applyDedup,
         skipDedup: opts.skipDedup,
+        // #185: persist the dependency-check override. When the flag is
+        // active, the deferred set renders as a WARNING force-included
+        // block instead of a deferred block — the preview text differs
+        // either way, and the previewHash binds that difference.
+        includeBlocked: opts.includeBlocked,
       },
     });
     process.stdout.write("Plan saved. No agents launched.\n");

--- a/src/orchestrator/dependencies.test.ts
+++ b/src/orchestrator/dependencies.test.ts
@@ -1,0 +1,318 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseDependencyRefs,
+  checkDependencies,
+  formatBlockingReason,
+  type DependencyRef,
+  type DependencyState,
+} from "./dependencies.js";
+import type { IssueSummary } from "../types.js";
+
+// Tests for issue #185 — pre-dispatch dependency check. The parser is
+// the main correctness surface (false-negatives let bad dispatches
+// through; false-positives are absorbed by --include-blocked, but
+// shouldn't be excessive). The orchestrator wiring is exercised by
+// pure-function checkDependencies tests with stubbed state resolvers.
+
+function makeSummary(id: number, title = `Issue ${id}`): IssueSummary {
+  return { id, title, labels: [], state: "open" };
+}
+
+// ---------- parseDependencyRefs ----------
+
+test("parseDependencyRefs: empty body returns []", () => {
+  assert.deepEqual(parseDependencyRefs(""), []);
+  // @ts-expect-error -- runtime guard for accidental nullish bodies
+  assert.deepEqual(parseDependencyRefs(undefined), []);
+});
+
+test("parseDependencyRefs: `## Dependencies` heading section yields refs", () => {
+  const body = `## Problem\n\nFoo bar.\n\n## Dependencies\n\n- #178 must land first\n- #179 also blocks\n\n## Plan\n\nNot related: #200\n`;
+  const refs = parseDependencyRefs(body);
+  assert.deepEqual(
+    refs.map((r) => r.issueId).sort(),
+    [178, 179],
+    "only refs inside the heading section are extracted; #200 in ## Plan is not pulled",
+  );
+});
+
+test("parseDependencyRefs: aliases — `## Depends on`, `## Prerequisites`, `## Blocked by`", () => {
+  const body1 = `## Depends on\n\n#1\n`;
+  const body2 = `## Prerequisites\n\n#2\n`;
+  const body3 = `## Blocked by\n\n#3\n`;
+  assert.deepEqual(parseDependencyRefs(body1).map((r) => r.issueId), [1]);
+  assert.deepEqual(parseDependencyRefs(body2).map((r) => r.issueId), [2]);
+  assert.deepEqual(parseDependencyRefs(body3).map((r) => r.issueId), [3]);
+});
+
+test("parseDependencyRefs: heading match is case-insensitive", () => {
+  const body = `## DEPENDENCIES\n\n#42\n`;
+  assert.deepEqual(parseDependencyRefs(body).map((r) => r.issueId), [42]);
+});
+
+test("parseDependencyRefs: section ends at next `## ` heading (not `### `)", () => {
+  const body = `## Dependencies\n\n#10\n\n### Sub-section still in deps\n\n#11\n\n## Out of scope\n\n#99\n`;
+  const refs = parseDependencyRefs(body).map((r) => r.issueId).sort();
+  assert.deepEqual(refs, [10, 11], "sub-section content stays inside Dependencies; #99 in Out of scope is excluded");
+});
+
+test("parseDependencyRefs: inline `Dependencies:` line yields the refs", () => {
+  // The proposal's primary motivating example — #180's body had:
+  //   *Dependencies: [#178](...) (Phase 1) MUST land first*
+  const body = `*Dependencies: [#178](https://example/issues/178) (Phase 1) MUST land first*\n\nrest of body`;
+  const refs = parseDependencyRefs(body);
+  assert.deepEqual(refs.map((r) => r.issueId), [178]);
+});
+
+test("parseDependencyRefs: inline `Depends on:` with multiple refs", () => {
+  const body = `Depends on: #1, #2, #3\n`;
+  const refs = parseDependencyRefs(body).map((r) => r.issueId).sort();
+  assert.deepEqual(refs, [1, 2, 3]);
+});
+
+test("parseDependencyRefs: inline match accepts blockquote/emphasis leaders", () => {
+  const body1 = `> Dependencies: #5\n`;
+  const body2 = `*Depends on:* #6\n`;
+  const body3 = `_Dependencies:_ #7\n`;
+  assert.deepEqual(parseDependencyRefs(body1).map((r) => r.issueId), [5]);
+  assert.deepEqual(parseDependencyRefs(body2).map((r) => r.issueId), [6]);
+  assert.deepEqual(parseDependencyRefs(body3).map((r) => r.issueId), [7]);
+});
+
+test("parseDependencyRefs: cross-repo refs preserve the repo prefix", () => {
+  const body = `## Dependencies\n\n- szhygulin/vaultpilot-mcp#100\n- #50\n`;
+  const refs = parseDependencyRefs(body);
+  const cross = refs.find((r) => r.repo);
+  const same = refs.find((r) => !r.repo);
+  assert.ok(cross, "cross-repo ref should be parsed");
+  assert.equal(cross!.repo, "szhygulin/vaultpilot-mcp");
+  assert.equal(cross!.issueId, 100);
+  assert.ok(same, "same-repo ref should be parsed");
+  assert.equal(same!.issueId, 50);
+});
+
+test("parseDependencyRefs: dedupes same id from heading + inline detection", () => {
+  // A body that has BOTH a heading section and an inline line referencing
+  // the same issue should yield exactly one ref entry.
+  const body = `## Dependencies\n\n- #178\n\nMore prose.\n\nDependencies: #178\n`;
+  const refs = parseDependencyRefs(body);
+  assert.equal(refs.length, 1, "duplicate refs across detection paths must dedupe");
+  assert.equal(refs[0].issueId, 178);
+});
+
+test("parseDependencyRefs: ignores `#NNN` mentions outside any deps section", () => {
+  // The motivating false-positive: this issue body (#185) itself mentions
+  // many `#N` numbers in prose without any Dependencies section.
+  const body = `## Problem\n\nDispatched [#180](https://example) and [#178](https://example) together.\n\n## Proposal\n\nDo something with #200.\n`;
+  assert.deepEqual(parseDependencyRefs(body), []);
+});
+
+test("parseDependencyRefs: skips invalid ref ids (zero, too-long)", () => {
+  const body = `## Dependencies\n\n#0 should not match. #1234567 is too long. #42 is fine.\n`;
+  // `#1234567` is 7 digits which exceeds {1,5}; the regex will only match
+  // the leading 5 → #12345. Accept either behavior so long as #42 is in.
+  const ids = parseDependencyRefs(body).map((r) => r.issueId);
+  assert.ok(ids.includes(42), "#42 must be parsed");
+  assert.ok(!ids.includes(0), "#0 must not be parsed");
+});
+
+// ---------- checkDependencies ----------
+
+function stubResolver(map: Map<number, DependencyState>) {
+  return async (ref: DependencyRef): Promise<DependencyState> => {
+    return map.get(ref.issueId) ?? "unknown";
+  };
+}
+
+test("checkDependencies: all deps satisfied → all dispatch", async () => {
+  const candidates = [
+    { summary: makeSummary(1), body: "no deps" },
+    { summary: makeSummary(2), body: "## Dependencies\n\n#10\n" },
+  ];
+  const resolver = stubResolver(new Map([[10, "closed-completed"]]));
+  const result = await checkDependencies({
+    repo: "owner/repo",
+    candidates,
+    includeBlocked: false,
+    resolveExternalState: resolver,
+  });
+  assert.equal(result.dispatchIssues.length, 2);
+  assert.equal(result.deferred.length, 0);
+  assert.equal(result.forceIncluded.length, 0);
+});
+
+test("checkDependencies: open prerequisite defers the dependent", async () => {
+  // The motivating shape from #185: #180 depends on #178 which is open.
+  const candidates = [
+    {
+      summary: makeSummary(180),
+      body: "*Dependencies: [#178](...) (Phase 1) MUST land first*",
+    },
+  ];
+  const resolver = stubResolver(new Map([[178, "open"]]));
+  const result = await checkDependencies({
+    repo: "owner/repo",
+    candidates,
+    includeBlocked: false,
+    resolveExternalState: resolver,
+  });
+  assert.equal(result.dispatchIssues.length, 0);
+  assert.equal(result.deferred.length, 1);
+  assert.equal(result.deferred[0].issue.id, 180);
+  assert.equal(result.deferred[0].blockingVerdicts[0].ref.issueId, 178);
+  assert.equal(result.deferred[0].blockingVerdicts[0].state, "open");
+  assert.match(result.deferred[0].reason, /open #178/);
+  assert.match(result.deferred[0].reason, /re-dispatch after #178 lands/);
+});
+
+test("checkDependencies: same-batch dependency defers without a state lookup", async () => {
+  // #178 is in the same batch as #180. The check must defer #180 WITHOUT
+  // consulting the resolver — the in-batch presence is itself the signal.
+  let resolverCalls = 0;
+  const candidates = [
+    { summary: makeSummary(178), body: "" },
+    { summary: makeSummary(180), body: "## Dependencies\n\n#178\n" },
+  ];
+  const resolver = async (): Promise<DependencyState> => {
+    resolverCalls += 1;
+    return "closed-completed";
+  };
+  const result = await checkDependencies({
+    repo: "owner/repo",
+    candidates,
+    includeBlocked: false,
+    resolveExternalState: resolver,
+  });
+  assert.equal(resolverCalls, 0, "same-batch dep must not trigger the resolver");
+  assert.equal(result.dispatchIssues.length, 1);
+  assert.equal(result.dispatchIssues[0].id, 178);
+  assert.equal(result.deferred.length, 1);
+  assert.equal(result.deferred[0].issue.id, 180);
+});
+
+test("checkDependencies: closed-not-planned dep defers with the dedicated tail", async () => {
+  const candidates = [
+    { summary: makeSummary(50), body: "## Dependencies\n\n#40\n" },
+  ];
+  const resolver = stubResolver(new Map([[40, "closed-not-planned"]]));
+  const result = await checkDependencies({
+    repo: "owner/repo",
+    candidates,
+    includeBlocked: false,
+    resolveExternalState: resolver,
+  });
+  assert.equal(result.deferred.length, 1);
+  assert.match(result.deferred[0].reason, /closed-not-planned #40/);
+  assert.match(result.deferred[0].reason, /re-read/);
+});
+
+test("checkDependencies: unknown dep state defers (resolver returns unknown)", async () => {
+  // Network/permissions error or a 404 on cross-repo defaults to unknown,
+  // which is treated as blocking with the conservative "verify state" tail.
+  const candidates = [
+    { summary: makeSummary(50), body: "## Dependencies\n\n#40\n" },
+  ];
+  const resolver = stubResolver(new Map([[40, "unknown"]]));
+  const result = await checkDependencies({
+    repo: "owner/repo",
+    candidates,
+    includeBlocked: false,
+    resolveExternalState: resolver,
+  });
+  assert.equal(result.deferred.length, 1);
+  assert.match(result.deferred[0].reason, /unknown #40/);
+  assert.match(result.deferred[0].reason, /verify/);
+});
+
+test("checkDependencies: --include-blocked moves deferred → forceIncluded but still dispatches", async () => {
+  const candidates = [
+    { summary: makeSummary(180), body: "## Dependencies\n\n#178\n" },
+  ];
+  const resolver = stubResolver(new Map([[178, "open"]]));
+  const result = await checkDependencies({
+    repo: "owner/repo",
+    candidates,
+    includeBlocked: true,
+    resolveExternalState: resolver,
+  });
+  assert.equal(result.dispatchIssues.length, 1, "force-included issues still dispatch");
+  assert.equal(result.deferred.length, 0, "deferred set is empty when force-included");
+  assert.equal(result.forceIncluded.length, 1);
+  assert.equal(result.forceIncluded[0].issue.id, 180);
+});
+
+test("checkDependencies: state cache shares lookups across multiple dependents", async () => {
+  // Two dependents, both pointing at #178. The resolver must be called
+  // exactly once for #178 — subsequent lookups hit the cache.
+  let calls = 0;
+  const candidates = [
+    { summary: makeSummary(179), body: "## Dependencies\n\n#178\n" },
+    { summary: makeSummary(180), body: "## Dependencies\n\n#178\n" },
+  ];
+  const resolver = async (ref: DependencyRef): Promise<DependencyState> => {
+    if (ref.issueId === 178) {
+      calls += 1;
+      return "open";
+    }
+    return "closed-completed";
+  };
+  const result = await checkDependencies({
+    repo: "owner/repo",
+    candidates,
+    includeBlocked: false,
+    resolveExternalState: resolver,
+  });
+  assert.equal(calls, 1, "shared dep state cached after first lookup");
+  assert.equal(result.deferred.length, 2);
+});
+
+test("checkDependencies: self-reference in body is ignored", async () => {
+  // An issue whose body cites its own number in a Dependencies block must
+  // not be deferred against itself — that's nonsensical and would block
+  // every dispatch with a self-reference typo.
+  let resolverCalls = 0;
+  const candidates = [
+    { summary: makeSummary(50), body: "## Dependencies\n\n#50 (self)\n" },
+  ];
+  const resolver = async (): Promise<DependencyState> => {
+    resolverCalls += 1;
+    return "open";
+  };
+  const result = await checkDependencies({
+    repo: "owner/repo",
+    candidates,
+    includeBlocked: false,
+    resolveExternalState: resolver,
+  });
+  assert.equal(resolverCalls, 0, "self-reference must be filtered before the lookup");
+  assert.equal(result.dispatchIssues.length, 1, "self-only deps are not blocking");
+  assert.equal(result.deferred.length, 0);
+});
+
+// ---------- formatBlockingReason ----------
+
+test("formatBlockingReason: single open dep gets the re-dispatch tail", () => {
+  const text = formatBlockingReason([
+    { ref: { issueId: 178 }, state: "open" },
+  ]);
+  assert.match(text, /^depends on open #178/);
+  assert.match(text, /re-dispatch after #178 lands$/);
+});
+
+test("formatBlockingReason: cross-repo ref renders the owner/repo prefix", () => {
+  const text = formatBlockingReason([
+    { ref: { repo: "szhygulin/vaultpilot-mcp", issueId: 100 }, state: "open" },
+  ]);
+  assert.match(text, /szhygulin\/vaultpilot-mcp#100/);
+});
+
+test("formatBlockingReason: multiple deps elide the per-dep tail", () => {
+  const text = formatBlockingReason([
+    { ref: { issueId: 1 }, state: "open" },
+    { ref: { issueId: 2 }, state: "closed-not-planned" },
+  ]);
+  assert.match(text, /open #1/);
+  assert.match(text, /closed-not-planned #2/);
+  assert.doesNotMatch(text, /re-dispatch after/);
+});

--- a/src/orchestrator/dependencies.ts
+++ b/src/orchestrator/dependencies.ts
@@ -1,0 +1,343 @@
+// Pre-dispatch dependency check (issue #185).
+//
+// Surfaced 2026-05-06: dispatching #180 (Phase 3 advisory, depends on #178)
+// alongside #178 (Phase 1 data collection) in the same `vp-dev run` batch
+// burned ~$1.50 on a pushback that was inevitable from reading the issue
+// body. The harness is the right place to enforce the operator habit
+// ("read each issue's Dependencies block before dispatch") — a manual
+// scan fails when the dispatch batch is large.
+//
+// At dispatch planning time (between triage and pickAgents), this module
+// scans each candidate issue body for a `## Dependencies` (or alias)
+// heading or an inline `Dependencies:` line, extracts `#NNN` references,
+// queries the GitHub state of each, and defers any candidate whose
+// prerequisite is OPEN, UNKNOWN, or CLOSED-NOT-PLANNED. The override flag
+// `--include-blocked` (wired from cli.ts) force-includes deferred issues.
+//
+// Detection is heuristic and conservative — false-positives (issues that
+// *mention* a number without strictly depending on it) are acceptable
+// because `--include-blocked` is the escape hatch.
+//
+// Same-batch deferral: when dependent #180 references prerequisite #178
+// and BOTH are in the same dispatch batch, #180 is deferred even though
+// #178 is "in this run" — the orchestrator can't wait for #178 to land
+// mid-run since merging is operator-driven (per the issue's edge-case
+// table). Re-dispatch #180 manually after #178 lands.
+//
+// Closed-not-planned (wontfix) is treated as blocking: the rule the
+// dependent cited may have been abandoned, and the operator should
+// re-read the dependent before dispatch.
+
+import { promisify } from "node:util";
+import { execFile as execFileCb } from "node:child_process";
+import type { IssueSummary } from "../types.js";
+import type { Logger } from "../log/logger.js";
+
+const execFile = promisify(execFileCb);
+
+export type DependencyState =
+  | "open"
+  | "closed-completed"
+  | "closed-not-planned"
+  | "unknown";
+
+export interface DependencyRef {
+  /** Cross-repo prefix when the ref was `owner/repo#N`; undefined → same-repo. */
+  repo?: string;
+  issueId: number;
+}
+
+export interface DependencyVerdict {
+  ref: DependencyRef;
+  state: DependencyState;
+}
+
+export interface DeferredByDependency {
+  issue: IssueSummary;
+  /** Only the verdicts that triggered the defer (open / unknown / closed-not-planned). */
+  blockingVerdicts: DependencyVerdict[];
+  /** Single short phrase rendered into the preview, e.g. "depends on open #178 — re-dispatch after #178 lands". */
+  reason: string;
+}
+
+export interface DependencyCheckResult {
+  /** Candidates that pass the check (all dependencies satisfied OR force-included). */
+  dispatchIssues: IssueSummary[];
+  /** Candidates withheld because at least one dep was open/unknown/closed-not-planned. */
+  deferred: DeferredByDependency[];
+  /** Issues that would have been deferred but were force-included via `--include-blocked`. */
+  forceIncluded: DeferredByDependency[];
+}
+
+export interface CheckDependenciesInput {
+  /** Default repo for resolving same-repo refs (e.g. "owner/repo"). */
+  repo: string;
+  /** Triage-passed candidates with their fetched bodies. */
+  candidates: { summary: IssueSummary; body: string }[];
+  /** When true, defer the deferred set into `forceIncluded` instead. */
+  includeBlocked: boolean;
+  /** Optional injection for tests; defaults to `fetchExternalDependencyState`. */
+  resolveExternalState?: (ref: DependencyRef) => Promise<DependencyState>;
+  /** Optional structured logger; the check emits `deps.*` events. */
+  logger?: Logger;
+}
+
+/**
+ * Extract dependency references from an issue body.
+ *
+ * Two detection paths:
+ *   1. Heading-anchored: `## Dependencies` / `## Depends on` /
+ *      `## Prerequisites` / `## Blocked by` — refs are scanned from the
+ *      heading line until the next `## ` heading or end-of-body.
+ *   2. Inline at line-start: lines like `Dependencies: #178` or
+ *      `Depends on: #178, #179`. Optional Markdown emphasis / blockquote
+ *      leaders (`*Dependencies:* foo`, `> Dependencies: foo`) are accepted.
+ *
+ * Cross-repo refs (`owner/repo#N`) preserve the `repo` field; same-repo
+ * refs leave `repo` undefined. Same-id duplicates across the two detection
+ * paths are deduped before return.
+ *
+ * Pure: no side effects, no I/O. Exported for tests.
+ */
+export function parseDependencyRefs(body: string): DependencyRef[] {
+  if (!body) return [];
+  const sections: string[] = [];
+
+  // (1) Heading-anchored sections. The heading regex matches the entire
+  // heading line; we slice the body from immediately after the line until
+  // the next `## ` (NOT `### ` — sub-sections still belong to the parent)
+  // or end-of-body. `gim` flags: g for multi-match, i for case-insensitive
+  // heading word, m for line-anchored `^`.
+  const headingRe = /^##\s+(?:Dependencies|Depends on|Prerequisites|Blocked by)\b[^\n]*$/gim;
+  let hm: RegExpExecArray | null;
+  while ((hm = headingRe.exec(body)) !== null) {
+    const start = hm.index + hm[0].length;
+    const rest = body.slice(start);
+    // Match `## ` at line-start in the remaining body — but NOT `###` (which
+    // does not match `^##\s` because the third `#` blocks the `\s`).
+    const next = rest.search(/^##\s/m);
+    sections.push(next === -1 ? rest : rest.slice(0, next));
+  }
+
+  // (2) Inline lines that start (modulo Markdown emphasis / blockquote
+  // leaders) with `Dependencies:` or `Depends on:`. Captured group is
+  // the post-colon content of that line.
+  const inlineRe = /^[ \t>*_]*(?:Dependencies?|Depends on)\s*:[ \t]*([^\n]+)$/gim;
+  let im: RegExpExecArray | null;
+  while ((im = inlineRe.exec(body)) !== null) {
+    sections.push(im[1] ?? "");
+  }
+
+  const refs: DependencyRef[] = [];
+  const seen = new Set<string>();
+  for (const section of sections) {
+    extractRefs(section, refs, seen);
+  }
+  return refs;
+}
+
+function extractRefs(
+  text: string,
+  out: DependencyRef[],
+  seen: Set<string>,
+): void {
+  // `[owner/repo]#N` or `#N`. `[\w.-]+/[\w.-]+` matches `owner/repo` shapes
+  // but won't span URL paths (no `:` allowed), so a stray
+  // `https://example.com/foo#bar123` doesn't trigger because `https:` has a
+  // colon. Same-repo refs leave the repo capture group undefined.
+  const refRe = /(?:([\w.-]+\/[\w.-]+))?#(\d{1,5})\b/g;
+  let m: RegExpExecArray | null;
+  while ((m = refRe.exec(text)) !== null) {
+    const repo = m[1];
+    const issueId = Number.parseInt(m[2], 10);
+    if (Number.isNaN(issueId) || issueId <= 0) continue;
+    const key = `${repo ?? ""}#${issueId}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ repo, issueId });
+  }
+}
+
+/**
+ * Resolve a single dependency reference's GitHub state via `gh issue view`.
+ *
+ * Returns "open" / "closed-completed" / "closed-not-planned" / "unknown".
+ * `unknown` covers any failure mode (404, network blip, permissions error,
+ * cross-repo we can't read) — the caller treats unknown as blocking by
+ * default; the operator overrides via `--include-blocked`.
+ *
+ * Cross-repo refs use `ref.repo` instead of the default; same-repo refs
+ * fall back to `defaultRepo`. No retries — `gh` already retries internally
+ * on transient network errors, and the dependency check is best-effort.
+ */
+export async function fetchExternalDependencyState(
+  defaultRepo: string,
+  ref: DependencyRef,
+): Promise<DependencyState> {
+  const repo = ref.repo ?? defaultRepo;
+  try {
+    const { stdout } = await execFile(
+      "gh",
+      [
+        "issue",
+        "view",
+        String(ref.issueId),
+        "--repo",
+        repo,
+        "--json",
+        "state,stateReason",
+      ],
+      { maxBuffer: 5 * 1024 * 1024 },
+    );
+    const parsed = JSON.parse(stdout) as { state?: string; stateReason?: string | null };
+    const state = (parsed.state ?? "").toLowerCase();
+    if (state === "open") return "open";
+    const reason = (parsed.stateReason ?? "").toUpperCase();
+    if (reason === "NOT_PLANNED") return "closed-not-planned";
+    return "closed-completed";
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
+ * Run the pre-dispatch dependency check.
+ *
+ * For each candidate, parse its body for dep refs, resolve each ref's
+ * state, and partition the candidate set into:
+ *   - `dispatchIssues`: deps satisfied (or force-included)
+ *   - `deferred`: at least one blocking dep, NOT force-included
+ *   - `forceIncluded`: at least one blocking dep, but `includeBlocked`
+ *     was true so the issue still dispatches (with a WARNING line in the
+ *     gate)
+ *
+ * Same-batch optimization: when a ref points at another candidate already
+ * in this batch, we treat its state as "open" without a `gh` round-trip
+ * (it's open by definition — that's why it's a candidate). State results
+ * for cross-batch refs are cached so multiple dependents on the same
+ * prerequisite only pay one round-trip.
+ *
+ * Self-references are filtered (an issue mentioning its own number isn't
+ * a dependency).
+ */
+export async function checkDependencies(
+  input: CheckDependenciesInput,
+): Promise<DependencyCheckResult> {
+  const sameBatchOpenIds = new Set(input.candidates.map((c) => c.summary.id));
+  const resolveExternal =
+    input.resolveExternalState ??
+    ((ref: DependencyRef) => fetchExternalDependencyState(input.repo, ref));
+
+  const stateCache = new Map<string, DependencyState>();
+  const refKey = (ref: DependencyRef): string =>
+    `${(ref.repo ?? input.repo).toLowerCase()}#${ref.issueId}`;
+
+  const dispatchIssues: IssueSummary[] = [];
+  const deferred: DeferredByDependency[] = [];
+  const forceIncluded: DeferredByDependency[] = [];
+
+  for (const cand of input.candidates) {
+    const refs = parseDependencyRefs(cand.body).filter(
+      (r) =>
+        // Drop self-references — an issue mentioning its own number is not
+        // a dep on itself.
+        !(isSameRepo(r, input.repo) && r.issueId === cand.summary.id),
+    );
+    const blocking: DependencyVerdict[] = [];
+    for (const ref of refs) {
+      const key = refKey(ref);
+      let state: DependencyState;
+      if (stateCache.has(key)) {
+        state = stateCache.get(key)!;
+      } else if (
+        isSameRepo(ref, input.repo) &&
+        sameBatchOpenIds.has(ref.issueId)
+      ) {
+        // Same-batch dependent: orchestrator can't wait for it mid-run.
+        state = "open";
+      } else {
+        try {
+          state = await resolveExternal(ref);
+        } catch {
+          state = "unknown";
+        }
+      }
+      stateCache.set(key, state);
+      if (
+        state === "open" ||
+        state === "unknown" ||
+        state === "closed-not-planned"
+      ) {
+        blocking.push({ ref, state });
+      }
+    }
+    if (blocking.length === 0) {
+      dispatchIssues.push(cand.summary);
+      continue;
+    }
+    const entry: DeferredByDependency = {
+      issue: cand.summary,
+      blockingVerdicts: blocking,
+      reason: formatBlockingReason(blocking),
+    };
+    if (input.includeBlocked) {
+      forceIncluded.push(entry);
+      dispatchIssues.push(cand.summary);
+      input.logger?.info("deps.force_included", {
+        issueId: cand.summary.id,
+        blocking: blocking.map((b) => ({
+          ref: refToString(b.ref),
+          state: b.state,
+        })),
+      });
+    } else {
+      deferred.push(entry);
+      input.logger?.info("deps.deferred", {
+        issueId: cand.summary.id,
+        blocking: blocking.map((b) => ({
+          ref: refToString(b.ref),
+          state: b.state,
+        })),
+      });
+    }
+  }
+
+  return { dispatchIssues, deferred, forceIncluded };
+}
+
+function isSameRepo(ref: DependencyRef, repo: string): boolean {
+  return !ref.repo || ref.repo.toLowerCase() === repo.toLowerCase();
+}
+
+function refToString(ref: DependencyRef): string {
+  return ref.repo ? `${ref.repo}#${ref.issueId}` : `#${ref.issueId}`;
+}
+
+/**
+ * Render the single-line "depends on …" reason rendered in the gate
+ * preview. Pure helper exported for tests.
+ *
+ * Single blocking dep: "depends on open #178 — re-dispatch after #178 lands".
+ * Multiple: "depends on open #178, closed-not-planned #200" (no tail —
+ * the operator inspects each manually).
+ */
+export function formatBlockingReason(blocking: DependencyVerdict[]): string {
+  if (blocking.length === 0) return "depends on (none)";
+  const parts = blocking.map((b) => `${b.state} ${refToString(b.ref)}`);
+  if (blocking.length === 1) {
+    const v = blocking[0];
+    const tail = blockingTail(v);
+    return tail ? `depends on ${parts[0]} — ${tail}` : `depends on ${parts[0]}`;
+  }
+  return `depends on ${parts.join(", ")}`;
+}
+
+function blockingTail(v: DependencyVerdict): string | null {
+  const ref = refToString(v.ref);
+  if (v.state === "open") return `re-dispatch after ${ref} lands`;
+  if (v.state === "closed-not-planned") {
+    return `re-read this issue — ${ref} closed not_planned`;
+  }
+  if (v.state === "unknown") return `verify ${ref} state and retry`;
+  return null;
+}

--- a/src/orchestrator/setup.test.ts
+++ b/src/orchestrator/setup.test.ts
@@ -36,6 +36,8 @@ function basePreview(overrides: Partial<SetupPreview> = {}): SetupPreview {
     budgetExceededSkipped: [],
     incompleteBranchesAvailable: [],
     duplicateClusters: [],
+    dependencyDeferred: [],
+    dependencyForceIncluded: [],
     ...overrides,
   };
 }
@@ -204,4 +206,80 @@ test("formatSetupPreview: cluster set + dedup cost are bound into the rendered t
   const c = formatSetupPreview(basePreview({ dedupCostUsd: undefined }));
   const d = formatSetupPreview(basePreview({ dedupCostUsd: 0.01 }));
   assert.notEqual(c, d, "dedup cost drift must change rendered preview text");
+});
+
+// Issue #185: pre-dispatch dependency check renders. Same render-bound-into-
+// previewHash story as the dedup block — drift between --plan and --confirm
+// must change the rendered text.
+
+test("formatSetupPreview: empty dependencyDeferred renders no skip block", () => {
+  const text = formatSetupPreview(basePreview({ dependencyDeferred: [] }));
+  assert.doesNotMatch(text, /declared prerequisite/);
+  assert.doesNotMatch(text, /Override with --include-blocked/);
+});
+
+test("formatSetupPreview: non-empty dependencyDeferred renders the skip block + override hint", () => {
+  const deferred = [
+    {
+      issue: { id: 180, title: "Phase 3 advisory", state: "open" as const, labels: [] },
+      blockingVerdicts: [
+        { ref: { issueId: 178 }, state: "open" as const },
+      ],
+      reason: "depends on open #178 — re-dispatch after #178 lands",
+    },
+  ];
+  const text = formatSetupPreview(basePreview({ dependencyDeferred: deferred }));
+  assert.match(text, /1 issue\(s\) deferred — declared prerequisite\(s\) not satisfied/);
+  assert.match(text, /#180\s+depends on open #178 — re-dispatch after #178 lands/);
+  assert.match(text, /Override with --include-blocked/);
+});
+
+test("formatSetupPreview: dependencyForceIncluded renders WARNING block (not deferred block)", () => {
+  const forceIncluded = [
+    {
+      issue: { id: 180, title: "Phase 3 advisory", state: "open" as const, labels: [] },
+      blockingVerdicts: [
+        { ref: { issueId: 178 }, state: "open" as const },
+      ],
+      reason: "depends on open #178 — re-dispatch after #178 lands",
+    },
+  ];
+  const text = formatSetupPreview(
+    basePreview({ dependencyForceIncluded: forceIncluded, dependencyDeferred: [] }),
+  );
+  assert.match(text, /WARNING: 1 issue\(s\) with unsatisfied prerequisites force-included via --include-blocked/);
+  assert.match(text, /#180\s+depends on open #178/);
+  // Override hint is NOT rendered in force-included mode (the operator
+  // already passed the override).
+  assert.doesNotMatch(text, /Override with --include-blocked/);
+});
+
+test("formatSetupPreview: dependency block drift changes the rendered text (previewHash coverage)", () => {
+  const a = formatSetupPreview(basePreview({ dependencyDeferred: [] }));
+  const b = formatSetupPreview(
+    basePreview({
+      dependencyDeferred: [
+        {
+          issue: { id: 50, title: "x", state: "open", labels: [] },
+          blockingVerdicts: [{ ref: { issueId: 40 }, state: "open" }],
+          reason: "depends on open #40 — re-dispatch after #40 lands",
+        },
+      ],
+    }),
+  );
+  assert.notEqual(a, b, "dependency-deferred drift must change rendered preview text");
+
+  const c = formatSetupPreview(basePreview({ dependencyForceIncluded: [] }));
+  const d = formatSetupPreview(
+    basePreview({
+      dependencyForceIncluded: [
+        {
+          issue: { id: 50, title: "x", state: "open", labels: [] },
+          blockingVerdicts: [{ ref: { issueId: 40 }, state: "open" }],
+          reason: "depends on open #40 — re-dispatch after #40 lands",
+        },
+      ],
+    }),
+  );
+  assert.notEqual(c, d, "force-included drift must change rendered preview text");
 });

--- a/src/orchestrator/setup.ts
+++ b/src/orchestrator/setup.ts
@@ -8,6 +8,7 @@ import {
   type OverloadVerdict,
 } from "../agent/split.js";
 import type { BudgetExceededSkipped } from "./costEstimator.js";
+import type { DeferredByDependency } from "./dependencies.js";
 
 export interface TriageSkipped {
   issue: IssueSummary;
@@ -132,6 +133,24 @@ export interface SetupPreview {
    * "no triage" vs "free triage" distinction from #55.
    */
   dedupCostUsd?: number;
+  /**
+   * Issue #185: candidates withheld because at least one referenced
+   * prerequisite is OPEN, UNKNOWN, or CLOSED-NOT-PLANNED. Surfaced as a
+   * skip block in the gate so the operator sees what's being deferred
+   * before y/N. Always an array — empty when no candidate body declared
+   * a dependency or every dep was satisfied. Bound into the rendered
+   * preview, so the previewHash drift protection (#149) automatically
+   * extends to dep-state changes between `--plan` and `--confirm`.
+   */
+  dependencyDeferred: DeferredByDependency[];
+  /**
+   * Issue #185: issues that would have been deferred by the dependency
+   * check but were force-included because the operator passed
+   * `--include-blocked`. Rendered as a WARNING block in the gate so the
+   * surface stays visible — silent override would defeat the whole point
+   * of the check.
+   */
+  dependencyForceIncluded: DeferredByDependency[];
 }
 
 export interface BuildPreviewInput {
@@ -171,6 +190,14 @@ export interface BuildPreviewInput {
    *  when the pass was bypassed; the renderer skips the line entirely
    *  in that case rather than showing $0.0000. */
   dedupCostUsd?: number;
+  /** Issue #185: caller-provided list of issues deferred by the
+   *  dependency check (open / unknown / closed-not-planned dep). Empty
+   *  array (or omitted) renders no skip block. */
+  dependencyDeferred?: DeferredByDependency[];
+  /** Issue #185: caller-provided list of issues that would have been
+   *  deferred but were force-included via `--include-blocked`. Empty
+   *  array (or omitted) renders no warning block. */
+  dependencyForceIncluded?: DeferredByDependency[];
 }
 
 export async function buildSetupPreview(input: BuildPreviewInput): Promise<SetupPreview> {
@@ -215,6 +242,8 @@ export async function buildSetupPreview(input: BuildPreviewInput): Promise<Setup
     incompleteBranchesAvailable: input.incompleteBranchesAvailable ?? [],
     duplicateClusters: input.duplicateClusters ?? [],
     dedupCostUsd: input.dedupCostUsd,
+    dependencyDeferred: input.dependencyDeferred ?? [],
+    dependencyForceIncluded: input.dependencyForceIncluded ?? [],
   };
 }
 
@@ -322,6 +351,35 @@ export function formatSetupPreview(p: SetupPreview): string {
     lines.push(
       "  The PR from the prior run is the in-flight work. Let it land (or close it) before re-dispatching.",
     );
+    lines.push("");
+  }
+
+  // Issue #185: pre-dispatch dependency check. Issues whose body declares
+  // a `## Dependencies` (or alias) section / inline `Dependencies:` line
+  // referencing an OPEN, UNKNOWN, or CLOSED-NOT-PLANNED issue are
+  // deferred so they don't waste agent time on inevitable pushbacks
+  // (motivating incident: #180 dispatched alongside its open prerequisite
+  // #178, ~$1.50 burned on a foreordained pushback). The deferred set
+  // renders here so the operator sees what's being held back before y/N.
+  // Force-includes via --include-blocked render as a WARNING block — the
+  // surface must stay visible because silent override defeats the check.
+  if (p.dependencyDeferred.length > 0) {
+    lines.push(
+      `${p.dependencyDeferred.length} issue(s) deferred — declared prerequisite(s) not satisfied:`,
+    );
+    for (const d of p.dependencyDeferred) {
+      lines.push(`  #${d.issue.id}  ${d.reason}`);
+    }
+    lines.push("  Override with --include-blocked to dispatch anyway.");
+    lines.push("");
+  }
+  if (p.dependencyForceIncluded.length > 0) {
+    lines.push(
+      `WARNING: ${p.dependencyForceIncluded.length} issue(s) with unsatisfied prerequisites force-included via --include-blocked:`,
+    );
+    for (const d of p.dependencyForceIncluded) {
+      lines.push(`  #${d.issue.id}  ${d.reason}`);
+    }
     lines.push("");
   }
 

--- a/src/state/runConfirm.ts
+++ b/src/state/runConfirm.ts
@@ -71,6 +71,15 @@ export interface RunConfirmParams {
   // mode cannot be confirmed under the other. Optional for back-compat
   // with tokens written before #148.
   skipDedup?: boolean;
+  // Issue #185: persisted intent flag for the pre-dispatch dependency
+  // check override. When `true`, the dependency check still runs and
+  // surfaces the would-be-deferred set as a WARNING block, but the
+  // candidates are dispatched anyway. Bound into the previewHash via the
+  // rendered preview text — a token written under `--include-blocked`
+  // cannot be confirmed without it (and vice versa) without forcing a
+  // fresh `--plan`. Optional for back-compat with tokens written
+  // before #185.
+  includeBlocked?: boolean;
 }
 
 export interface RunConfirmToken {


### PR DESCRIPTION
Closes #185

## Summary

- Adds `src/orchestrator/dependencies.ts`: heuristic body parser
  (`parseDependencyRefs` — `## Dependencies` / `## Depends on` /
  `## Prerequisites` / `## Blocked by` heading sections + inline
  `Dependencies:` / `Depends on:` lines, with optional Markdown
  emphasis / blockquote leaders) plus `checkDependencies` that
  resolves each ref's GitHub state via `gh issue view --json
  state,stateReason` and partitions candidates into
  `dispatchIssues` / `deferred` / `forceIncluded`.
- Wires the check into `cli.ts` between triage and the dedup pass, so
  dedup operates on the post-deferral candidate set (no Opus call on
  issues we're about to defer).
- Adds `--include-blocked` (force-dispatch). The would-be-deferred set
  still surfaces in the gate as a `WARNING: ... force-included via
  --include-blocked` block — silent override would defeat the check.
- Threads `includeBlocked` through `RunConfirmParams` and the rendered
  preview text, so the `--plan` → `--confirm` previewHash check rejects
  a token whose dep state drifted between plan and confirm.
- Same-batch refs short-circuit the `gh` round-trip: when a dep points
  at another candidate already in this batch, treat its state as
  "open" without a network call (orchestrator can't wait for an
  in-batch dep to land mid-run since merging is operator-driven).
- State results cached per `(repo, issueId)` so multiple dependents on
  the same prerequisite share one round-trip.

## Catches the literal motivating shape

```
*Dependencies: [#178](...) (Phase 1) MUST land first*
```

→ deferred with reason `depends on open #178 — re-dispatch after #178 lands`.

The motivating incident — dispatching #180 alongside open #178 in
run-2026-05-05T22-51-54-224Z — burned ~$1.50 on a foreordained
pushback. Manual scan-each-issue-body fails on larger batches; the
harness is the right place to enforce the operator habit.

## Edge cases (matches the issue body's table)

| dep state               | default     | --include-blocked              |
|-------------------------|-------------|--------------------------------|
| open                    | defer       | force-include with WARNING     |
| closed-completed        | dispatch    | dispatch (already satisfied)   |
| closed-not-planned      | defer (re-read directive) | force-include    |
| unknown (gh fail / 404) | defer       | force-include with WARNING     |
| same-batch open         | defer (no gh round-trip) | force-include     |
| self-reference          | filtered before lookup (typo guard) | filtered |

## Files

- `src/orchestrator/dependencies.ts` (new): parser + resolver + check
- `src/orchestrator/dependencies.test.ts` (new): 23 tests covering
  parser variants, every dep-state outcome, same-batch short-circuit,
  state caching, self-reference filtering, and the override flag
- `src/orchestrator/setup.ts`: `dependencyDeferred` /
  `dependencyForceIncluded` fields on `SetupPreview`; render block
  with override hint; WARNING block for force-include
- `src/orchestrator/setup.test.ts`: 4 new tests covering the new
  render blocks + previewHash drift coverage
- `src/cli.ts`: `--include-blocked` option, `RunOpts.includeBlocked`,
  the dep-check call site, plan→confirm carry, ERROR exit when the
  check empties the dispatch list
- `src/state/runConfirm.ts`: `includeBlocked?: boolean` on
  `RunConfirmParams` (back-compat: optional)

## Out of scope (matches the issue body's "Out of scope" section)

- Auto-re-dispatching deferred issues when the prerequisite merges —
  operator re-runs `vp-dev run --issues <deferred>` after the merge.
- Cross-repo dependency parsing for arbitrary repos. The parser
  recognizes `owner/repo#N` shape but the same-batch shortcut only
  applies to same-repo refs.
- Inferred dependencies ("after the parser fix lands" without a `#N`).

## Test plan

- [x] `npm run build` and `npm run typecheck` clean
- [x] `npm test` passes (685 tests, 27 new for #185)
- [ ] Dry-run `vp-dev run --plan --issues 178,180 --target-repo
      szhygulin/vaultpilot-development-agents` and confirm the gate
      text shows #180 deferred + the override hint
- [ ] Dry-run with `--include-blocked` and confirm the WARNING block
      replaces the deferred block
- [ ] Confirm a `--plan` token written without `--include-blocked`
      rejects when re-invoked with `--include-blocked` (previewHash drift)

— Hipparchus (agent-b7b8)
