### PR TITLE
fix(curve-study): hardcode CLAUDE.md isolation for measurement validity

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -634,7 +634,7 @@ export function buildCli(): Command {
     .addCommand(
       new Command("curve-study")
         .description(
-          "Refit src/util/contextCostCurve.ts (CLAUDE.md size → accuracyDegradationFactor). Operator pre-trims the parent dev-agent into N forks at chosen byte budgets and registers them; this command dispatches all (devAgent × issue) cells with 4-way parallelism + per-dev-agent serialization, aggregates outcomes, scores quality per #179, fits an OLS polynomial regression, and writes a JSON proposal the operator hand-merges into CONTEXT_COST_SAMPLES.",
+          "Refit src/util/contextCostCurve.ts (CLAUDE.md size → accuracyDegradationFactor). Operator pre-trims the parent dev-agent into N forks at chosen byte budgets and registers them; this command dispatches all (devAgent × issue) cells with 4-way parallelism + per-dev-agent serialization, aggregates outcomes, scores quality per #179, fits an OLS polynomial regression, and writes a JSON proposal the operator hand-merges into CONTEXT_COST_SAMPLES. Each cell runs ISOLATED — neither the live target-repo CLAUDE.md nor the user-global ~/.claude/CLAUDE.md is loaded. Effective context per cell = per-agent CLAUDE.md only, matching the size axis we're varying. Isolation is hardcoded; running loaded would distort the curve by an operator-specific amount.",
         )
         .requiredOption("--agents-spec <path>", "JSON file: array of {devAgentId, sizeBytes, clonePath}")
         .requiredOption("--target-repo <owner/repo>", "GitHub target repo (e.g. szhygulin/vaultpilot-mcp-smoke-test)")
@@ -651,10 +651,6 @@ export function buildCli(): Command {
         .option(
           "--issue-body-only",
           "Forward --issue-body-only to each cell's spawn. Step 1 fetches body only — no comments. Required for closed-issue dispatches so the resolution-PR link doesn't contaminate the measurement.",
-        )
-        .option(
-          "--no-target-claude-md",
-          "Forward --no-target-claude-md to each cell's spawn. Suppress the live target-repo CLAUDE.md prepend so effective context size matches the per-agent CLAUDE.md size we're varying.",
         )
         .option(
           "--max-total-cost-usd <usd>",
@@ -4220,8 +4216,6 @@ interface ResearchCurveStudyOpts {
   dryRun: boolean;
   allowClosedIssue?: boolean;
   issueBodyOnly?: boolean;
-  /** commander's --no-target-claude-md sets `targetClaudeMd: false`. */
-  targetClaudeMd?: boolean;
   maxTotalCostUsd?: number;
   mode: string;
   collisionPolicy: string;
@@ -4286,7 +4280,14 @@ async function cmdResearchCurveStudy(opts: ResearchCurveStudyOpts): Promise<void
     dryRun: opts.dryRun,
     allowClosedIssue: !!opts.allowClosedIssue,
     issueBodyOnly: !!opts.issueBodyOnly,
-    suppressTargetClaudeMd: opts.targetClaudeMd === false,
+    // Hardcoded isolation: each cell runs without the live target-repo CLAUDE.md
+    // or the user-global ~/.claude/CLAUDE.md. Effective context = per-agent
+    // CLAUDE.md only, matching the size axis we're varying. Loaded mode is
+    // operator-specific (user-global content varies per individual) and would
+    // dilute the per-agent signal — the curve is consumed by the orchestrator's
+    // pickAgents at decision time, where target + global are constant across
+    // candidates and per-agent bytes are the only variable that differs.
+    suppressTargetClaudeMd: true,
     maxTotalCostUsd: opts.maxTotalCostUsd,
     logsDir: opts.logsDir,
     outputPath: opts.output,


### PR DESCRIPTION
## Summary

`vp-dev research curve-study` was misconfigured: `--no-target-claude-md` was an **optional** operator-facing flag. If the operator forgot to pass it, each cell loaded BOTH the live target-repo CLAUDE.md (~14 KB) AND the user-global \`~/.claude/CLAUDE.md\` (~30 KB, operator-specific) on top of the per-agent file we're varying. The shipped curve constants in \`src/util/contextCostCurve.ts\` would then reflect operator-specific upstream content rather than the per-agent context size we're measuring.

This PR removes the flag from \`curve-study\` and hardcodes \`suppressTargetClaudeMd: true\` in the handler. Effective context per cell = per-agent CLAUDE.md only, matching the orchestrator's \`pickAgents\` decision variable (per-agent bytes — target and global are constant across candidates within a run, so isolation is the right axis).

## Why now

Surfacing pre-Phase-3 dispatch of the curve-redo experiment. Per the rule we just shipped to global CLAUDE.md ("Name the Measure of Success Before the Mechanics"), this is exactly the measurement-validity footgun the rule warns about: a side variable (operator's user-global file) leaking into the controlled axis. Phase-2 of #179 used \`--no-target-claude-md\` correctly; the redo can't rely on the operator remembering.

## Scope

- Only \`vp-dev research curve-study\`. The lower-level \`vp-dev spawn --no-target-claude-md\` flag is unchanged — real spawn invocations still need to opt into isolation explicitly.
- \`vp-dev research bench-specialists\` is unaffected — it's meant to test specialists in their natural environment with full upstream context loaded.

## Files

- \`src/cli.ts\` — removes the optional flag from the curve-study definition; removes \`targetClaudeMd?\` from \`ResearchCurveStudyOpts\`; hardcodes \`suppressTargetClaudeMd: true\` at the call site with a comment explaining the rationale; updates the curve-study description to surface the isolation contract.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm test\` — 753 / 753 pass (no test changes; the existing isolation behavior in \`prompt.ts\` is already covered)
- [x] \`vp-dev research curve-study --help\` — \`--no-target-claude-md\` no longer listed; description names the isolation contract
- [ ] Pre-Phase-3 smoke: dispatch one cell, inspect the system prompt, confirm only the per-agent CLAUDE.md is rendered (no \`# User global CLAUDE.md\` or \`# Project rules (live target-repo CLAUDE.md)\` headers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)