### PR TITLE
feat(lessons): soft byte-budget warning at empirical p95 (#200)

### DIFF
--- a/src/agent/runIssueCore.ts
+++ b/src/agent/runIssueCore.ts
@@ -11,7 +11,10 @@ import {
 } from "./specialization.js";
 import { isInfraFlake, summarizeFailureRun, summarizeRun, type SummarizerOutput } from "./summarizer.js";
 import { resolveExpiryPolicies } from "../util/sentinels.js";
-import { normalizedAccuracyFactor } from "../util/contextCostCurve.js";
+import {
+  BYTE_BUDGET_WARNING_THRESHOLD,
+  normalizedAccuracyFactor,
+} from "../util/contextCostCurve.js";
 import {
   checkLessonNovelty,
   deriveStableSectionId,
@@ -667,6 +670,24 @@ async function maybeAppendSummary(args: AppendArgs): Promise<{
       bytesAppended: appendOutcome.bytesAppended,
       totalBytes: appendOutcome.totalBytes,
     });
+    // Soft byte-budget warning (#200, option 1 scope). Fires when the
+    // post-append size meets/exceeds the empirical p95 of the calibration
+    // sample bytes. Observability only — no enforcement, no eviction. The
+    // model-free p95 statistic was chosen over the issue's original
+    // "elbow" framing because the validated K=13 fit (#179 / #203) is
+    // linear-log and monotone (no inflection). Forced eviction is
+    // deferred until a utility-signal correlation study lands per #200's
+    // bake-window note.
+    if (appendOutcome.totalBytes >= BYTE_BUDGET_WARNING_THRESHOLD) {
+      args.logger.warn("specialization.budget_warning", {
+        agentId: args.agent.agentId,
+        issueId: args.issue.id,
+        totalBytes: appendOutcome.totalBytes,
+        threshold: BYTE_BUDGET_WARNING_THRESHOLD,
+        overBy: appendOutcome.totalBytes - BYTE_BUDGET_WARNING_THRESHOLD,
+        reason: "claude-md size at/above empirical p95 of calibration samples",
+      });
+    }
   } else {
     args.logger.warn("specialization.cap", {
       agentId: args.agent.agentId,

--- a/src/util/contextCostCurve.test.ts
+++ b/src/util/contextCostCurve.test.ts
@@ -2,9 +2,11 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   ACCURACY_DEGRADATION_SAMPLES,
+  BYTE_BUDGET_WARNING_THRESHOLD,
   DEFAULT_COST_WEIGHTS,
   TOKEN_COST_SAMPLES,
   accuracyDegradationFactor,
+  byteBudgetWarningThreshold,
   contextCostFactor,
   getAccuracyDegradationRegression,
   getTokenCostRegression,
@@ -13,6 +15,7 @@ import {
   resetContextCostCurveCache,
   tokenCostFactor,
 } from "./contextCostCurve.js";
+import { SOFT_CAP_BYTES } from "../agent/specialization.js";
 
 test("samples: both curves have factor >= 1 at every sample (normalized to cheapest=1.0)", () => {
   for (const arr of [ACCURACY_DEGRADATION_SAMPLES, TOKEN_COST_SAMPLES]) {
@@ -136,6 +139,56 @@ test("contextCostFactor: rejects negative weights", () => {
   assert.throws(() =>
     contextCostFactor(24000, { weights: { accuracy: 1.5, cost: -0.5 } }),
   );
+});
+
+// ---------------------------------------------------------------------------
+// Soft byte-budget warning threshold (#200, option 1 scope).
+// ---------------------------------------------------------------------------
+
+test("byteBudgetWarningThreshold: equals R-7 p95 of ACCURACY_DEGRADATION_SAMPLES.xBytes", () => {
+  // Independent recomputation: sort the bytes asc, linearly interpolate at
+  // rank = 0.95 * (n-1). For n=18 the rank is 16.15, between order-stats
+  // 16 and 17. Round to integer to match the threshold's representation.
+  const xs = ACCURACY_DEGRADATION_SAMPLES.map((s) => s.xBytes).sort(
+    (a, b) => a - b,
+  );
+  const rank = 0.95 * (xs.length - 1);
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  const frac = rank - lo;
+  const expected = Math.round(
+    lo === hi ? xs[lo] : xs[lo] + frac * (xs[hi] - xs[lo]),
+  );
+  assert.equal(byteBudgetWarningThreshold(), expected);
+  assert.equal(BYTE_BUDGET_WARNING_THRESHOLD, expected);
+});
+
+test("BYTE_BUDGET_WARNING_THRESHOLD: sits below the hard SOFT_CAP_BYTES so warnings precede the cap", () => {
+  // The whole point of a soft warning is that it fires BEFORE the existing
+  // hard cap blocks the append; otherwise operators only see the cap event
+  // and never get an early heads-up.
+  assert.ok(
+    BYTE_BUDGET_WARNING_THRESHOLD < SOFT_CAP_BYTES,
+    `threshold ${BYTE_BUDGET_WARNING_THRESHOLD} must be < SOFT_CAP_BYTES ${SOFT_CAP_BYTES}`,
+  );
+});
+
+test("BYTE_BUDGET_WARNING_THRESHOLD: sits within the calibration sample range (not extrapolation)", () => {
+  // The threshold is a percentile of measured sample bytes — by
+  // construction it lies between min and max of the samples. Guarding
+  // against an off-by-one in the percentile helper that would push the
+  // value outside the sample range.
+  const xs = ACCURACY_DEGRADATION_SAMPLES.map((s) => s.xBytes);
+  const lo = Math.min(...xs);
+  const hi = Math.max(...xs);
+  assert.ok(BYTE_BUDGET_WARNING_THRESHOLD >= lo);
+  assert.ok(BYTE_BUDGET_WARNING_THRESHOLD <= hi);
+});
+
+test("byteBudgetWarningThreshold: idempotent across calls (stateless on the immutable sample array)", () => {
+  const a = byteBudgetWarningThreshold();
+  const b = byteBudgetWarningThreshold();
+  assert.equal(a, b);
 });
 
 test("contextCostFactor: clampHigh propagates to both component curves", () => {

--- a/src/util/contextCostCurve.ts
+++ b/src/util/contextCostCurve.ts
@@ -255,3 +255,59 @@ export function getAccuracyDegradationRegression(): PolynomialRegression {
 export function getTokenCostRegression(): PolynomialRegression {
   return getTokenCost();
 }
+
+/**
+ * Soft-warning byte threshold for per-agent CLAUDE.md size (#200, option 1
+ * scope after Markov's pushback). Returns the 95th-percentile of the
+ * calibration sample's xBytes — a deliberately model-free statistic, not
+ * an "elbow." The validated K=13 fit is linear-log (degree 1, x→log(x)),
+ * which is monotone and carries no inflection point; picking any single
+ * x-value off it as a knot would be arbitrary.
+ *
+ * Properties:
+ *   - Model-free: drawn from the ordered sample bytes via R-7 linear
+ *     interpolation (matches Excel/numpy default), so the threshold moves
+ *     with the calibration data without depending on the regression form.
+ *   - Above the typical sample density: by construction p95 sits in the
+ *     upper tail of the existing measurements, so warnings fire only at
+ *     empirically-attested-as-large sizes.
+ *   - Below {@link SOFT_CAP_BYTES} (64 KiB): the existing hard cap still
+ *     blocks the append; this warning surfaces approach-to-cap.
+ *
+ * Used by `runIssueCore.maybeAppendSummary` to emit a
+ * `specialization.budget_warning` log event after a successful append when
+ * the post-append byte count meets/exceeds the threshold. No enforcement
+ * and no victim-eviction here — both deferred per #200's bake-window note
+ * (needs a validated utility-signal study to drive forced eviction).
+ */
+export function byteBudgetWarningThreshold(): number {
+  const xs = ACCURACY_DEGRADATION_SAMPLES.map((s) => s.xBytes).sort(
+    (a, b) => a - b,
+  );
+  return Math.round(percentile(xs, 0.95));
+}
+
+/**
+ * Memoized value of {@link byteBudgetWarningThreshold} for hot-path callers.
+ * The samples are immutable at module load, so a single computation suffices.
+ * Exported separately from the function so diagnostics tooling can inline
+ * the constant while tests retain a recomputation seam.
+ */
+export const BYTE_BUDGET_WARNING_THRESHOLD: number = byteBudgetWarningThreshold();
+
+/**
+ * R-7 percentile (numpy / Excel default): linear interpolation between
+ * adjacent order statistics. `sorted` MUST already be ascending. `p` in [0, 1].
+ * Returns 0 on empty input (caller-facing helpers don't pass empty arrays;
+ * the guard is defensive).
+ */
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  if (sorted.length === 1) return sorted[0];
+  const rank = p * (sorted.length - 1);
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  if (lo === hi) return sorted[lo];
+  const frac = rank - lo;
+  return sorted[lo] + frac * (sorted[hi] - sorted[lo]);
+}


### PR DESCRIPTION
Closes #200

Re-scopes #200 from "fixed byte budget at curve elbow + forced swap" to "soft warning at empirical p95" per Markov's pushback (option 1, owner-acked with "Do 1"). The validated K=13 fit (#179 / #203) is linear-log and monotone — no defensible elbow — and forced eviction needs a utility-signal correlation study that hasn't landed yet.

## Summary
- New `byteBudgetWarningThreshold()` in `contextCostCurve.ts` returns the R-7 p95 of `ACCURACY_DEGRADATION_SAMPLES.xBytes` (56521 bytes on the current K=13 data). Model-free; no claim of statistical structure beyond the calibration sample's empirical tail. Memoized as `BYTE_BUDGET_WARNING_THRESHOLD` for hot-path callers.
- `runIssueCore.maybeAppendSummary` emits a `logger.warn("specialization.budget_warning", …)` event after a successful append when post-append bytes meet/exceed the threshold. Observability only — no enforcement, no eviction, no `pickEvictionVictim` helper.
- Threshold sits below `SOFT_CAP_BYTES` (65536) so the warning fires before the existing hard cap blocks the append, giving operators an early heads-up.

## Out of scope (deferred per #200's bake-window note)
- Forced eviction with `pickEvictionVictim`. Needs a study cross-correlating `predictedUtility` (PR #193) × `reinforcementRuns.length` (PR #178/#190) × `intrinsicUtility` (PR #198) so one signal is shown reliable enough to drive eviction. File a follow-up issue once the trio collect enough data.
- Hard byte ceiling. The linear-log curve is monotone; picking any single x-value as a "ceiling" is arbitrary until either a piecewise re-fit shows a significant breakpoint (option 3 in Markov's pushback) or operator-defensible policy reasons land.

## Test plan
- [x] `npm run build` — passes (tsc clean)
- [x] `npm test` — 742 tests pass, includes 4 new tests:
  - `byteBudgetWarningThreshold: equals R-7 p95 of ACCURACY_DEGRADATION_SAMPLES.xBytes`
  - `BYTE_BUDGET_WARNING_THRESHOLD: sits below the hard SOFT_CAP_BYTES so warnings precede the cap`
  - `BYTE_BUDGET_WARNING_THRESHOLD: sits within the calibration sample range (not extrapolation)`
  - `byteBudgetWarningThreshold: idempotent across calls (stateless on the immutable sample array)`
- [ ] Operator: post-merge, watch JSONL logs for `specialization.budget_warning` events. Distribution of `overBy` values informs whether/when to revisit the deferred eviction question.

— Sofia (agent-2a3d)
