### PR TITLE
fix(curve-redo): rescale judge to 0-50, total quality stays 0-100 (50+50)

### DIFF
--- a/src/research/curveStudy/cellScores.test.ts
+++ b/src/research/curveStudy/cellScores.test.ts
@@ -42,20 +42,21 @@ test("cellKeyFor: format with replicate", () => {
   assert.equal(cellKeyFor("agent-916a", 190, 2), "agent-916a-190-r2");
 });
 
-test("qualityFromAB: implement = A + B at the maximum", () => {
-  const q = qualityFromAB({ decision: "implement", judge: judge(85), test: tests(72) });
-  assert.equal(q, 85 + 72);
+test("qualityFromAB: implement = A + B (A ∈ 0..50, B = passed/total × 50)", () => {
+  // judge=42 → A=42; tests(72/100) → B=36. quality = 78.
+  const q = qualityFromAB({ decision: "implement", judge: judge(42), test: tests(72) });
+  assert.equal(q, 42 + 36);
 });
 
-test("qualityFromAB: implement caps at 200 with A=100, B=100", () => {
-  const q = qualityFromAB({ decision: "implement", judge: judge(100), test: tests(100) });
-  assert.equal(q, 200);
+test("qualityFromAB: implement caps at 100 with A=50, B=50", () => {
+  const q = qualityFromAB({ decision: "implement", judge: judge(50), test: tests(100) });
+  assert.equal(q, 100);
 });
 
 test("qualityFromAB: implement = 0 when test apply failed", () => {
   const q = qualityFromAB({
     decision: "implement",
-    judge: judge(85),
+    judge: judge(45),
     test: tests(50, 100, false),
   });
   assert.equal(q, 0);
@@ -71,7 +72,7 @@ test("qualityFromAB: implement = 0 when judge errored even if tests passed", () 
 });
 
 test("qualityFromAB: implement = 0 when test data is missing", () => {
-  const q = qualityFromAB({ decision: "implement", judge: judge(85) });
+  const q = qualityFromAB({ decision: "implement", judge: judge(45) });
   assert.equal(q, 0);
 });
 
@@ -83,19 +84,25 @@ test("qualityFromAB: implement = 0 when judge data is missing", () => {
 test("qualityFromAB: implement = 0 when test errorReason is set", () => {
   const q = qualityFromAB({
     decision: "implement",
-    judge: judge(85),
+    judge: judge(45),
     test: { ...tests(50), errorReason: "test-runner timed out" },
   });
   assert.equal(q, 0);
 });
 
 test("qualityFromAB: pushback = 2 × A regardless of test outcome", () => {
+  // judge=40 → A=40; pushback uses 2A = 80.
   const q = qualityFromAB({
     decision: "pushback",
-    judge: judge(75),
+    judge: judge(40),
     test: tests(0), // tests irrelevant for pushback
   });
-  assert.equal(q, 150);
+  assert.equal(q, 80);
+});
+
+test("qualityFromAB: pushback caps at 100 with A=50", () => {
+  const q = qualityFromAB({ decision: "pushback", judge: judge(50) });
+  assert.equal(q, 100);
 });
 
 test("qualityFromAB: pushback = 0 when judge errored", () => {
@@ -106,7 +113,7 @@ test("qualityFromAB: pushback = 0 when judge errored", () => {
 test("qualityFromAB: error decision = 0 even with judge + tests", () => {
   const q = qualityFromAB({
     decision: "error",
-    judge: judge(85),
+    judge: judge(45),
     test: tests(80),
   });
   assert.equal(q, 0);
@@ -115,7 +122,7 @@ test("qualityFromAB: error decision = 0 even with judge + tests", () => {
 test("qualityFromAB: error_max_turns decision = 0", () => {
   const q = qualityFromAB({
     decision: "error_max_turns",
-    judge: judge(85),
+    judge: judge(45),
     test: tests(80),
   });
   assert.equal(q, 0);
@@ -126,34 +133,34 @@ test("qualityFromAB: null decision = 0", () => {
   assert.equal(q, 0);
 });
 
-test("qualityFromAB: implement with non-100 total normalizes B to 0-100", () => {
-  // 12/40 passed → B should be 30, not 12
+test("qualityFromAB: implement with non-100 total normalizes B onto 0..50", () => {
+  // 12/40 passed → B = 12/40 × 50 = 15. judge=30 → A=30. quality = 45.
   const q = qualityFromAB({
     decision: "implement",
-    judge: judge(50),
+    judge: judge(30),
     test: tests(12, 40),
   });
-  assert.equal(q, 50 + 30);
+  assert.equal(q, 45);
 });
 
 test("qualityFromAB: implement with total=0 returns 0 (avoid div by zero)", () => {
   const q = qualityFromAB({
     decision: "implement",
-    judge: judge(50),
+    judge: judge(40),
     test: { passed: 0, failed: 0, errored: 0, total: 0, applyCleanly: true, runtimeMs: 0 },
   });
   assert.equal(q, 0);
 });
 
-test("qualityFromAB: out-of-range judge median is clamped", () => {
-  // Schema in reasoningJudge.ts already enforces 0-100, but the loader
-  // accepts arbitrary JSON; clamp defensively.
+test("qualityFromAB: out-of-range judge median is clamped to 50", () => {
+  // Schema in reasoningJudge.ts already enforces 0-50, but the loader
+  // accepts arbitrary JSON; clamp defensively. judge=85 → A=50; tests(50) → B=25.
   const q = qualityFromAB({
     decision: "implement",
-    judge: judge(150),
+    judge: judge(85),
     test: tests(50),
   });
-  assert.equal(q, 100 + 50); // A clamped to 100
+  assert.equal(q, 50 + 25);
 });
 
 test("loadCellScores: returns empty map when scoresDir doesn't exist", async () => {
@@ -170,7 +177,7 @@ test("loadCellScores: pairs <cellKey>-tests.json + <cellKey>-judge.json into one
     );
     await fs.writeFile(
       path.join(dir, "agent-x-100-judge.json"),
-      JSON.stringify(judge(75)),
+      JSON.stringify(judge(40)),
     );
     await fs.writeFile(
       path.join(dir, "unrelated.txt"),
@@ -181,7 +188,7 @@ test("loadCellScores: pairs <cellKey>-tests.json + <cellKey>-judge.json into one
     const e = out.get("agent-x-100");
     assert.ok(e);
     assert.equal(e!.test?.passed, 80);
-    assert.equal(e!.judge?.median, 75);
+    assert.equal(e!.judge?.median, 40);
   } finally {
     await fs.rm(dir, { recursive: true, force: true });
   }
@@ -193,13 +200,13 @@ test("loadCellScores: malformed JSON leaves the entry's slot undefined", async (
     await fs.writeFile(path.join(dir, "agent-y-200-tests.json"), "not json");
     await fs.writeFile(
       path.join(dir, "agent-y-200-judge.json"),
-      JSON.stringify(judge(60)),
+      JSON.stringify(judge(35)),
     );
     const out = await loadCellScores(dir);
     const e = out.get("agent-y-200");
     assert.ok(e);
     assert.equal(e!.test, undefined);
-    assert.equal(e!.judge?.median, 60);
+    assert.equal(e!.judge?.median, 35);
   } finally {
     await fs.rm(dir, { recursive: true, force: true });
   }
@@ -212,11 +219,14 @@ test("samplesFromCellScores: per-agent mean + factor anchored at qmax=1.0", () =
     cell("agent-large", 50000, 100, "implement"),
     cell("agent-large", 50000, 200, "implement"),
   ];
+  // small agent: judge=40, tests(80) → A+B = 40 + 40 = 80 per cell, mean = 80
+  // large agent: judge=25, tests(50) → A+B = 25 + 25 = 50 per cell, mean = 50
+  // qmax = 80; small factor = 1.0; large factor = 80/50 = 1.6
   const scores = new Map([
-    ["agent-small-100", { cellKey: "agent-small-100", judge: judge(80), test: tests(80) }],
-    ["agent-small-200", { cellKey: "agent-small-200", judge: judge(80), test: tests(80) }],
-    ["agent-large-100", { cellKey: "agent-large-100", judge: judge(50), test: tests(50) }],
-    ["agent-large-200", { cellKey: "agent-large-200", judge: judge(50), test: tests(50) }],
+    ["agent-small-100", { cellKey: "agent-small-100", judge: judge(40), test: tests(80) }],
+    ["agent-small-200", { cellKey: "agent-small-200", judge: judge(40), test: tests(80) }],
+    ["agent-large-100", { cellKey: "agent-large-100", judge: judge(25), test: tests(50) }],
+    ["agent-large-200", { cellKey: "agent-large-200", judge: judge(25), test: tests(50) }],
   ]);
   const samples = samplesFromCellScores(cells, scores);
   assert.equal(samples.length, 2);
@@ -224,9 +234,7 @@ test("samplesFromCellScores: per-agent mean + factor anchored at qmax=1.0", () =
     samples.map((s) => s.xBytes),
     [6000, 50000],
   );
-  // small agent: mean quality 160 (qmax)
   assert.equal(samples[0].factor, 1);
-  // large agent: mean quality 100 → factor = 160/100 = 1.6
   assert.ok(Math.abs(samples[1].factor - 1.6) < 1e-9, `expected ~1.6, got ${samples[1].factor}`);
 });
 
@@ -236,15 +244,16 @@ test("samplesFromCellScores: cells with no matching score entry contribute 0 qua
     cell("agent-x", 6000, 200, "implement"), // no score entry
     cell("agent-y", 50000, 100, "implement"),
   ];
+  // agent-x: judge=50,tests(100) → 100, plus 0 (missing) → mean = 50
+  // agent-y: judge=40,tests(80)  → 80, mean = 80
+  // qmax = 80; agent-x factor = 80/50 = 1.6; agent-y factor = 1.0
   const scores = new Map([
-    ["agent-x-100", { cellKey: "agent-x-100", judge: judge(100), test: tests(100) }],
-    ["agent-y-100", { cellKey: "agent-y-100", judge: judge(80), test: tests(80) }],
+    ["agent-x-100", { cellKey: "agent-x-100", judge: judge(50), test: tests(100) }],
+    ["agent-y-100", { cellKey: "agent-y-100", judge: judge(40), test: tests(80) }],
   ]);
   const samples = samplesFromCellScores(cells, scores);
-  // agent-x mean = (200 + 0) / 2 = 100; agent-y mean = 160; qmax = 160
-  // agent-x factor = 160/100 = 1.6; agent-y factor = 1.0
   assert.equal(samples.length, 2);
-  assert.equal(samples[1].factor, 1); // agent-y is qmax
+  assert.equal(samples[1].factor, 1);
   assert.ok(Math.abs(samples[0].factor - 1.6) < 1e-9);
 });
 
@@ -253,13 +262,13 @@ test("samplesFromCellScores: pushback cells use 2A scoring", () => {
     cell("agent-p", 6000, 100, "pushback"),
     cell("agent-p", 6000, 200, "pushback"),
   ];
+  // judge=40 → 2A=80; judge=30 → 2A=60. mean = 70. only agent → factor=1.
   const scores = new Map([
-    ["agent-p-100", { cellKey: "agent-p-100", judge: judge(80) }],
-    ["agent-p-200", { cellKey: "agent-p-200", judge: judge(60) }],
+    ["agent-p-100", { cellKey: "agent-p-100", judge: judge(40) }],
+    ["agent-p-200", { cellKey: "agent-p-200", judge: judge(30) }],
   ]);
   const samples = samplesFromCellScores(cells, scores);
   assert.equal(samples.length, 1);
-  // mean = (160 + 120) / 2 = 140; only agent so factor=1
   assert.equal(samples[0].factor, 1);
 });
 
@@ -285,9 +294,9 @@ test("samplesFromCellScores: agents are sorted by sizeBytes ascending", () => {
     cell("agent-b", 14000, 100, "implement"),
   ];
   const scores = new Map([
-    ["agent-c-100", { cellKey: "agent-c-100", judge: judge(80), test: tests(80) }],
-    ["agent-a-100", { cellKey: "agent-a-100", judge: judge(50), test: tests(50) }],
-    ["agent-b-100", { cellKey: "agent-b-100", judge: judge(60), test: tests(60) }],
+    ["agent-c-100", { cellKey: "agent-c-100", judge: judge(40), test: tests(80) }],
+    ["agent-a-100", { cellKey: "agent-a-100", judge: judge(25), test: tests(50) }],
+    ["agent-b-100", { cellKey: "agent-b-100", judge: judge(30), test: tests(60) }],
   ]);
   const samples = samplesFromCellScores(cells, scores);
   assert.deepEqual(samples.map((s) => s.xBytes), [6000, 14000, 35000]);

--- a/src/research/curveStudy/cellScores.ts
+++ b/src/research/curveStudy/cellScores.ts
@@ -6,7 +6,7 @@
 // scores, variance). Phase 1d's job:
 //
 //   1. Load both files for each cell.
-//   2. Compute the per-cell quality (0..200 scale):
+//   2. Compute the per-cell quality (0..100 scale; A and B each ∈ 0..50):
 //        quality = A + B            if decision == "implement" AND test apply succeeded
 //                = 2 × A             if decision == "pushback"
 //                = 0                 if decision == "error" / test apply failed / parse failure
@@ -120,19 +120,25 @@ export async function loadCellScores(scoresDir: string): Promise<Map<string, Cel
 }
 
 /**
- * The 0..200 quality formula:
- *   - implement: A + B (full range when test+judge both succeeded)
- *   - pushback:  2 × A (no diff to test; double the judge score so the
- *     range is comparable to implement)
+ * The 0..100 quality formula:
+ *   - implement: A + B (range 0..100, with A and B each ∈ 0..50)
+ *   - pushback:  2 × A (range 0..100; no diff to test, so double the judge
+ *     score to keep parity with implement's A + B max)
  *   - error / missing data / dirty test apply: 0
  *
  * Inputs:
  *   decision    — from Cell.decision (envelope-reported)
- *   judge       — from CellScores.judge (Phase 1c reasoningJudge output)
+ *   judge       — from CellScores.judge; median ∈ 0..50 (reasoningJudge prompt
+ *                 instructs Opus to use the 0-50 scale; schema rejects > 50)
  *   test        — from CellScores.test (Phase 1c testRunner output)
  *
  * `applyCleanly: false` zeroes the cell even when the judge ran cleanly,
  * because the test signal is structurally untrustworthy.
+ *
+ * Equal-weight rationale: A and B both contribute up to 50 each, so the
+ * judge's qualitative read carries the same maximum signal as the hidden
+ * test pass rate. A high-quality diff with all tests passing scores
+ * 50 + 50 = 100; a confidently-correct pushback scores 2 × 50 = 100.
  */
 export function qualityFromAB(args: {
   decision: Decision | null;
@@ -142,7 +148,7 @@ export function qualityFromAB(args: {
   if (args.decision === "error" || args.decision === "error_max_turns" || args.decision == null) {
     return 0;
   }
-  const A = args.judge && !args.judge.isError ? clamp(args.judge.median, 0, 100) : null;
+  const A = args.judge && !args.judge.isError ? clamp(args.judge.median, 0, 50) : null;
   if (args.decision === "pushback") {
     if (A == null) return 0;
     return 2 * A;
@@ -151,10 +157,10 @@ export function qualityFromAB(args: {
   if (A == null) return 0;
   if (!args.test || !args.test.applyCleanly || args.test.errorReason) return 0;
   if (args.test.total <= 0) return 0;
-  // B is reported as a count out of `total`; normalize to 0..100 even if
-  // total != 100 (the operator might have used a different cap during
-  // smoke runs).
-  const B = clamp((args.test.passed / args.test.total) * 100, 0, 100);
+  // B normalizes the pass count out of `total` onto the 0..50 scale so
+  // it's comparable to A. total != 100 is supported (operator might cap
+  // differently during smoke runs).
+  const B = clamp((args.test.passed / args.test.total) * 50, 0, 50);
   return A + B;
 }
 

--- a/src/research/curveStudy/reasoningJudge.test.ts
+++ b/src/research/curveStudy/reasoningJudge.test.ts
@@ -63,12 +63,12 @@ test("gradeReasoning: returns median + variance across K=3 samples", async () =>
     decision: "implement",
     diff: "diff --git a/foo.ts ...",
     k: 3,
-    llmCall: makeLlm([70, 80, 90]),
+    llmCall: makeLlm([35, 40, 45]),
   });
   assert.equal(r.isError, false);
-  assert.equal(r.median, 80);
-  assert.deepEqual(r.scores, [70, 80, 90]);
-  assert.equal(r.variance, 100); // sample variance of 70,80,90
+  assert.equal(r.median, 40);
+  assert.deepEqual(r.scores, [35, 40, 45]);
+  assert.equal(r.variance, 25); // sample variance of 35,40,45
   assert.equal(r.partialFailure, false);
   assert.equal(r.rationales.length, 3);
 });
@@ -81,12 +81,12 @@ test("gradeReasoning: K=3 with one failed sample reports partialFailure but stil
     decision: "implement",
     diff: "diff",
     k: 3,
-    llmCall: makeLlm([70, "error", 90]),
+    llmCall: makeLlm([35, "error", 45]),
   });
   assert.equal(r.isError, false);
   assert.equal(r.partialFailure, true);
-  assert.deepEqual(r.scores, [70, 90]);
-  assert.equal(r.median, 80);
+  assert.deepEqual(r.scores, [35, 45]);
+  assert.equal(r.median, 40);
 });
 
 test("gradeReasoning: returns isError=true when all samples fail", async () => {
@@ -125,7 +125,7 @@ test("gradeReasoning: refuses when decision='implement' without diff", async () 
     issueBody: "B",
     decision: "implement",
     k: 2,
-    llmCall: makeLlm([50, 50]),
+    llmCall: makeLlm([25, 25]),
   });
   assert.equal(r.isError, true);
   assert.match(r.errorReason ?? "", /no diff supplied/);
@@ -138,7 +138,7 @@ test("gradeReasoning: refuses when decision='pushback' without comment", async (
     issueBody: "B",
     decision: "pushback",
     k: 2,
-    llmCall: makeLlm([50, 50]),
+    llmCall: makeLlm([25, 25]),
   });
   assert.equal(r.isError, true);
   assert.match(r.errorReason ?? "", /no comment supplied/);
@@ -151,7 +151,7 @@ test("gradeReasoning: refuses when decision='error' (not gradable)", async () =>
     issueBody: "B",
     decision: "error",
     k: 2,
-    llmCall: makeLlm([50, 50]),
+    llmCall: makeLlm([25, 25]),
   });
   assert.equal(r.isError, true);
   assert.match(r.errorReason ?? "", /not gradable/);
@@ -165,17 +165,17 @@ test("gradeReasoning: median of even-sized survivors uses average of two middle 
     decision: "implement",
     diff: "d",
     k: 4,
-    llmCall: makeLlm([10, 20, 80, 90]),
+    llmCall: makeLlm([5, 10, 40, 45]),
   });
-  // Median of [10,20,80,90] = (20+80)/2 = 50
-  assert.equal(r.median, 50);
+  // Median of [5,10,40,45] = (10+40)/2 = 25
+  assert.equal(r.median, 25);
 });
 
 test("gradeReasoning: blinds the artifact before sending to the judge", async () => {
   let captured = "";
   const llm: LlmCall = async ({ userPrompt }) => {
     captured = userPrompt;
-    return { raw: JSON.stringify({ score: 50, rationale: "x" }), isError: false };
+    return { raw: JSON.stringify({ score: 25, rationale: "x" }), isError: false };
   };
   await gradeReasoning({
     issueId: 9,
@@ -190,9 +190,9 @@ test("gradeReasoning: blinds the artifact before sending to the judge", async ()
   assert.doesNotMatch(captured, /trim-50000/);
 });
 
-test("gradeReasoning: scores outside 0-100 are rejected by the schema", async () => {
+test("gradeReasoning: scores outside 0-50 are rejected by the schema", async () => {
   const llm: LlmCall = async () => ({
-    raw: JSON.stringify({ score: 150, rationale: "x" }),
+    raw: JSON.stringify({ score: 75, rationale: "x" }),
     isError: false,
   });
   const r = await gradeReasoning({

--- a/src/research/curveStudy/reasoningJudge.ts
+++ b/src/research/curveStudy/reasoningJudge.ts
@@ -1,7 +1,7 @@
 // Curve-redo Phase 1c: blinded reasoning judge.
 //
 // For each cell, Opus reads {issue body, agent's diff OR pushback comment}
-// and emits a 0-100 score on whether the artifact addresses the issue. K=3
+// and emits a 0-50 score on whether the artifact addresses the issue. K=3
 // independent samples per cell, median; variance reported so high-variance
 // cells can be flagged for operator review.
 //
@@ -11,8 +11,12 @@
 // knowing who wrote it.
 //
 // The output JSON is what Phase 1d's aggregator reads. Schema:
-//   {median: 0..100, scores: number[], variance, rationales: string[],
+//   {median: 0..50, scores: number[], variance, rationales: string[],
 //    costUsd, isError, errorReason}
+//
+// The 0-50 range pairs with B (hidden-test pass rate, also 0-50) for a
+// 0-100 total quality range. Pushback cells use 2A (also 0-100). The
+// rescale lets the test signal carry equal weight to the judge signal.
 //
 // LlmCall is injectable so unit tests can substitute a synthetic K-sample
 // generator without spinning up the real SDK.
@@ -25,7 +29,7 @@ import { ORCHESTRATOR_MODEL_REASONING_JUDGE } from "../../orchestrator/models.js
 import type { Logger } from "../../log/logger.js";
 
 const JUDGE_OUTPUT_SCHEMA = z.object({
-  score: z.number().min(0).max(100),
+  score: z.number().min(0).max(50),
   rationale: z.string().min(1),
 });
 
@@ -48,7 +52,7 @@ export interface GradeReasoningInput {
 }
 
 export interface GradeReasoningResult {
-  /** Median of the K judge samples. 0-100. */
+  /** Median of the K judge samples. 0-50. */
   median: number;
   /** All K samples (after blinding). */
   scores: number[];
@@ -82,26 +86,26 @@ const DEFAULT_K = 3;
 
 const JUDGE_SYSTEM_PROMPT = `You grade a coding agent's response to a GitHub issue. The agent either (a) implemented a fix and produced a unified diff, or (b) pushed back on the issue and produced a comment explaining why no implementation is appropriate.
 
-Score 0-100 on whether the artifact correctly addresses the issue. Use the full range:
+Score 0-50 on whether the artifact correctly addresses the issue. Use the full range:
 
-  0-25   — Misses the issue's intent, harmful, or unsupported by the code.
-  26-50  — Addresses the issue partially or has obvious bugs / wrong scope.
-  51-75  — Addresses the issue with reasonable scope; minor concerns; would
+  0-12   — Misses the issue's intent, harmful, or unsupported by the code.
+  13-25  — Addresses the issue partially or has obvious bugs / wrong scope.
+  26-37  — Addresses the issue with reasonable scope; minor concerns; would
            need small revisions to merge.
-  76-100 — Addresses the issue cleanly; right scope; sound approach.
+  38-50  — Addresses the issue cleanly; right scope; sound approach.
 
 Calibration anchors:
   - A diff that adds a guard rail the issue body explicitly requests, with
-    matching tests, scopes correctly: 80-90.
+    matching tests, scopes correctly: 40-45.
   - A pushback that names the issue's exact failure mode, cites a more
     appropriate venue (e.g. "this belongs upstream / in skill / advisory
-    not implementation"), and proposes 2-3 alternatives: 80-90.
+    not implementation"), and proposes 2-3 alternatives: 40-45.
   - A diff that does the wrong thing (fixes a different file, ignores the
-    body's constraint, breaks an obvious invariant): 10-20.
-  - A pushback that just refuses without engaging with the body: 10-20.
+    body's constraint, breaks an obvious invariant): 5-10.
+  - A pushback that just refuses without engaging with the body: 5-10.
 
 OUTPUT FORMAT — strict JSON, no prose around it:
-{ "score": <integer 0-100>, "rationale": "<1-3 sentences>" }`;
+{ "score": <integer 0-50>, "rationale": "<1-3 sentences>" }`;
 
 // Order matters: more-specific patterns first. Branch names contain
 // agent-ids, so the branch pattern runs before agent-id stripping


### PR DESCRIPTION
## Summary

Equal-weight rescale per operator direction. The old scale was A ∈ 0–100 (judge), B ∈ 0–100 (test pass rate), total 0–200 — but B is the falsifiable signal and A is the proxy. Weighting both up to 100 each let either dimension dominate the curve. The new scale caps each at 50 so they contribute equally:

\`\`\`
A — reasoning judge (0–50): blinded Opus K=3 median
B — hidden-test pass rate (0–50): (passed / total) × 50

quality_per_cell =
   A + B    if implement (range 0..100)
   2 × A    if pushback  (range 0..100, parity with implement's max)
   0        if error / dirty test apply / data missing
\`\`\`

## Files

- \`src/research/curveStudy/reasoningJudge.ts\` — \`JUDGE_OUTPUT_SCHEMA\` max 100 → max 50; \`JUDGE_SYSTEM_PROMPT\` rebanded (0-12 / 13-25 / 26-37 / 38-50) with calibration anchors halved; module header + return-type JSDoc note new range
- \`src/research/curveStudy/cellScores.ts\` \`qualityFromAB\`: A clamped to 50, B = (passed/total) × 50, implement → A+B (0..100), pushback → 2A (0..100). Module header note rescaled.
- \`src/research/curveStudy/reasoningJudge.test.ts\` — score values rescaled into 0–50 range; \"scores outside 0-100\" → \"scores outside 0-50\".
- \`src/research/curveStudy/cellScores.test.ts\` — all numeric expectations rescaled; added \"pushback caps at 100 with A=50\" case; \"out-of-range judge median\" test asserts clamping at 50 (not 100).

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] \`npm test\` — 813 / 813 pass

## Impact

The curve-redo bundle (PR-pending) ships with this formula. No callers outside \`curveStudy/\` depend on the quality value's range — the curve fit projects through \`qmax / quality\`, which is scale-invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)