### PR TITLE
feat(curve-redo): testGenerator module + generate-tests CLI (Phase 1b)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -642,6 +642,45 @@ export function buildCli(): Command {
         .action(async (opts) => {
           await cmdResearchBenchSpecialists(opts);
         }),
+    )
+    .addCommand(
+      new Command("generate-tests")
+        .description(
+          "Curve-redo Phase 1b: generate exactly N hidden tests per issue via Opus. Writes one .test.ts per generated test under --out-dir. Coding agents do NOT see these tests — they're applied to the agent's worktree-diff in Phase 1c's testRunner to score implementation quality. Default 4 batches × 25 tests = 100. Baseline-validation (do all tests fail before any agent runs?) is a Phase 2 operator concern, NOT this subcommand's responsibility.",
+        )
+        .requiredOption("--issue <n>", "Issue number to generate tests for", parsePositive)
+        .requiredOption("--target-repo <owner/repo>", "Target GitHub repo (for issue body fetch)")
+        .option(
+          "--target-repo-path <path>",
+          "Local clone path of the target repo (used for repo-tree + style fixture). Defaults to $HOME/dev/<repo-name>.",
+        )
+        .requiredOption(
+          "--framework <name>",
+          "Target test framework: 'node-test' (vp-development-agents) or 'vitest' (vp-mcp).",
+        )
+        .requiredOption(
+          "--out-dir <path>",
+          "Where the .test.ts files land (e.g. feature-plans/curve-redo-tests/<issueId>/). Created if missing.",
+        )
+        .option(
+          "--batch-count <n>",
+          "Number of LLM calls (default 4). Total tests = batch-count × tests-per-batch.",
+          parsePositive,
+          4,
+        )
+        .option(
+          "--tests-per-batch <n>",
+          "Tests requested per LLM call (default 25). Total tests = batch-count × tests-per-batch.",
+          parsePositive,
+          25,
+        )
+        .option(
+          "--style-fixture <path>",
+          "Optional path to a sibling .test.ts file to use as a style hint. Defaults to the largest .test.ts found in the repo.",
+        )
+        .action(async (opts) => {
+          await cmdResearchGenerateTests(opts);
+        }),
     );
   program.addCommand(researchCmd);
 
@@ -3843,6 +3882,52 @@ async function cmdResearchBenchSpecialists(
   });
   process.stdout.write("\n" + formatBenchReport(result) + "\n");
   process.stdout.write(`\nProposal written to ${opts.output}.\n`);
