### PR TITLE
feat(curve-redo): per-cell A/B aggregator + 0-200 quality formula (Phase 1d)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -676,6 +676,10 @@ export function buildCli(): Command {
           "Regression form: linear-log (y ~ a + b·log(x)) | linear-raw (y ~ a + b·x) | poly2-log (y ~ a + b·log(x) + c·log(x)²) | poly2-raw (y ~ a + b·x + c·x²). Default linear-log per #179 leg-1 finding (linear-log beat poly2-raw on accuracy p=0.097 vs 0.111 and token-cost p=0.176 vs 0.404 at n=18).",
           "linear-log",
         )
+        .option(
+          "--cell-scores-dir <path>",
+          "Curve-redo Phase 1d: read per-cell A (reasoning judge) + B (hidden-test pass rate) JSONs from this directory and use the 0–200 quality formula instead of the envelope-label-derived QualityScore. Each cell needs `<agentId>-<issueId>-tests.json` and `-judge.json` files written by `vp-dev research run-tests` and `vp-dev research grade-reasoning`. Cells missing either side score 0.",
+        )
         .action(async (opts) => {
           await cmdResearchCurveStudy(opts);
         }),
@@ -4222,6 +4226,8 @@ interface ResearchCurveStudyOpts {
   mode: string;
   collisionPolicy: string;
   curveForm: string;
+  /** Curve-redo Phase 1d: per-cell A/B JSON dir; opts into the new 0–200 quality formula. */
+  cellScoresDir?: string;
 }
 
 type CurveForm = "linear-log" | "linear-raw" | "poly2-log" | "poly2-raw";
@@ -4292,6 +4298,7 @@ async function cmdResearchCurveStudy(opts: ResearchCurveStudyOpts): Promise<void
     regressionXTransform: xTransform,
     existingAccuracySamples,
     existingTokenCostSamples,
+    cellScoresDir: opts.cellScoresDir,
   });
   process.stdout.write(`\nDone. ${result.cells.length} cells, $${result.totalCostUsd.toFixed(2)}, ${(result.wallMs / 60000).toFixed(1)}min.\n`);
   process.stdout.write(`Mode: ${result.mode}. Curve form: ${opts.curveForm}. Proposal written to ${opts.output}.\n`);

--- a/src/research/curveStudy/cellScores.test.ts
+++ b/src/research/curveStudy/cellScores.test.ts
@@ -1,0 +1,294 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  cellKeyFor,
+  loadCellScores,
+  qualityFromAB,
+  samplesFromCellScores,
+  type CellJudgeScore,
+  type CellTestScore,
+} from "./cellScores.js";
+import type { Cell } from "./types.js";
+
+function judge(median: number, isError = false): CellJudgeScore {
+  return { median, scores: [median], variance: 0, isError };
+}
+function tests(passed: number, total = 100, applyCleanly = true): CellTestScore {
+  return { passed, failed: total - passed, errored: 0, total, applyCleanly, runtimeMs: 1000 };
+}
+function cell(agentId: string, sizeBytes: number, issueId: number, decision: Cell["decision"]): Cell {
+  return {
+    agentId,
+    agentSizeBytes: sizeBytes,
+    issueId,
+    decision,
+    reason: null,
+    costUsd: 0,
+    durationMs: 0,
+    isError: decision === "error",
+    errorReason: null,
+    log: "",
+  };
+}
+
+test("cellKeyFor: format without replicate", () => {
+  assert.equal(cellKeyFor("agent-916a", 190), "agent-916a-190");
+});
+
+test("cellKeyFor: format with replicate", () => {
+  assert.equal(cellKeyFor("agent-916a", 190, 2), "agent-916a-190-r2");
+});
+
+test("qualityFromAB: implement = A + B at the maximum", () => {
+  const q = qualityFromAB({ decision: "implement", judge: judge(85), test: tests(72) });
+  assert.equal(q, 85 + 72);
+});
+
+test("qualityFromAB: implement caps at 200 with A=100, B=100", () => {
+  const q = qualityFromAB({ decision: "implement", judge: judge(100), test: tests(100) });
+  assert.equal(q, 200);
+});
+
+test("qualityFromAB: implement = 0 when test apply failed", () => {
+  const q = qualityFromAB({
+    decision: "implement",
+    judge: judge(85),
+    test: tests(50, 100, false),
+  });
+  assert.equal(q, 0);
+});
+
+test("qualityFromAB: implement = 0 when judge errored even if tests passed", () => {
+  const q = qualityFromAB({
+    decision: "implement",
+    judge: judge(0, true),
+    test: tests(50),
+  });
+  assert.equal(q, 0);
+});
+
+test("qualityFromAB: implement = 0 when test data is missing", () => {
+  const q = qualityFromAB({ decision: "implement", judge: judge(85) });
+  assert.equal(q, 0);
+});
+
+test("qualityFromAB: implement = 0 when judge data is missing", () => {
+  const q = qualityFromAB({ decision: "implement", test: tests(50) });
+  assert.equal(q, 0);
+});
+
+test("qualityFromAB: implement = 0 when test errorReason is set", () => {
+  const q = qualityFromAB({
+    decision: "implement",
+    judge: judge(85),
+    test: { ...tests(50), errorReason: "test-runner timed out" },
+  });
+  assert.equal(q, 0);
+});
+
+test("qualityFromAB: pushback = 2 × A regardless of test outcome", () => {
+  const q = qualityFromAB({
+    decision: "pushback",
+    judge: judge(75),
+    test: tests(0), // tests irrelevant for pushback
+  });
+  assert.equal(q, 150);
+});
+
+test("qualityFromAB: pushback = 0 when judge errored", () => {
+  const q = qualityFromAB({ decision: "pushback", judge: judge(0, true) });
+  assert.equal(q, 0);
+});
+
+test("qualityFromAB: error decision = 0 even with judge + tests", () => {
+  const q = qualityFromAB({
+    decision: "error",
+    judge: judge(85),
+    test: tests(80),
+  });
+  assert.equal(q, 0);
+});
+
+test("qualityFromAB: error_max_turns decision = 0", () => {
+  const q = qualityFromAB({
+    decision: "error_max_turns",
+    judge: judge(85),
+    test: tests(80),
+  });
+  assert.equal(q, 0);
+});
+
+test("qualityFromAB: null decision = 0", () => {
+  const q = qualityFromAB({ decision: null });
+  assert.equal(q, 0);
+});
+
+test("qualityFromAB: implement with non-100 total normalizes B to 0-100", () => {
+  // 12/40 passed → B should be 30, not 12
+  const q = qualityFromAB({
+    decision: "implement",
+    judge: judge(50),
+    test: tests(12, 40),
+  });
+  assert.equal(q, 50 + 30);
+});
+
+test("qualityFromAB: implement with total=0 returns 0 (avoid div by zero)", () => {
+  const q = qualityFromAB({
+    decision: "implement",
+    judge: judge(50),
+    test: { passed: 0, failed: 0, errored: 0, total: 0, applyCleanly: true, runtimeMs: 0 },
+  });
+  assert.equal(q, 0);
+});
+
+test("qualityFromAB: out-of-range judge median is clamped", () => {
+  // Schema in reasoningJudge.ts already enforces 0-100, but the loader
+  // accepts arbitrary JSON; clamp defensively.
+  const q = qualityFromAB({
+    decision: "implement",
+    judge: judge(150),
+    test: tests(50),
+  });
+  assert.equal(q, 100 + 50); // A clamped to 100
+});
+
+test("loadCellScores: returns empty map when scoresDir doesn't exist", async () => {
+  const out = await loadCellScores(path.join(os.tmpdir(), "definitely-not-a-real-dir-" + Date.now()));
+  assert.equal(out.size, 0);
+});
+
+test("loadCellScores: pairs <cellKey>-tests.json + <cellKey>-judge.json into one entry", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cell-scores-test-"));
+  try {
+    await fs.writeFile(
+      path.join(dir, "agent-x-100-tests.json"),
+      JSON.stringify(tests(80)),
+    );
+    await fs.writeFile(
+      path.join(dir, "agent-x-100-judge.json"),
+      JSON.stringify(judge(75)),
+    );
+    await fs.writeFile(
+      path.join(dir, "unrelated.txt"),
+      "irrelevant",
+    );
+    const out = await loadCellScores(dir);
+    assert.equal(out.size, 1);
+    const e = out.get("agent-x-100");
+    assert.ok(e);
+    assert.equal(e!.test?.passed, 80);
+    assert.equal(e!.judge?.median, 75);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadCellScores: malformed JSON leaves the entry's slot undefined", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cell-scores-test-"));
+  try {
+    await fs.writeFile(path.join(dir, "agent-y-200-tests.json"), "not json");
+    await fs.writeFile(
+      path.join(dir, "agent-y-200-judge.json"),
+      JSON.stringify(judge(60)),
+    );
+    const out = await loadCellScores(dir);
+    const e = out.get("agent-y-200");
+    assert.ok(e);
+    assert.equal(e!.test, undefined);
+    assert.equal(e!.judge?.median, 60);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("samplesFromCellScores: per-agent mean + factor anchored at qmax=1.0", () => {
+  const cells: Cell[] = [
+    cell("agent-small", 6000, 100, "implement"),
+    cell("agent-small", 6000, 200, "implement"),
+    cell("agent-large", 50000, 100, "implement"),
+    cell("agent-large", 50000, 200, "implement"),
+  ];
+  const scores = new Map([
+    ["agent-small-100", { cellKey: "agent-small-100", judge: judge(80), test: tests(80) }],
+    ["agent-small-200", { cellKey: "agent-small-200", judge: judge(80), test: tests(80) }],
+    ["agent-large-100", { cellKey: "agent-large-100", judge: judge(50), test: tests(50) }],
+    ["agent-large-200", { cellKey: "agent-large-200", judge: judge(50), test: tests(50) }],
+  ]);
+  const samples = samplesFromCellScores(cells, scores);
+  assert.equal(samples.length, 2);
+  assert.deepEqual(
+    samples.map((s) => s.xBytes),
+    [6000, 50000],
+  );
+  // small agent: mean quality 160 (qmax)
+  assert.equal(samples[0].factor, 1);
+  // large agent: mean quality 100 → factor = 160/100 = 1.6
+  assert.ok(Math.abs(samples[1].factor - 1.6) < 1e-9, `expected ~1.6, got ${samples[1].factor}`);
+});
+
+test("samplesFromCellScores: cells with no matching score entry contribute 0 quality", () => {
+  const cells: Cell[] = [
+    cell("agent-x", 6000, 100, "implement"),
+    cell("agent-x", 6000, 200, "implement"), // no score entry
+    cell("agent-y", 50000, 100, "implement"),
+  ];
+  const scores = new Map([
+    ["agent-x-100", { cellKey: "agent-x-100", judge: judge(100), test: tests(100) }],
+    ["agent-y-100", { cellKey: "agent-y-100", judge: judge(80), test: tests(80) }],
+  ]);
+  const samples = samplesFromCellScores(cells, scores);
+  // agent-x mean = (200 + 0) / 2 = 100; agent-y mean = 160; qmax = 160
+  // agent-x factor = 160/100 = 1.6; agent-y factor = 1.0
+  assert.equal(samples.length, 2);
+  assert.equal(samples[1].factor, 1); // agent-y is qmax
+  assert.ok(Math.abs(samples[0].factor - 1.6) < 1e-9);
+});
+
+test("samplesFromCellScores: pushback cells use 2A scoring", () => {
+  const cells: Cell[] = [
+    cell("agent-p", 6000, 100, "pushback"),
+    cell("agent-p", 6000, 200, "pushback"),
+  ];
+  const scores = new Map([
+    ["agent-p-100", { cellKey: "agent-p-100", judge: judge(80) }],
+    ["agent-p-200", { cellKey: "agent-p-200", judge: judge(60) }],
+  ]);
+  const samples = samplesFromCellScores(cells, scores);
+  assert.equal(samples.length, 1);
+  // mean = (160 + 120) / 2 = 140; only agent so factor=1
+  assert.equal(samples[0].factor, 1);
+});
+
+test("samplesFromCellScores: all-zero quality returns factor=1 for every agent (degenerate but fittable)", () => {
+  const cells: Cell[] = [
+    cell("agent-a", 6000, 100, "error"),
+    cell("agent-b", 50000, 100, "error"),
+  ];
+  const samples = samplesFromCellScores(cells, new Map());
+  assert.equal(samples.length, 2);
+  assert.deepEqual(samples.map((s) => s.factor), [1, 1]);
+});
+
+test("samplesFromCellScores: empty input returns empty array", () => {
+  const samples = samplesFromCellScores([], new Map());
+  assert.equal(samples.length, 0);
+});
+
+test("samplesFromCellScores: agents are sorted by sizeBytes ascending", () => {
+  const cells: Cell[] = [
+    cell("agent-c", 35000, 100, "implement"),
+    cell("agent-a", 6000, 100, "implement"),
+    cell("agent-b", 14000, 100, "implement"),
+  ];
+  const scores = new Map([
+    ["agent-c-100", { cellKey: "agent-c-100", judge: judge(80), test: tests(80) }],
+    ["agent-a-100", { cellKey: "agent-a-100", judge: judge(50), test: tests(50) }],
+    ["agent-b-100", { cellKey: "agent-b-100", judge: judge(60), test: tests(60) }],
+  ]);
+  const samples = samplesFromCellScores(cells, scores);
+  assert.deepEqual(samples.map((s) => s.xBytes), [6000, 14000, 35000]);
+});

--- a/src/research/curveStudy/cellScores.ts
+++ b/src/research/curveStudy/cellScores.ts
@@ -1,0 +1,217 @@
+// Curve-redo Phase 1d: per-cell A/B score aggregation.
+//
+// Phase 1c writes two JSON files per cell — one from `vp-dev research
+// run-tests` (B = hidden-test pass count, applyCleanly, errorReason) and
+// one from `vp-dev research grade-reasoning` (A = blinded judge median,
+// scores, variance). Phase 1d's job:
+//
+//   1. Load both files for each cell.
+//   2. Compute the per-cell quality (0..200 scale):
+//        quality = A + B            if decision == "implement" AND test apply succeeded
+//                = 2 × A             if decision == "pushback"
+//                = 0                 if decision == "error" / test apply failed / parse failure
+//   3. Aggregate per-agent (mean across cells of that agent).
+//   4. Project per-agent quality into a CurveSample (factor = qmax / quality)
+//      that fit.ts's existing regression machinery can consume.
+//
+// This module is read-only: it consumes Phase 1c's JSON output. The shape is
+// duplicated here intentionally — Phase 1d should land independently of
+// Phase 1c, so we don't import from testRunner.ts / reasoningJudge.ts. Once
+// both PRs merge, a follow-up cleanup can centralize the schema.
+//
+// Decision is inherited from each cell's envelope (already in Cell.decision
+// from aggregate.ts).
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { Cell, CurveSample, Decision } from "./types.js";
+
+/**
+ * Per-cell test-pass score, persisted by `vp-dev research run-tests`.
+ * Schema mirrors `RunHiddenTestsResult` in testRunner.ts (Phase 1c).
+ */
+export interface CellTestScore {
+  passed: number;
+  failed: number;
+  errored: number;
+  total: number;
+  applyCleanly: boolean;
+  applyError?: string;
+  runtimeMs: number;
+  errorReason?: string;
+}
+
+/**
+ * Per-cell judge score, persisted by `vp-dev research grade-reasoning`.
+ * Schema mirrors `GradeReasoningResult` in reasoningJudge.ts (Phase 1c).
+ */
+export interface CellJudgeScore {
+  median: number;
+  scores: number[];
+  variance: number;
+  rationales?: string[];
+  partialFailure?: boolean;
+  isError: boolean;
+  errorReason?: string;
+}
+
+export interface CellScores {
+  cellKey: string;
+  test?: CellTestScore;
+  judge?: CellJudgeScore;
+}
+
+const TEST_SUFFIX = "-tests.json";
+const JUDGE_SUFFIX = "-judge.json";
+
+/**
+ * Cell key encoding: `<agentId>-<issueId>`. Phase 1c CLI writes per-cell
+ * JSON files at `<scoresDir>/<cellKey>{-tests,-judge}.json`. Replicates
+ * (when K>1) are encoded by the operator workflow as `<agentId>-<issueId>-r<N>`.
+ */
+export function cellKeyFor(agentId: string, issueId: number, replicate?: number): string {
+  if (replicate != null) return `${agentId}-${issueId}-r${replicate}`;
+  return `${agentId}-${issueId}`;
+}
+
+/**
+ * Load all per-cell score JSONs from `scoresDir`. Files are matched by
+ * suffix (`-tests.json`, `-judge.json`). Cells with only one of the two
+ * appear with the other side undefined; downstream `qualityFromAB`
+ * scores them as 0 (incomplete data).
+ */
+export async function loadCellScores(scoresDir: string): Promise<Map<string, CellScores>> {
+  const out = new Map<string, CellScores>();
+  let files: string[];
+  try {
+    files = await fs.readdir(scoresDir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return out;
+    throw err;
+  }
+  for (const f of files) {
+    let cellKey: string;
+    let kind: "test" | "judge";
+    if (f.endsWith(TEST_SUFFIX)) {
+      cellKey = f.slice(0, -TEST_SUFFIX.length);
+      kind = "test";
+    } else if (f.endsWith(JUDGE_SUFFIX)) {
+      cellKey = f.slice(0, -JUDGE_SUFFIX.length);
+      kind = "judge";
+    } else {
+      continue;
+    }
+    let bucket = out.get(cellKey);
+    if (!bucket) {
+      bucket = { cellKey };
+      out.set(cellKey, bucket);
+    }
+    try {
+      const raw = await fs.readFile(path.join(scoresDir, f), "utf-8");
+      const parsed = JSON.parse(raw);
+      if (kind === "test") bucket.test = parsed as CellTestScore;
+      else bucket.judge = parsed as CellJudgeScore;
+    } catch {
+      // Malformed JSON — leave the bucket's slot undefined. Downstream
+      // qualityFromAB will score this cell as 0.
+    }
+  }
+  return out;
+}
+
+/**
+ * The 0..200 quality formula:
+ *   - implement: A + B (full range when test+judge both succeeded)
+ *   - pushback:  2 × A (no diff to test; double the judge score so the
+ *     range is comparable to implement)
+ *   - error / missing data / dirty test apply: 0
+ *
+ * Inputs:
+ *   decision    — from Cell.decision (envelope-reported)
+ *   judge       — from CellScores.judge (Phase 1c reasoningJudge output)
+ *   test        — from CellScores.test (Phase 1c testRunner output)
+ *
+ * `applyCleanly: false` zeroes the cell even when the judge ran cleanly,
+ * because the test signal is structurally untrustworthy.
+ */
+export function qualityFromAB(args: {
+  decision: Decision | null;
+  judge?: CellJudgeScore;
+  test?: CellTestScore;
+}): number {
+  if (args.decision === "error" || args.decision === "error_max_turns" || args.decision == null) {
+    return 0;
+  }
+  const A = args.judge && !args.judge.isError ? clamp(args.judge.median, 0, 100) : null;
+  if (args.decision === "pushback") {
+    if (A == null) return 0;
+    return 2 * A;
+  }
+  // implement
+  if (A == null) return 0;
+  if (!args.test || !args.test.applyCleanly || args.test.errorReason) return 0;
+  if (args.test.total <= 0) return 0;
+  // B is reported as a count out of `total`; normalize to 0..100 even if
+  // total != 100 (the operator might have used a different cap during
+  // smoke runs).
+  const B = clamp((args.test.passed / args.test.total) * 100, 0, 100);
+  return A + B;
+}
+
+function clamp(x: number, lo: number, hi: number): number {
+  if (!Number.isFinite(x)) return 0;
+  return Math.max(lo, Math.min(hi, x));
+}
+
+/**
+ * Project per-cell quality into per-agent CurveSamples. For each agent,
+ * average the cell qualities; convert to a degradation factor anchored
+ * at 1.0 against the agent with the highest mean quality.
+ *
+ * Cells without a matching CellScores entry contribute 0 (incomplete
+ * data) — the same treatment as a structurally-failed cell. Caller can
+ * filter `cells` upstream if a different policy is needed.
+ *
+ * Empty input → empty output. Single-agent input → single sample with
+ * factor=1.
+ */
+export function samplesFromCellScores(
+  cells: ReadonlyArray<Cell>,
+  cellScores: Map<string, CellScores>,
+): CurveSample[] {
+  if (cells.length === 0) return [];
+  // Group quality_per_cell by agent.
+  const perAgent = new Map<string, { sizeBytes: number; qualities: number[] }>();
+  for (const c of cells) {
+    const key = cellKeyFor(c.agentId, c.issueId);
+    const scores = cellScores.get(key);
+    const q = qualityFromAB({
+      decision: c.decision,
+      judge: scores?.judge,
+      test: scores?.test,
+    });
+    let bucket = perAgent.get(c.agentId);
+    if (!bucket) {
+      bucket = { sizeBytes: c.agentSizeBytes, qualities: [] };
+      perAgent.set(c.agentId, bucket);
+    }
+    bucket.qualities.push(q);
+  }
+  const meanByAgent = [...perAgent.entries()]
+    .map(([agentId, b]) => ({
+      agentId,
+      sizeBytes: b.sizeBytes,
+      meanQuality: b.qualities.reduce((s, x) => s + x, 0) / b.qualities.length,
+    }))
+    .sort((a, b) => a.sizeBytes - b.sizeBytes);
+  const qmax = Math.max(...meanByAgent.map((a) => a.meanQuality));
+  if (!(qmax > 0)) {
+    // Every cell scored 0 — degenerate. Return all-1 factors so the
+    // caller's regression sees something fittable rather than NaN.
+    return meanByAgent.map((a) => ({ xBytes: a.sizeBytes, factor: 1 }));
+  }
+  return meanByAgent.map((a) => ({
+    xBytes: a.sizeBytes,
+    factor: a.meanQuality > 0 ? Math.max(1, qmax / a.meanQuality) : Number.POSITIVE_INFINITY,
+  }));
+}

--- a/src/research/curveStudy/study.ts
+++ b/src/research/curveStudy/study.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { dispatchCells, type CellSpec } from "./dispatch.js";
 import { aggregateLogsDir } from "./aggregate.js";
 import { scoreAllAgents } from "./score.js";
+import { loadCellScores, samplesFromCellScores } from "./cellScores.js";
 import { mergeSamples, samplesFromCost, samplesFromScores } from "./fit.js";
 import {
   fitPolynomialRegression,
@@ -57,6 +58,16 @@ export interface StudyInput {
   /** Existing token-cost samples (mode="update" reads from contextCostCurve.ts). */
   existingTokenCostSamples?: ReadonlyArray<CurveSample>;
   collisionPolicy?: CollisionPolicy;
+  /**
+   * Curve-redo Phase 1d: when set, the accuracy curve is computed from
+   * per-cell A (reasoning judge) + B (hidden-test pass rate) JSONs in this
+   * directory instead of the envelope-label-derived QualityScore. Each cell
+   * must have `<cellKey>-tests.json` and `<cellKey>-judge.json` files
+   * (cellKey = `<agentId>-<issueId>`); cells missing one or both score 0.
+   * The token-cost curve is unchanged. When undefined, behavior is the
+   * pre-curve-redo path (samplesFromScores via the weighted composite).
+   */
+  cellScoresDir?: string;
 }
 
 export interface FittedCurve {
@@ -124,8 +135,13 @@ export async function runCurveStudy(input: StudyInput): Promise<StudyOutput> {
   const scores = scoreAllAgents(allCells, input.rubrics);
   const totalCostUsd = allCells.reduce((s, c) => s + c.costUsd, 0);
 
-  // Accuracy curve: from per-agent quality scores
-  const freshAccuracy = samplesFromScores(scores);
+  // Accuracy curve: Phase 1d adds an alternate path when --cell-scores-dir
+  // is supplied — A (reasoning judge) + B (hidden-test pass rate) per cell
+  // → mean per agent → factor anchored at qmax. The pre-curve-redo path
+  // (samplesFromScores via weighted composite) stays the default.
+  const freshAccuracy = input.cellScoresDir
+    ? samplesFromCellScores(allCells, await loadCellScores(input.cellScoresDir))
+    : samplesFromScores(scores);
   const finalAccuracy =
     mode === "update"
       ? mergeSamples(input.existingAccuracySamples ?? [], freshAccuracy, input.collisionPolicy)


### PR DESCRIPTION
## Summary

Phase 1d of the curve-redo experiment. Wires Phase 1c's per-cell test-pass and reasoning-judge JSONs into the curve-study regression.

When `--cell-scores-dir <path>` is supplied to `vp-dev research curve-study`, the accuracy curve uses the 0–200 quality formula:

```
quality_per_cell =
   A + B    if decision == "implement" AND test apply succeeded
   2 × A    if decision == "pushback"
   0        if decision == "error" / test apply failed / data missing
```

- `A` — judge median (0–100), from `vp-dev research grade-reasoning` (Phase 1c)
- `B` — `passed / total × 100`, from `vp-dev research run-tests` (Phase 1c)

Per-agent quality is the mean across cells; the regression sample is `factor = qmax / quality` (anchored at 1.0 for the highest-quality agent), feeding the existing polynomial regression machinery untouched. When `--cell-scores-dir` is omitted, behavior is the pre-curve-redo path. Token-cost curve is unchanged either way.

## Why

Closes the loop. Phase 1a captures the diff; Phase 1b generates hidden tests; Phase 1c scores diffs (judge) and runs tests (B). This PR consumes those JSONs, applies the 0–200 formula, and feeds it into the regression that produces samples for `src/util/contextCostCurve.ts`. Phase 3 will run the actual experiment + re-fit.

## Files

- `src/research/curveStudy/cellScores.ts` (new, 200 lines) — `CellTestScore` + `CellJudgeScore` types (mirroring Phase 1c output schema, deliberately duplicated for independence), `loadCellScores`, `qualityFromAB`, `samplesFromCellScores`
- `src/research/curveStudy/cellScores.test.ts` (new, 290 lines) — 26 tests covering the formula (all decision branches, missing-data zeroing, total≠100 normalization, judge-median clamping), the loader (missing dir, pairing tests+judge JSONs, malformed JSON handling), and the per-agent projection (mean + qmax-anchored factor, missing-cell zeroing, pushback path, all-zero degenerate, sort by sizeBytes)
- `src/research/curveStudy/study.ts` — adds optional `cellScoresDir`; routes to `samplesFromCellScores` when set
- `src/cli.ts` — `--cell-scores-dir` flag on `vp-dev research curve-study`

## Independence

Schema is duplicated from Phase 1c's two modules intentionally — Phase 1d doesn't import from `testRunner.ts` / `reasoningJudge.ts`, so the four phase-1 PRs ([#207](https://github.com/szhygulin/vaultpilot-development-agents/pull/207), [#212](https://github.com/szhygulin/vaultpilot-development-agents/pull/212), [#213](https://github.com/szhygulin/vaultpilot-development-agents/pull/213), this one) land in any order. Once all four are on main, Phase 2 (corpus) and Phase 3 (dispatch + re-fit) can proceed.

After all four phase-1 PRs land, a follow-up cleanup can centralize the duplicated types into a shared module.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 684 / 684 pass (26 new cellScores tests; was 658 on main)
- [x] `vp-dev research curve-study --help` shows `--cell-scores-dir`
- [ ] Smoke pre-Phase-3: dispatch a 2-cell run with replay-mode + capture-diff, run testRunner + reasoningJudge per cell, then `curve-study --cell-scores-dir <path>` and confirm the accuracy curve uses A+B (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)