+}
+
+interface ResearchGenerateTestsOpts {
+  issue: number;
+  targetRepo: string;
+  targetRepoPath?: string;
+  framework: string;
+  outDir: string;
+  batchCount: number;
+  testsPerBatch: number;
+  styleFixture?: string;
+}
+
+async function cmdResearchGenerateTests(opts: ResearchGenerateTestsOpts): Promise<void> {
+  if (opts.framework !== "node-test" && opts.framework !== "vitest") {
+    process.stderr.write(
+      `ERROR: --framework must be 'node-test' or 'vitest', got '${opts.framework}'.\n`,
+    );
+    process.exit(2);
+  }
+  const repoPath = await resolveTargetRepoPath(opts.targetRepo, opts.targetRepoPath);
+  const detail = await getIssueDetail(opts.targetRepo, opts.issue);
+  if (!detail) {
+    process.stderr.write(`ERROR: issue #${opts.issue} not found in ${opts.targetRepo}.\n`);
+    process.exit(2);
+  }
+  const { generateTests } = await import("./research/curveStudy/testGenerator.js");
+  const totalRequested = opts.batchCount * opts.testsPerBatch;
+  process.stderr.write(
+    `Generating ${totalRequested} tests for issue #${opts.issue} (${detail.title})\n` +
+      `  framework=${opts.framework}, batches=${opts.batchCount} × ${opts.testsPerBatch}\n` +
+      `  out-dir=${opts.outDir}\n`,
+  );
+  const result = await generateTests({
+    issueId: opts.issue,
+    issueTitle: detail.title,
+    issueBody: detail.body,
+    repoPath,
+    framework: opts.framework as "node-test" | "vitest",
+    outDir: opts.outDir,
+    batchCount: opts.batchCount,
+    testsPerBatch: opts.testsPerBatch,
+    styleFixturePath: opts.styleFixture,
+  });
+  process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+  if (!result.ok) process.exit(1);
 }
 
 function printCurveSummary(

--- a/src/orchestrator/models.ts
+++ b/src/orchestrator/models.ts
@@ -43,6 +43,17 @@ export const ORCHESTRATOR_MODEL_TRIM =
 export const ORCHESTRATOR_MODEL_DEDUP =
   process.env.VP_DEV_DEDUP_MODEL ?? "claude-opus-4-7";
 
+// Curve-redo experiment (Phase 1b/1c): hidden-test generator and
+// blinded reasoning judge both run on opus by default — quality of the
+// generated tests and grading rubric is the load-bearing dimension.
+// Operators tightening the budget can downshift to sonnet via env var,
+// but the default is opus for consistent measurement across cells.
+export const ORCHESTRATOR_MODEL_TEST_GENERATOR =
+  process.env.VP_DEV_TEST_GENERATOR_MODEL ?? "claude-opus-4-7";
+
+export const ORCHESTRATOR_MODEL_REASONING_JUDGE =
+  process.env.VP_DEV_REASONING_JUDGE_MODEL ?? "claude-opus-4-7";
+
 /**
  * Snapshot of the resolved model map, suitable for inclusion in the
  * `run.started` log payload. Built as a function (not a const map) so each
@@ -57,6 +68,8 @@ export function resolvedModelTiers(): {
   summarizer: string;
   trim: string;
   dedup: string;
+  testGenerator: string;
+  reasoningJudge: string;
 } {
   return {
     triage: ORCHESTRATOR_MODEL_TRIAGE,
@@ -65,5 +78,7 @@ export function resolvedModelTiers(): {
     summarizer: ORCHESTRATOR_MODEL_SUMMARIZER,
     trim: ORCHESTRATOR_MODEL_TRIM,
     dedup: ORCHESTRATOR_MODEL_DEDUP,
+    testGenerator: ORCHESTRATOR_MODEL_TEST_GENERATOR,
+    reasoningJudge: ORCHESTRATOR_MODEL_REASONING_JUDGE,
   };
 }

--- a/src/research/curveStudy/testGenerator.test.ts
+++ b/src/research/curveStudy/testGenerator.test.ts
@@ -1,0 +1,322 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  generateTests,
+  parseTestBatch,
+  pickStyleFixture,
+  listRepoTree,
+  writeTestFiles,
+  type LlmCall,
+} from "./testGenerator.js";
+
+async function makeRepo(opts?: { withStyleFixture?: boolean }): Promise<{
+  repoPath: string;
+  cleanup: () => Promise<void>;
+}> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "test-generator-test-"));
+  await fs.mkdir(path.join(dir, "src"), { recursive: true });
+  await fs.mkdir(path.join(dir, "src", "agent"), { recursive: true });
+  await fs.writeFile(path.join(dir, "src", "index.ts"), "export const x = 1;\n");
+  if (opts?.withStyleFixture !== false) {
+    await fs.writeFile(
+      path.join(dir, "src", "agent", "example.test.ts"),
+      `import { test } from "node:test";\nimport assert from "node:assert/strict";\n\ntest("example: basic assertion", () => {\n  assert.equal(1 + 1, 2);\n});\n`,
+    );
+  }
+  return {
+    repoPath: dir,
+    cleanup: async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+function makeSyntheticLlm(
+  responses: Array<{ tests: { filename: string; code: string; description?: string }[] } | string>,
+): LlmCall {
+  let i = 0;
+  return async () => {
+    if (i >= responses.length) {
+      return { raw: "", isError: true, errorReason: "no more synthetic responses" };
+    }
+    const r = responses[i++];
+    if (typeof r === "string") {
+      return { raw: r, isError: false, costUsd: 0.05 };
+    }
+    return { raw: JSON.stringify(r), isError: false, costUsd: 0.05 };
+  };
+}
+
+test("parseTestBatch: extracts tests from valid JSON", () => {
+  const raw = JSON.stringify({
+    tests: [
+      { filename: "foo-bar.test.ts", code: "test('a', () => {});", description: "checks a" },
+      { filename: "baz.test.ts", code: "test('b', () => {});" },
+    ],
+  });
+  const out = parseTestBatch(raw);
+  assert.equal(out.ok, true);
+  if (out.ok) {
+    assert.equal(out.tests.length, 2);
+    assert.equal(out.tests[0].filename, "foo-bar.test.ts");
+  }
+});
+
+test("parseTestBatch: rejects malformed JSON", () => {
+  const out = parseTestBatch("not json at all");
+  assert.equal(out.ok, false);
+});
+
+test("parseTestBatch: rejects valid JSON missing required fields", () => {
+  const raw = JSON.stringify({ tests: [{ filename: "x.test.ts" }] }); // missing code
+  const out = parseTestBatch(raw);
+  assert.equal(out.ok, false);
+});
+
+test("parseTestBatch: salvages JSON wrapped in markdown fences", () => {
+  const raw = "```json\n" + JSON.stringify({
+    tests: [{ filename: "foo.test.ts", code: "test('x', () => {});" }],
+  }) + "\n```";
+  const out = parseTestBatch(raw);
+  assert.equal(out.ok, true);
+});
+
+test("listRepoTree: emits depth-2 listing, excludes node_modules / dist / .git", async () => {
+  const { repoPath, cleanup } = await makeRepo();
+  try {
+    await fs.mkdir(path.join(repoPath, "node_modules"), { recursive: true });
+    await fs.writeFile(path.join(repoPath, "node_modules", "should-not-appear.txt"), "");
+    const tree = await listRepoTree(repoPath, 2);
+    assert.match(tree, /src\//);
+    assert.match(tree, /agent\//);
+    assert.doesNotMatch(tree, /node_modules/);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("pickStyleFixture: returns the largest .test.ts file", async () => {
+  const { repoPath, cleanup } = await makeRepo();
+  try {
+    const fixture = await pickStyleFixture(repoPath);
+    assert.ok(fixture, "expected a style fixture");
+    if (fixture) {
+      assert.match(fixture.path, /\.test\.ts$/);
+      assert.match(fixture.contents, /import \{ test \} from "node:test"/);
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+test("pickStyleFixture: returns null when no test files exist", async () => {
+  const { repoPath, cleanup } = await makeRepo({ withStyleFixture: false });
+  try {
+    const fixture = await pickStyleFixture(repoPath);
+    assert.equal(fixture, null);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("writeTestFiles: writes one file per test, sanitizes filenames", async () => {
+  const { repoPath, cleanup } = await makeRepo();
+  try {
+    const outDir = path.join(repoPath, "out");
+    const written = await writeTestFiles({
+      outDir,
+      batch: 1,
+      tests: [
+        { filename: "Foo Bar.test.ts", code: "// a" },
+        { filename: "weird/path/baz.test.ts", code: "// b" },
+        { filename: "", code: "// fallback" },
+      ],
+    });
+    assert.equal(written.length, 3);
+    for (const p of written) {
+      assert.match(path.basename(p), /^b1-[a-z0-9-]+\.test\.ts$/);
+      const contents = await fs.readFile(p, "utf-8");
+      assert.ok(contents.length > 0);
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+test("writeTestFiles: deduplicates filename collisions across the batch", async () => {
+  const { repoPath, cleanup } = await makeRepo();
+  try {
+    const outDir = path.join(repoPath, "out");
+    const written = await writeTestFiles({
+      outDir,
+      batch: 1,
+      tests: [
+        { filename: "same.test.ts", code: "// one" },
+        { filename: "same.test.ts", code: "// two" },
+        { filename: "same.test.ts", code: "// three" },
+      ],
+    });
+    assert.equal(written.length, 3);
+    const names = new Set(written.map((p) => path.basename(p)));
+    assert.equal(names.size, 3, "expected three unique filenames");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("generateTests: ok=true when all batches return the requested test count", async () => {
+  const { repoPath, cleanup } = await makeRepo();
+  try {
+    const llm = makeSyntheticLlm([
+      { tests: [{ filename: "a-1.test.ts", code: "// 1" }, { filename: "a-2.test.ts", code: "// 2" }] },
+      { tests: [{ filename: "b-1.test.ts", code: "// 3" }, { filename: "b-2.test.ts", code: "// 4" }] },
+    ]);
+    const out = await generateTests({
+      issueId: 100,
+      issueTitle: "Test issue",
+      issueBody: "Body",
+      repoPath,
+      framework: "node-test",
+      outDir: path.join(repoPath, "tests-out"),
+      batchCount: 2,
+      testsPerBatch: 2,
+      llmCall: llm,
+    });
+    assert.equal(out.ok, true);
+    assert.equal(out.testsRequested, 4);
+    assert.equal(out.testsWritten, 4);
+    assert.equal(out.generatedFiles.length, 4);
+    assert.equal(out.failures.length, 0);
+    assert.equal(out.perBatch.length, 2);
+    assert.equal(out.costUsd, 0.1);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("generateTests: ok=false and failures recorded when LLM short-counts a batch", async () => {
+  const { repoPath, cleanup } = await makeRepo();
+  try {
+    const llm = makeSyntheticLlm([
+      { tests: [{ filename: "a-1.test.ts", code: "// 1" }] }, // requested 2, got 1
+      { tests: [{ filename: "b-1.test.ts", code: "// 2" }, { filename: "b-2.test.ts", code: "// 3" }] },
+    ]);
+    const out = await generateTests({
+      issueId: 200,
+      issueTitle: "Short-count issue",
+      issueBody: "Body",
+      repoPath,
+      framework: "node-test",
+      outDir: path.join(repoPath, "tests-out"),
+      batchCount: 2,
+      testsPerBatch: 2,
+      llmCall: llm,
+    });
+    assert.equal(out.ok, false);
+    assert.equal(out.testsWritten, 3);
+    assert.ok(out.failures.some((f) => f.includes("batch 1")));
+  } finally {
+    await cleanup();
+  }
+});
+
+test("generateTests: ok=false when LLM returns an error", async () => {
+  const { repoPath, cleanup } = await makeRepo();
+  try {
+    const llm: LlmCall = async () => ({
+      raw: "",
+      isError: true,
+      errorReason: "rate_limit",
+    });
+    const out = await generateTests({
+      issueId: 300,
+      issueTitle: "Rate-limited",
+      issueBody: "Body",
+      repoPath,
+      framework: "vitest",
+      outDir: path.join(repoPath, "tests-out"),
+      batchCount: 1,
+      testsPerBatch: 5,
+      llmCall: llm,
+    });
+    assert.equal(out.ok, false);
+    assert.ok(out.failures.some((f) => f.includes("rate_limit")));
+    assert.equal(out.testsWritten, 0);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("generateTests: ok=false when LLM returns malformed JSON", async () => {
+  const { repoPath, cleanup } = await makeRepo();
+  try {
+    const llm = makeSyntheticLlm(["this is not JSON"]);
+    const out = await generateTests({
+      issueId: 400,
+      issueTitle: "Malformed",
+      issueBody: "Body",
+      repoPath,
+      framework: "node-test",
+      outDir: path.join(repoPath, "tests-out"),
+      batchCount: 1,
+      testsPerBatch: 3,
+      llmCall: llm,
+    });
+    assert.equal(out.ok, false);
+    assert.equal(out.testsWritten, 0);
+    assert.ok(out.failures.some((f) => /parse error/.test(f)));
+  } finally {
+    await cleanup();
+  }
+});
+
+test("generateTests: ok=false when no style fixture is available in the repo", async () => {
+  const { repoPath, cleanup } = await makeRepo({ withStyleFixture: false });
+  try {
+    const out = await generateTests({
+      issueId: 500,
+      issueTitle: "No style",
+      issueBody: "Body",
+      repoPath,
+      framework: "node-test",
+      outDir: path.join(repoPath, "tests-out"),
+      batchCount: 1,
+      testsPerBatch: 1,
+      llmCall: makeSyntheticLlm([]),
+    });
+    assert.equal(out.ok, false);
+    assert.ok(out.failures.some((f) => /style fixture/.test(f)));
+  } finally {
+    await cleanup();
+  }
+});
+
+test("generateTests: respects an explicit styleFixturePath", async () => {
+  const { repoPath, cleanup } = await makeRepo();
+  try {
+    const customFixture = path.join(repoPath, "custom.test.ts");
+    await fs.writeFile(customFixture, "import { test } from 'vitest';\ntest('x', () => {});\n");
+    const llm = makeSyntheticLlm([
+      { tests: [{ filename: "a.test.ts", code: "// a" }] },
+    ]);
+    const out = await generateTests({
+      issueId: 600,
+      issueTitle: "Custom fixture",
+      issueBody: "Body",
+      repoPath,
+      framework: "vitest",
+      outDir: path.join(repoPath, "tests-out"),
+      batchCount: 1,
+      testsPerBatch: 1,
+      styleFixturePath: customFixture,
+      llmCall: llm,
+    });
+    assert.equal(out.ok, true);
+    assert.equal(out.testsWritten, 1);
+  } finally {
+    await cleanup();
+  }
+});

--- a/src/research/curveStudy/testGenerator.ts
+++ b/src/research/curveStudy/testGenerator.ts
@@ -1,0 +1,452 @@
+// Curve-redo Phase 1b: hidden-test generator.
+//
+// For each issue in the corpus we generate exactly N (default 100) hidden
+// tests via Opus. The tests grade whether a coding agent's implementation
+// solves the issue — they're applied to the agent's worktree-diff and run
+// in Phase 1c's testRunner. Coding agents do NOT see the tests; this module
+// is operator-only, run once per corpus issue ahead of dispatch.
+//
+// Design choices:
+//   - One LLM call per BATCH of testsPerBatch tests (default 25, ×4 = 100).
+//     Single-call 100-test generation truncates output for issues with rich
+//     surface area; batching keeps each response under the model's natural
+//     output cap and lets the prompt steer each batch toward a different
+//     test category (happy-path / edges / errors / contracts).
+//   - Strict JSON output schema. parseJsonEnvelope salvages
+//     near-malformed responses (apostrophe escapes, etc.) so a single
+//     batch's parse failure doesn't poison the whole run.
+//   - Baseline-validation (do all 100 tests fail on the unmodified base?)
+//     lives in Phase 2 operator workflow, NOT here. testGenerator's job
+//     is generation; testRunner (Phase 1c) does the run, and the operator
+//     decides whether to regenerate.
+//
+// LlmCall is injectable so unit tests can substitute a synthetic generator
+// without spinning up the real SDK.
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { z } from "zod";
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { claudeBinPath } from "../../agent/sdkBinary.js";
+import { parseJsonEnvelope } from "../../util/parseJsonEnvelope.js";
+import { ORCHESTRATOR_MODEL_TEST_GENERATOR } from "../../orchestrator/models.js";
+import type { Logger } from "../../log/logger.js";
+
+export type Framework = "node-test" | "vitest";
+
+const TEST_BATCH_SCHEMA = z.object({
+  tests: z.array(
+    z.object({
+      filename: z.string().min(1),
+      description: z.string().optional(),
+      code: z.string().min(1),
+    }),
+  ),
+});
+
+export interface GenerateTestsInput {
+  issueId: number;
+  issueTitle: string;
+  issueBody: string;
+  /** Absolute path to a clone of the target repo (used for repo-tree + style fixture). */
+  repoPath: string;
+  framework: Framework;
+  /** Where the .test.ts files land. Created if missing. */
+  outDir: string;
+  /** Default 4. Total tests = batchCount × testsPerBatch. */
+  batchCount?: number;
+  /** Default 25. Total tests = batchCount × testsPerBatch. */
+  testsPerBatch?: number;
+  /**
+   * Optional path to a sibling test file used as style hint. When absent,
+   * the generator picks one automatically via `pickStyleFixture`.
+   */
+  styleFixturePath?: string;
+  /** Test seam: substitute the SDK call in unit tests. */
+  llmCall?: LlmCall;
+  logger?: Logger;
+}
+
+export interface GenerateTestsResult {
+  ok: boolean;
+  testsRequested: number;
+  testsWritten: number;
+  generatedFiles: string[];
+  perBatch: BatchOutcome[];
+  costUsd?: number;
+  failures: string[];
+}
+
+export interface BatchOutcome {
+  batch: number;
+  category: string;
+  requested: number;
+  received: number;
+  written: number;
+  costUsd?: number;
+  error?: string;
+}
+
+export type LlmCall = (args: {
+  systemPrompt: string;
+  userPrompt: string;
+  model: string;
+}) => Promise<LlmCallResult>;
+
+export interface LlmCallResult {
+  raw: string;
+  costUsd?: number;
+  isError: boolean;
+  errorReason?: string;
+}
+
+const DEFAULT_BATCH_COUNT = 4;
+const DEFAULT_TESTS_PER_BATCH = 25;
+
+const BATCH_CATEGORIES = [
+  "Happy-path / canonical correctness — the issue's primary success case is exercised end-to-end.",
+  "Edge cases — empty inputs, single-element collections, off-by-one boundaries, max/min sizes.",
+  "Error paths / negative tests — invalid inputs, malformed data, contract violations should fail loudly.",
+  "Side effects / contracts — observable state transitions, integration with the surfaces the issue body names.",
+];
+
+const SYSTEM_PROMPT = `You generate hidden behavior-level tests that grade whether a coding agent's implementation of an issue solves the problem described. Each test you generate is a self-contained TypeScript test file in the named framework that will be run against the agent's worktree-diff applied on top of the unmodified base SHA.
+
+CRITICAL CONSTRAINTS — violating these wastes the test:
+- Tests check OBSERVABLE BEHAVIOR (return values, file contents, exported symbol shapes, side effects), NOT implementation details (private helper names, internal variable names, specific data structures).
+- Each test must FAIL on the unmodified baseline AND PASS only after a correct implementation diff is applied.
+- Each test file imports ONLY from public module paths named in the issue body or visible in the repo tree. Imports of paths the issue doesn't mention will fail compile and waste the test.
+- Test files MUST compile cleanly. Use the framework's idiomatic test/expect API exactly as the style fixture demonstrates.
+- Filenames are kebab-case ending in \`.test.ts\`. No spaces, no uppercase, no special chars.
+
+OUTPUT FORMAT — strict JSON object, no prose before or after:
+{
+  "tests": [
+    {
+      "filename": "behavior-foo-<descriptive-slug>.test.ts",
+      "description": "one short sentence on what observable behavior this verifies",
+      "code": "<full TypeScript test file content, ready to write to disk>"
+    }
+  ]
+}
+
+Generate exactly the requested number of tests, all in the requested category. No fewer.`;
+
+function buildUserPrompt(args: {
+  issueTitle: string;
+  issueBody: string;
+  framework: Framework;
+  category: string;
+  testCount: number;
+  repoTree: string;
+  styleFixture: string;
+  styleFixturePath: string;
+}): string {
+  const frameworkInstructions =
+    args.framework === "node-test"
+      ? "Framework: Node built-in test runner. Use `import { test } from \"node:test\"` and `import assert from \"node:assert/strict\"`."
+      : "Framework: Vitest. Use `import { test, expect } from \"vitest\"`.";
+  return [
+    `Issue: ${args.issueTitle}`,
+    "",
+    "--- Issue body ---",
+    args.issueBody,
+    "--- end body ---",
+    "",
+    frameworkInstructions,
+    "",
+    "Repo tree (depth 2):",
+    args.repoTree,
+    "",
+    `Style fixture (existing test from this repo at ${args.styleFixturePath} — match this style):`,
+    "```ts",
+    args.styleFixture,
+    "```",
+    "",
+    `Generate exactly ${args.testCount} tests in this category: ${args.category}`,
+    "",
+    "Emit only the JSON object specified in the system prompt. No markdown fences, no prose.",
+  ].join("\n");
+}
+
+/**
+ * Walk the repo (depth 2) and emit a compact directory listing usable as
+ * an LLM-prompt context. Excludes node_modules, dist, .git, agents, logs,
+ * state — directories the LLM doesn't need to reason about.
+ */
+export async function listRepoTree(repoPath: string, depth = 2): Promise<string> {
+  const skip = new Set(["node_modules", "dist", ".git", "agents", "logs", "state"]);
+  const lines: string[] = [];
+  async function walk(dir: string, depthLeft: number, indent: string) {
+    if (depthLeft < 0) return;
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+    for (const e of entries) {
+      if (skip.has(e.name) || e.name.startsWith(".")) continue;
+      lines.push(`${indent}${e.name}${e.isDirectory() ? "/" : ""}`);
+      if (e.isDirectory()) {
+        await walk(path.join(dir, e.name), depthLeft - 1, indent + "  ");
+      }
+    }
+  }
+  await walk(repoPath, depth, "");
+  return lines.join("\n");
+}
+
+/**
+ * Find a representative .test.ts (or .spec.ts) file in the repo to use as
+ * a style hint. Prefers the largest test file under src/ (more realistic
+ * coverage of the framework's idioms). Returns null when no test files
+ * exist — the caller fails the run rather than fabricating a fixture.
+ */
+export async function pickStyleFixture(repoPath: string): Promise<{ path: string; contents: string } | null> {
+  const candidates: { path: string; size: number }[] = [];
+  async function walk(dir: string, depthLeft: number) {
+    if (depthLeft < 0) return;
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (e.name === "node_modules" || e.name === "dist" || e.name === ".git") continue;
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        await walk(p, depthLeft - 1);
+      } else if (e.isFile() && (/\.(test|spec)\.ts$/.test(e.name))) {
+        try {
+          const st = await fs.stat(p);
+          candidates.push({ path: p, size: st.size });
+        } catch {
+          // ignore unreadable
+        }
+      }
+    }
+  }
+  await walk(repoPath, 6);
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => b.size - a.size);
+  // Cap at 4 KB — a style fixture only needs to demonstrate idioms.
+  const picked = candidates[0];
+  const full = await fs.readFile(picked.path, "utf-8");
+  return { path: picked.path, contents: full.slice(0, 4096) };
+}
+
+export function parseTestBatch(raw: string): { ok: true; tests: { filename: string; code: string; description?: string }[] } | { ok: false; error: string } {
+  const extracted = parseJsonEnvelope(raw, TEST_BATCH_SCHEMA);
+  if (!extracted.ok || !extracted.value) {
+    return { ok: false, error: extracted.error ?? "JSON parse failed" };
+  }
+  return { ok: true, tests: extracted.value.tests };
+}
+
+const FILENAME_SAFE_RE = /^[a-z0-9][a-z0-9-]{0,80}\.test\.ts$/;
+
+function sanitizeFilename(name: string, fallbackIndex: number, batch: number): string {
+  const base = name
+    .toLowerCase()
+    .replace(/\.test\.tsx?$/, "")
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60);
+  const safe = `${base || `t${fallbackIndex}`}.test.ts`;
+  if (FILENAME_SAFE_RE.test(safe)) return `b${batch}-${safe}`;
+  return `b${batch}-t${fallbackIndex}.test.ts`;
+}
+
+export async function writeTestFiles(args: {
+  outDir: string;
+  batch: number;
+  tests: { filename: string; code: string }[];
+}): Promise<string[]> {
+  await fs.mkdir(args.outDir, { recursive: true });
+  const written: string[] = [];
+  const seen = new Set<string>();
+  for (let i = 0; i < args.tests.length; i++) {
+    const t = args.tests[i];
+    let safe = sanitizeFilename(t.filename, i, args.batch);
+    let suffix = 1;
+    while (seen.has(safe)) {
+      safe = safe.replace(/\.test\.ts$/, `-${suffix}.test.ts`);
+      suffix++;
+    }
+    seen.add(safe);
+    const target = path.join(args.outDir, safe);
+    await fs.writeFile(target, t.code);
+    written.push(target);
+  }
+  return written;
+}
+
+async function defaultLlmCall(args: {
+  systemPrompt: string;
+  userPrompt: string;
+  model: string;
+}): Promise<LlmCallResult> {
+  let raw = "";
+  let costUsd: number | undefined;
+  try {
+    const stream = query({
+      prompt: args.userPrompt,
+      options: {
+        model: args.model,
+        systemPrompt: args.systemPrompt,
+        tools: [],
+        permissionMode: "default",
+        env: process.env,
+        maxTurns: 1,
+        settingSources: [],
+        persistSession: false,
+        pathToClaudeCodeExecutable: claudeBinPath(),
+      },
+    });
+    for await (const msg of stream) {
+      if (msg.type === "result") {
+        if (msg.subtype === "success") {
+          raw = msg.result;
+          costUsd = msg.total_cost_usd;
+        } else {
+          return {
+            raw: "",
+            costUsd: msg.total_cost_usd,
+            isError: true,
+            errorReason: msg.subtype,
+          };
+        }
+      }
+    }
+  } catch (err) {
+    return { raw: "", isError: true, errorReason: (err as Error).message };
+  }
+  return { raw, costUsd, isError: false };
+}
+
+export async function generateTests(input: GenerateTestsInput): Promise<GenerateTestsResult> {
+  const batchCount = input.batchCount ?? DEFAULT_BATCH_COUNT;
+  const testsPerBatch = input.testsPerBatch ?? DEFAULT_TESTS_PER_BATCH;
+  const totalRequested = batchCount * testsPerBatch;
+  const llm = input.llmCall ?? defaultLlmCall;
+
+  const repoTree = await listRepoTree(input.repoPath);
+  let styleFixture: { path: string; contents: string } | null;
+  if (input.styleFixturePath) {
+    try {
+      const contents = await fs.readFile(input.styleFixturePath, "utf-8");
+      styleFixture = { path: input.styleFixturePath, contents: contents.slice(0, 4096) };
+    } catch (err) {
+      return {
+        ok: false,
+        testsRequested: totalRequested,
+        testsWritten: 0,
+        generatedFiles: [],
+        perBatch: [],
+        failures: [`style fixture read failed: ${(err as Error).message}`],
+      };
+    }
+  } else {
+    styleFixture = await pickStyleFixture(input.repoPath);
+  }
+  if (!styleFixture) {
+    return {
+      ok: false,
+      testsRequested: totalRequested,
+      testsWritten: 0,
+      generatedFiles: [],
+      perBatch: [],
+      failures: ["no .test.ts / .spec.ts file found in repo to use as style fixture"],
+    };
+  }
+
+  const allFiles: string[] = [];
+  const perBatch: BatchOutcome[] = [];
+  const failures: string[] = [];
+  let totalCost = 0;
+
+  for (let b = 0; b < batchCount; b++) {
+    const category = BATCH_CATEGORIES[b % BATCH_CATEGORIES.length];
+    const userPrompt = buildUserPrompt({
+      issueTitle: input.issueTitle,
+      issueBody: input.issueBody,
+      framework: input.framework,
+      category,
+      testCount: testsPerBatch,
+      repoTree,
+      styleFixture: styleFixture.contents,
+      styleFixturePath: styleFixture.path,
+    });
+
+    const llmResult = await llm({
+      systemPrompt: SYSTEM_PROMPT,
+      userPrompt,
+      model: ORCHESTRATOR_MODEL_TEST_GENERATOR,
+    });
+    if (llmResult.costUsd !== undefined) totalCost += llmResult.costUsd;
+
+    if (llmResult.isError) {
+      perBatch.push({
+        batch: b + 1,
+        category,
+        requested: testsPerBatch,
+        received: 0,
+        written: 0,
+        costUsd: llmResult.costUsd,
+        error: llmResult.errorReason,
+      });
+      failures.push(`batch ${b + 1}: LLM error: ${llmResult.errorReason ?? "unknown"}`);
+      continue;
+    }
+
+    const parsed = parseTestBatch(llmResult.raw);
+    if (!parsed.ok) {
+      perBatch.push({
+        batch: b + 1,
+        category,
+        requested: testsPerBatch,
+        received: 0,
+        written: 0,
+        costUsd: llmResult.costUsd,
+        error: parsed.error,
+      });
+      failures.push(`batch ${b + 1}: parse error: ${parsed.error}`);
+      continue;
+    }
+
+    const written = await writeTestFiles({
+      outDir: input.outDir,
+      batch: b + 1,
+      tests: parsed.tests,
+    });
+    allFiles.push(...written);
+    perBatch.push({
+      batch: b + 1,
+      category,
+      requested: testsPerBatch,
+      received: parsed.tests.length,
+      written: written.length,
+      costUsd: llmResult.costUsd,
+    });
+
+    if (parsed.tests.length < testsPerBatch) {
+      failures.push(
+        `batch ${b + 1}: requested ${testsPerBatch}, received ${parsed.tests.length}`,
+      );
+    }
+  }
+
+  const ok = allFiles.length === totalRequested && failures.length === 0;
+  return {
+    ok,
+    testsRequested: totalRequested,
+    testsWritten: allFiles.length,
+    generatedFiles: allFiles,
+    perBatch,
+    costUsd: totalCost > 0 ? totalCost : undefined,
+    failures,
+  };
+}


### PR DESCRIPTION
## Summary

Phase 1b of the curve-redo experiment. Adds `vp-dev research generate-tests` — a CLI that generates exactly N (default 100) hidden tests per corpus issue via Opus.

```
vp-dev research generate-tests \
  --issue 190 \
  --target-repo szhygulin/vaultpilot-development-agents \
  --framework node-test \
  --out-dir feature-plans/curve-redo-tests/190
```

The generator splits the 100 tests across 4 batches of 25, steering each batch toward a different category (happy-path / edges / errors / contracts) so a single batch's output cap doesn't truncate the set. Output is one `.test.ts` per generated test under `--out-dir`. Filenames sanitized to `b<batch>-<slug>.test.ts`; collisions deduplicated.

Coding agents do NOT see these tests — they're applied to the agent's worktree-diff in Phase 1c's testRunner. Baseline-validation (do all 100 tests fail on the unmodified base?) is a Phase 2 operator concern, not this module's responsibility (that needs Phase 1c's testRunner).

## Why

Background in [PR #207](https://github.com/szhygulin/vaultpilot-development-agents/pull/207) (Phase 1a) and the curve-redo plan. The shipped curve in `src/util/contextCostCurve.ts` was calibrated against a quality metric that grades cells off the agent's self-reported envelope label, not whether the diff actually solves the issue. The redo replaces that with a 0–200 LLM-driven metric:

```
A — reasoning judge (0-100): blinded Opus K=3 on the diff or pushback comment
B — hidden-test pass rate (0-100): the testGenerator output, applied to the cell's diff
quality = A + B (implement) | 2A (pushback) | 0 (error)
```

This PR is the test-generation half of the metric.

## Files

- `src/research/curveStudy/testGenerator.ts` (new, 360 lines) — generator + LLM call shim + repo-tree + style-fixture picker + filename sanitization + JSON parsing
- `src/research/curveStudy/testGenerator.test.ts` (new, 270 lines) — 15 tests covering: JSON parsing happy + error paths (markdown fences, missing fields, malformed), `listRepoTree` exclusions, `pickStyleFixture` largest-file selection, `writeTestFiles` filename sanitization + collision dedup, full `generateTests` flow with synthetic LLM (success, short-count, LLM-error, malformed-JSON, no-style-fixture, explicit-style-fixture)
- `src/orchestrator/models.ts` — adds `ORCHESTRATOR_MODEL_TEST_GENERATOR` and `ORCHESTRATOR_MODEL_REASONING_JUDGE` (the latter reserved for Phase 1c). Both default to `claude-opus-4-7` with env-var override. Extends `resolvedModelTiers()`.
- `src/cli.ts` — `vp-dev research generate-tests` subcommand wired through `cmdResearchGenerateTests`. Resolves the issue body via existing `getIssueDetail`. Validates `--framework` is `node-test` or `vitest`.

## Independence

Pure new code. Doesn't import from Phase 1a or Phase 1c. Mergeable in any order with #207 and the upcoming Phase 1c PR.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 673 / 673 pass (15 new testGenerator tests included; was 658 on main)
- [x] `vp-dev research generate-tests --help` shows the documented options
- [ ] Smoke against one real open issue once Phase 1c lands and we can sanity-check the 100 generated tests against testRunner's baseline pass count (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)