### PR TITLE
feat(agents): prune-tags subcommand for over-broad agent registries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,16 @@ After every successful issue-resolution run, a separate sonnet summarizer rewrit
 ## CI is a hard gate
 `.github/workflows/ci.yml` runs `npm ci && npm run typecheck && npm run build` on every push and PR. All three must pass. CI failures block merges; reproduce locally with the same three commands before pushing if a PR is failing for unclear reasons.
 
+## Agent overload remediation: pick the right axis
+- **`split`, `compact-claude-md`, and `prune-tags` (#219) address distinct overload axes.** Picking the wrong tool wastes a round trip; an agent flagged for "tags=72 >= 50" doesn't need its CLAUDE.md compacted, and an agent with a 50KB CLAUDE.md doesn't need its tags pruned.
+- **Decision matrix** when an agent trips an overload threshold:
+  - `CLAUDE.md ≥ 30KB` AND `attributableSections ≥ 4` → `agents split` (carve into 2-3 sub-specialists).
+  - `CLAUDE.md ≥ 30KB` AND `attributableSections ≥ 3 per cluster` (but < 4 total) → `agents compact-claude-md` (merge near-duplicate sections in place).
+  - `tags ≥ 50` AND `attributableSections < 4` (split-blocked) → `agents prune-tags` (drop registry tags not backed by any section, optionally LLM-generalize survivors). Most relevant when `tag-to-section ratio > 5:1` — the registry has accumulated breadth from `memoryUpdate.addTags` envelopes that didn't land kept lessons.
+  - `issuesHandled ≥ 20` alone with all three `CLAUDE.md`/`tags`/`sections` axes healthy: informational only — no remediation, the agent is producing focused work at scale.
+- **Composition order**: when ≥2 axes trip, prune-tags first (cheapest, deterministic Phase 1), then re-evaluate. Pruning may bring the agent under the split threshold and unblock a cleaner subsequent split.
+- Past incident 2026-05-07: agent-92ff (Alonzo) tripped `tags=72` and `issuesHandled=20` but had 2 attributable sections — unsplittable AND uncompactable. Existing tooling no-op'd; #219 fills the gap by addressing tag breadth as its own axis. 72 → 9 deterministic, then ~9 → ~4 via Phase 2 LLM clustering.
+
 ## CLI tools: smoke-test the empty-result path before merging
 - **Before merging a new `vp-dev agents <subcommand>` (or any `vp-dev <verb>`), smoke-test it against a fixture that produces an EMPTY result, not just a populated one.** Empty-result paths often take distinct code (default values, no-op shortcuts, fallback expressions, `Math.min(...[]) === Infinity`) that the populated-result tests don't exercise.
 - **How to apply**: build a synthetic fixture with zero eligible items (empty `state/lesson-utility-<id>.json`, empty registry, no PRs, etc.), invoke the CLI in advisory mode, and read the output. If the rendered text contains nonsense (`Infinity`, `undefined`, `NaN`, empty `[]` where a default should have been substituted), that's a real bug regardless of whether unit tests pass.

--- a/src/agent/pruneTags.test.ts
+++ b/src/agent/pruneTags.test.ts
@@ -1,0 +1,266 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import {
+  parseSectionTagsUnion,
+  applyTagFloor,
+  computePruneTagsProposalHash,
+  type PruneTagsProposal,
+} from "./pruneTags.js";
+
+// Build a minimal CLAUDE.md fixture with N sentinels carrying the supplied
+// tag arrays.
+function buildClaudeMd(sentinels: { runId: string; issueId: number; tags: string[] }[]): string {
+  const lines: string[] = ["# Seed", ""];
+  for (const s of sentinels) {
+    const tagsPart = s.tags.length > 0 ? ` tags:${[...s.tags].sort().join(",")}` : "";
+    lines.push(
+      `<!-- run:${s.runId} issue:#${s.issueId} outcome:implement ts:2026-05-07T00:00:00Z${tagsPart} -->`,
+    );
+    lines.push(`## Lesson ${s.issueId}`);
+    lines.push("body");
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+describe("parseSectionTagsUnion", () => {
+  it("returns empty union and zero count for an empty file", () => {
+    const { union, sectionCount } = parseSectionTagsUnion("");
+    assert.equal(union.size, 0);
+    assert.equal(sectionCount, 0);
+  });
+
+  it("returns empty union and zero count when no sentinels present", () => {
+    const md = "# Seed\n\nSome prose. No sentinels here.\n";
+    const { union, sectionCount } = parseSectionTagsUnion(md);
+    assert.equal(union.size, 0);
+    assert.equal(sectionCount, 0);
+  });
+
+  it("collects tags across multiple sentinels", () => {
+    const md = buildClaudeMd([
+      { runId: "r1", issueId: 100, tags: ["alpha", "beta"] },
+      { runId: "r2", issueId: 101, tags: ["beta", "gamma"] },
+    ]);
+    const { union, sectionCount } = parseSectionTagsUnion(md);
+    assert.equal(sectionCount, 2);
+    assert.deepEqual([...union].sort(), ["alpha", "beta", "gamma"]);
+  });
+
+  it("counts sentinels without tags but contributes nothing to union (legacy)", () => {
+    const md = buildClaudeMd([
+      { runId: "r1", issueId: 100, tags: [] },
+      { runId: "r2", issueId: 101, tags: ["delta"] },
+    ]);
+    const { union, sectionCount } = parseSectionTagsUnion(md);
+    assert.equal(sectionCount, 2);
+    assert.deepEqual([...union], ["delta"]);
+  });
+
+  it("handles multi-issue (compacted) sentinels without crashing", () => {
+    const md = [
+      "# Seed",
+      "",
+      "<!-- run:r1 issue:#100+#101+#102 outcome:compacted ts:2026-05-07T00:00:00Z tags:zeta,eta -->",
+      "## Compacted lesson",
+      "body",
+    ].join("\n");
+    const { union, sectionCount } = parseSectionTagsUnion(md);
+    assert.equal(sectionCount, 1);
+    assert.deepEqual([...union].sort(), ["eta", "zeta"]);
+  });
+});
+
+describe("applyTagFloor", () => {
+  it("returns ['general'] for an empty input set", () => {
+    assert.deepEqual(applyTagFloor(new Set()), ["general"]);
+  });
+
+  it("preserves a single 'general' tag when alone", () => {
+    assert.deepEqual(applyTagFloor(new Set(["general"])), ["general"]);
+  });
+
+  it("strips 'general' when other tags survive", () => {
+    assert.deepEqual(applyTagFloor(new Set(["general", "alpha", "beta"])), [
+      "alpha",
+      "beta",
+    ]);
+  });
+
+  it("preserves the input set when 'general' is absent", () => {
+    assert.deepEqual(applyTagFloor(new Set(["alpha", "beta", "gamma"])), [
+      "alpha",
+      "beta",
+      "gamma",
+    ]);
+  });
+
+  it("dedupes via Set semantics (input is ReadonlySet so no array dupes)", () => {
+    const set = new Set<string>();
+    set.add("alpha");
+    set.add("beta");
+    assert.deepEqual(applyTagFloor(set), ["alpha", "beta"]);
+  });
+});
+
+// Phase 1 (no-LLM) proposal logic — exercises proposePruneTags via the
+// `noGeneralize: true` path so tests stay deterministic and don't require
+// the SDK / network.
+describe("proposePruneTags (Phase 1 only)", () => {
+  // Lazy import to avoid pulling the SDK at module load.
+  async function propose(args: {
+    tags: string[];
+    sentinels: { runId: string; issueId: number; tags: string[] }[];
+    noGeneralize?: boolean;
+  }) {
+    const { proposePruneTags } = await import("./pruneTags.js");
+    return proposePruneTags({
+      agent: {
+        agentId: "agent-test",
+        createdAt: "2026-01-01T00:00:00Z",
+        tags: args.tags,
+        issuesHandled: 0,
+        implementCount: 0,
+        pushbackCount: 0,
+        errorCount: 0,
+        lastActiveAt: "2026-01-01T00:00:00Z",
+      },
+      claudeMd: buildClaudeMd(args.sentinels),
+      noGeneralize: args.noGeneralize ?? true,
+    });
+  }
+
+  it("zero attributable sections: notes set, registry tags untouched", async () => {
+    const p = await propose({ tags: ["alpha", "beta"], sentinels: [] });
+    assert.equal(p.attributableSections, 0);
+    assert.deepEqual(p.orphanTags, []);
+    assert.deepEqual(p.finalTags, ["alpha", "beta"]);
+    assert.match(p.notes ?? "", /No attributable sections/);
+  });
+
+  it("sections present but no tag provenance (post-split children, pre-#142): tags untouched", async () => {
+    // Sentinels with empty tags array — exactly the shape post-split
+    // children carry from split.ts:458 (no `tags:` field on materialized
+    // sentinels) AND pre-#142 legacy sentinels.
+    const p = await propose({
+      tags: ["alpha", "beta", "gamma"],
+      sentinels: [
+        { runId: "r1", issueId: 1, tags: [] },
+        { runId: "r2", issueId: 2, tags: [] },
+      ],
+    });
+    assert.equal(p.attributableSections, 2);
+    assert.equal(p.sectionTagsUnion.length, 0);
+    assert.deepEqual(p.orphanTags, []);
+    assert.deepEqual(p.finalTags, ["alpha", "beta", "gamma"]);
+    assert.match(p.notes ?? "", /lack tag provenance/);
+  });
+
+  it("identifies orphans against section-tag union", async () => {
+    const p = await propose({
+      tags: ["alpha", "beta", "gamma", "general"],
+      sentinels: [{ runId: "r1", issueId: 1, tags: ["alpha"] }],
+    });
+    assert.deepEqual(p.orphanTags, ["beta", "gamma", "general"]);
+    assert.deepEqual(p.ungeneralizedKept, ["alpha"]);
+    assert.deepEqual(p.finalTags, ["alpha"]);
+  });
+
+  it("floor protection: registry of only orphans + general -> ['general']", async () => {
+    // Section has tags but none match the registry.
+    const p = await propose({
+      tags: ["unrelated", "general"],
+      sentinels: [{ runId: "r1", issueId: 1, tags: ["alpha"] }],
+    });
+    assert.deepEqual(p.orphanTags, ["general", "unrelated"]);
+    assert.deepEqual(p.ungeneralizedKept, []);
+    assert.deepEqual(p.finalTags, ["general"]);
+  });
+
+  it("registry exactly matches section-tag union: nothing to prune", async () => {
+    const p = await propose({
+      tags: ["alpha", "beta"],
+      sentinels: [{ runId: "r1", issueId: 1, tags: ["alpha", "beta"] }],
+    });
+    assert.deepEqual(p.orphanTags, []);
+    assert.deepEqual(p.finalTags, ["alpha", "beta"]);
+  });
+
+  it("--no-generalize note set when explicit and lesson-backed >= 2", async () => {
+    const p = await propose({
+      tags: ["alpha", "beta", "orphan"],
+      sentinels: [{ runId: "r1", issueId: 1, tags: ["alpha", "beta"] }],
+      noGeneralize: true,
+    });
+    assert.deepEqual(p.orphanTags, ["orphan"]);
+    assert.deepEqual(p.generalizationClusters, []);
+    assert.match(p.notes ?? "", /Phase 2 skipped/);
+  });
+
+  it("idempotent: re-running on a registry already equal to lesson-backed surfaces zero orphans", async () => {
+    const sentinels = [{ runId: "r1", issueId: 1, tags: ["alpha", "beta"] }];
+    const first = await propose({ tags: ["alpha", "beta", "orphan"], sentinels });
+    // Imagine apply happened: tags now equal first.finalTags.
+    const second = await propose({ tags: first.finalTags, sentinels });
+    assert.deepEqual(second.orphanTags, []);
+    assert.deepEqual(second.finalTags, first.finalTags);
+  });
+});
+
+describe("computePruneTagsProposalHash", () => {
+  function makeProposal(overrides: Partial<PruneTagsProposal> = {}): PruneTagsProposal {
+    return {
+      agentId: "agent-test",
+      generatedAt: "2026-05-07T00:00:00Z",
+      registryTagsBefore: ["alpha", "beta", "orphan"],
+      sectionTagsUnion: ["alpha", "beta"],
+      attributableSections: 1,
+      orphanTags: ["orphan"],
+      generalizationClusters: [],
+      ungeneralizedKept: ["alpha", "beta"],
+      finalTags: ["alpha", "beta"],
+      ...overrides,
+    };
+  }
+
+  it("stable across reruns with the same inputs", () => {
+    const p = makeProposal();
+    const tags = ["alpha", "beta", "orphan"];
+    const md = "# claudeMd content\n";
+    const h1 = computePruneTagsProposalHash(p, tags, md);
+    const h2 = computePruneTagsProposalHash(p, tags, md);
+    assert.equal(h1, h2);
+  });
+
+  it("changes when registry tags change", () => {
+    const p = makeProposal();
+    const md = "# claudeMd content\n";
+    const h1 = computePruneTagsProposalHash(p, ["alpha", "beta", "orphan"], md);
+    const h2 = computePruneTagsProposalHash(p, ["alpha", "beta", "orphan", "new"], md);
+    assert.notEqual(h1, h2);
+  });
+
+  it("changes when CLAUDE.md changes", () => {
+    const p = makeProposal();
+    const tags = ["alpha", "beta", "orphan"];
+    const h1 = computePruneTagsProposalHash(p, tags, "v1");
+    const h2 = computePruneTagsProposalHash(p, tags, "v2");
+    assert.notEqual(h1, h2);
+  });
+
+  it("changes when proposal finalTags differ", () => {
+    const tags = ["alpha", "beta", "orphan"];
+    const md = "# claudeMd content\n";
+    const h1 = computePruneTagsProposalHash(makeProposal({ finalTags: ["alpha", "beta"] }), tags, md);
+    const h2 = computePruneTagsProposalHash(makeProposal({ finalTags: ["alpha"] }), tags, md);
+    assert.notEqual(h1, h2);
+  });
+
+  it("hash is order-independent for input tags (sort before hash)", () => {
+    const p = makeProposal();
+    const md = "# claudeMd content\n";
+    const h1 = computePruneTagsProposalHash(p, ["alpha", "beta", "orphan"], md);
+    const h2 = computePruneTagsProposalHash(p, ["orphan", "beta", "alpha"], md);
+    assert.equal(h1, h2);
+  });
+});

--- a/src/agent/pruneTags.ts
+++ b/src/agent/pruneTags.ts
@@ -1,0 +1,515 @@
+// Tag pruning for over-broad agent registries (#219).
+//
+// Two phases:
+//   Phase 1 (deterministic): drop registry tags not present in the
+//     section-tag union. Sentinels carry `tags:t1,t2` provenance per
+//     `appendBlock` (#142); the union of those tags across all attributable
+//     sections is the lesson-backed tag set.
+//   Phase 2 (LLM): cluster the lesson-backed tags into broader categories
+//     where ≥2 fine-grained tags share a coherent thesis. Optional —
+//     `--no-generalize` skips this step.
+//
+// Two-step token gate mirrors `lessonPrune` (#179) and `compactClaudeMd`
+// (#162) so the destructive registry mutation requires explicit operator
+// review between proposal and apply:
+//   vp-dev agents prune-tags <agentId>           # advisory
+//   vp-dev agents prune-tags <agentId> --apply   # mints token
+//   vp-dev agents prune-tags <agentId> --confirm <token>   # mutates registry
+//
+// Hash binding rejects the confirm if the registry tag list OR CLAUDE.md
+// drifted between plan and confirm (concurrent run completing, hand-edit,
+// summarizer append).
+
+import { promises as fs } from "node:fs";
+import crypto from "node:crypto";
+import { z } from "zod";
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { agentClaudeMdPath } from "./specialization.js";
+import { claudeBinPath } from "./sdkBinary.js";
+import { mutateRegistry } from "../state/registry.js";
+import { parseJsonEnvelope } from "../util/parseJsonEnvelope.js";
+import { parseSentinelHeader } from "../util/sentinels.js";
+import { ORCHESTRATOR_MODEL_SPLIT } from "../orchestrator/models.js";
+import type { AgentRecord } from "../types.js";
+
+const PROPOSAL_MODEL = ORCHESTRATOR_MODEL_SPLIT;
+const MAX_CLUSTERS = 5;
+const RATIONALE_MAX = 500;
+const TO_NAME_MAX = 40;
+const GENERAL_TAG = "general";
+
+export interface GeneralizationCluster {
+  /** ≥ 2 fine-grained tags from `sectionTagsUnion`. Each input tag appears in
+   * at most one cluster. */
+  from: string[];
+  /** Generalized parent name (lowercase, hyphenated, ≤40 chars). */
+  to: string;
+  rationale: string;
+}
+
+export interface PruneTagsProposal {
+  agentId: string;
+  generatedAt: string;
+  /** Snapshot of agent.tags at plan time — sorted, deduped. */
+  registryTagsBefore: string[];
+  /** Union of `tags:` provenance fields across attributable sentinels. */
+  sectionTagsUnion: string[];
+  /** Number of `<!-- run:... -->` sentinels parsed from CLAUDE.md. */
+  attributableSections: number;
+  /** registryTagsBefore ∖ sectionTagsUnion (lesson-unbacked). Sorted. */
+  orphanTags: string[];
+  /** LLM-proposed merge clusters. Empty when generalization is skipped or
+   * the lesson-backed set is too small / too uniform to cluster. */
+  generalizationClusters: GeneralizationCluster[];
+  /** Lesson-backed tags not folded into any cluster. Sorted. */
+  ungeneralizedKept: string[];
+  /** The post-prune tag set the registry will receive on apply. Sorted,
+   * deduped, with floor-protection applied (≥1 tag; `general` stripped when
+   * other tags survive, reinstated only if the set would otherwise be empty). */
+  finalTags: string[];
+  /** Optional advisory text — surfaces "no attributable sections" /
+   * "generalization skipped" / etc. */
+  notes?: string;
+}
+
+const ClusterSchema = z.object({
+  from: z.array(z.string().min(1)).min(2).max(20),
+  to: z.string().min(1).max(TO_NAME_MAX),
+  rationale: z.string().min(1).max(RATIONALE_MAX),
+});
+
+const ProposalSchema = z.object({
+  clusters: z.array(ClusterSchema).max(MAX_CLUSTERS).default([]),
+  ungeneralized: z.array(z.string()).default([]),
+  notes: z.string().optional(),
+});
+
+function clampClusterFields(json: unknown): unknown {
+  // Trim oversize rationales / `to` names before Zod runs so a slightly-verbose
+  // model output doesn't discard the entire proposal. Same belt-and-suspenders
+  // pattern as split.ts:181 and the summarizer.
+  if (!json || typeof json !== "object") return json;
+  const obj = json as Record<string, unknown>;
+  const clusters = obj.clusters;
+  if (!Array.isArray(clusters)) return obj;
+  const next = clusters.map((c) => {
+    if (!c || typeof c !== "object") return c;
+    const cluster = c as Record<string, unknown>;
+    const out: Record<string, unknown> = { ...cluster };
+    if (typeof cluster.rationale === "string" && cluster.rationale.length > RATIONALE_MAX) {
+      out.rationale = cluster.rationale.slice(0, RATIONALE_MAX - 16) + "\n[…truncated]";
+    }
+    if (typeof cluster.to === "string" && cluster.to.length > TO_NAME_MAX) {
+      out.to = cluster.to.slice(0, TO_NAME_MAX - 3) + "...";
+    }
+    return out;
+  });
+  return { ...obj, clusters: next };
+}
+
+/**
+ * Parse a CLAUDE.md and return the union of all `tags:` provenance fields
+ * across `<!-- run:... -->` sentinel comments, plus the count of sentinels
+ * found. Sentinels written before tag-provenance landed (per #142) lack a
+ * `tags:` field; they contribute nothing to the union but still count
+ * toward the section total.
+ */
+export function parseSectionTagsUnion(
+  claudeMd: string,
+): { union: Set<string>; sectionCount: number } {
+  const union = new Set<string>();
+  let sectionCount = 0;
+  for (const line of claudeMd.split("\n")) {
+    const header = parseSentinelHeader(line.trim());
+    if (!header) continue;
+    sectionCount++;
+    for (const t of header.tags) union.add(t);
+  }
+  return { union, sectionCount };
+}
+
+/**
+ * Apply floor protection to a candidate post-prune tag set.
+ * - Strip `general` if at least one other tag survives (matches the
+ *   `isGeneralist` policy at routing.ts:73-79).
+ * - Reinstate `["general"]` only when the set would otherwise be empty —
+ *   keeps the agent visible to pickAgents instead of vanishing from
+ *   Jaccard scoring entirely.
+ */
+export function applyTagFloor(tags: ReadonlySet<string>): string[] {
+  const set = new Set(tags);
+  if (set.size > 1) set.delete(GENERAL_TAG);
+  if (set.size === 0) set.add(GENERAL_TAG);
+  return [...set].sort();
+}
+
+export interface ProposePruneTagsInput {
+  agent: AgentRecord;
+  /** The agent's current CLAUDE.md content (or "" if missing). */
+  claudeMd: string;
+  /** When true, skip Phase 2 (LLM generalization); orphan-drop only. */
+  noGeneralize?: boolean;
+}
+
+/**
+ * Compute the prune proposal. Phase 1 is deterministic; Phase 2 fires the
+ * LLM clusterer when `noGeneralize` is false AND there are ≥2 lesson-backed
+ * tags to potentially cluster.
+ */
+export async function proposePruneTags(
+  input: ProposePruneTagsInput,
+): Promise<PruneTagsProposal> {
+  const registryTagsBefore = [...new Set(input.agent.tags)].sort();
+  const { union: sectionTagsUnion, sectionCount } = parseSectionTagsUnion(input.claudeMd);
+  const sectionTagsSorted = [...sectionTagsUnion].sort();
+
+  const registrySet = new Set(registryTagsBefore);
+  const lessonBacked = new Set<string>();
+  const orphans: string[] = [];
+  for (const t of registrySet) {
+    if (sectionTagsUnion.has(t)) lessonBacked.add(t);
+    else orphans.push(t);
+  }
+  orphans.sort();
+
+  // Empty-result paths: leave tags untouched and surface the reason
+  // distinctly rather than silently dropping every tag.
+  //
+  // (a) Zero attributable sections — no signal at all.
+  // (b) Sections present but EVERY one lacks `tags:` provenance — pre-#142
+  //     legacy sentinels OR post-split children (split.ts:458 materializes
+  //     child sections without `tags:`). Lesson-backed evidence is empty
+  //     for the wrong reason; pruning would gut the agent on missing data.
+  if (sectionCount === 0 || sectionTagsUnion.size === 0) {
+    const notes =
+      sectionCount === 0
+        ? "No attributable sections in CLAUDE.md (no <!-- run:... --> sentinels). Tags untouched."
+        : `All ${sectionCount} attributable section(s) lack tag provenance (pre-#142 sentinels or post-split children). Tags untouched — re-run after the agent accumulates sections with tags.`;
+    return {
+      agentId: input.agent.agentId,
+      generatedAt: new Date().toISOString(),
+      registryTagsBefore,
+      sectionTagsUnion: sectionTagsSorted,
+      attributableSections: sectionCount,
+      orphanTags: [],
+      generalizationClusters: [],
+      ungeneralizedKept: [],
+      finalTags: registryTagsBefore,
+      notes,
+    };
+  }
+
+  // Phase 1 only: skip the LLM call.
+  if (input.noGeneralize || lessonBacked.size < 2) {
+    const finalTags = applyTagFloor(lessonBacked);
+    const noteParts: string[] = [];
+    if (input.noGeneralize) noteParts.push("Phase 2 skipped (--no-generalize).");
+    if (lessonBacked.size < 2) {
+      noteParts.push(
+        `Only ${lessonBacked.size} lesson-backed tag(s); generalization needs ≥2.`,
+      );
+    }
+    return {
+      agentId: input.agent.agentId,
+      generatedAt: new Date().toISOString(),
+      registryTagsBefore,
+      sectionTagsUnion: sectionTagsSorted,
+      attributableSections: sectionCount,
+      orphanTags: orphans,
+      generalizationClusters: [],
+      ungeneralizedKept: [...lessonBacked].sort(),
+      finalTags,
+      notes: noteParts.length ? noteParts.join(" ") : undefined,
+    };
+  }
+
+  // Phase 2: LLM call.
+  const llmResult = await runGeneralizationLLM(lessonBacked);
+  // Defensive validation: every cluster.from tag must be in lesson-backed
+  // set; cluster.from sets must be disjoint; ungeneralized + clusters must
+  // cover the lesson-backed set with no extras.
+  const claimed = new Set<string>();
+  const validClusters: GeneralizationCluster[] = [];
+  for (const c of llmResult.clusters) {
+    let valid = true;
+    for (const t of c.from) {
+      if (!lessonBacked.has(t) || claimed.has(t)) {
+        valid = false;
+        break;
+      }
+    }
+    if (!valid) continue;
+    for (const t of c.from) claimed.add(t);
+    validClusters.push({
+      from: [...c.from].sort(),
+      to: c.to,
+      rationale: c.rationale,
+    });
+  }
+  const ungeneralized: string[] = [];
+  for (const t of lessonBacked) if (!claimed.has(t)) ungeneralized.push(t);
+  ungeneralized.sort();
+
+  const finalSet = new Set<string>();
+  for (const t of ungeneralized) finalSet.add(t);
+  for (const c of validClusters) finalSet.add(c.to);
+  const finalTags = applyTagFloor(finalSet);
+
+  return {
+    agentId: input.agent.agentId,
+    generatedAt: new Date().toISOString(),
+    registryTagsBefore,
+    sectionTagsUnion: sectionTagsSorted,
+    attributableSections: sectionCount,
+    orphanTags: orphans,
+    generalizationClusters: validClusters,
+    ungeneralizedKept: ungeneralized,
+    finalTags,
+    notes: llmResult.notes,
+  };
+}
+
+const GENERALIZATION_SYSTEM_PROMPT = `You cluster an agent's fine-grained tags into broader generalized categories.
+
+Input: a list of fine-grained tags this agent has used in actual kept lessons (CLAUDE.md sections). Each tag is a domain label like "cli-flag-sugar", "rogue-mcp-collude", "cost-surface", etc.
+
+Your job: identify clusters of 2+ tags that share a coherent thesis and could be merged under a single broader name. Tags that don't coherently fit any cluster stay ungeneralized.
+
+Output rules:
+- 0 to 5 clusters. Empty array is fine if nothing clusters cleanly — better to leave tags ungeneralized than force them.
+- Each cluster:
+  - "from": ≥2 distinct tags drawn EXACTLY from the input list (no rephrasing, no new tokens).
+  - "to": 1-40 character generalized parent name. Lowercase, hyphenated. Should be broader than "from" but still meaningfully descriptive — NOT generic like "tooling", "code", "system", "general".
+  - "rationale": 1-3 sentences (≤500 chars) on why these tags share a thesis.
+- Each input tag appears in AT MOST ONE cluster.from.
+- Tags not in any cluster.from go in "ungeneralized" (or are simply absent — both treated the same downstream).
+- "notes": optional 1-2 sentence advisory.
+- JSON only, no fences, no prose outside the object.`;
+
+function buildGeneralizationPrompt(lessonBacked: Set<string>): string {
+  const tags = [...lessonBacked].sort();
+  return `Cluster these ${tags.length} lesson-backed tag(s) into broader generalizations:
+
+${JSON.stringify(tags)}
+
+Output JSON: {"clusters": [{"from": ["...", "..."], "to": "...", "rationale": "..."}, ...], "ungeneralized": ["..."], "notes": "..."}`;
+}
+
+interface LlmClusterRaw {
+  clusters: { from: string[]; to: string; rationale: string }[];
+  ungeneralized: string[];
+  notes?: string;
+}
+
+async function runGeneralizationLLM(lessonBacked: Set<string>): Promise<LlmClusterRaw> {
+  const userPrompt = buildGeneralizationPrompt(lessonBacked);
+  let raw = "";
+  const stream = query({
+    prompt: userPrompt,
+    options: {
+      model: PROPOSAL_MODEL,
+      systemPrompt: GENERALIZATION_SYSTEM_PROMPT,
+      tools: [],
+      permissionMode: "default",
+      env: process.env,
+      maxTurns: 1,
+      settingSources: [],
+      persistSession: false,
+      pathToClaudeCodeExecutable: claudeBinPath(),
+    },
+  });
+  for await (const msg of stream) {
+    if (msg.type === "result") {
+      if (msg.subtype === "success") raw = msg.result;
+      else throw new Error(`generalization clusterer failed: ${msg.subtype}`);
+    }
+  }
+  const extracted = parseJsonEnvelope(raw, z.unknown());
+  if (!extracted.ok) {
+    throw new Error(
+      `generalization clusterer output not valid JSON: ${raw.slice(0, 200)}`,
+    );
+  }
+  const clamped = clampClusterFields(extracted.value);
+  const parsed = ProposalSchema.safeParse(clamped);
+  if (!parsed.success) {
+    throw new Error(
+      `generalization clusterer schema invalid: ${parsed.error.message.replace(/\s+/g, " ").slice(0, 400)}`,
+    );
+  }
+  return {
+    clusters: parsed.data.clusters,
+    ungeneralized: parsed.data.ungeneralized,
+    notes: parsed.data.notes,
+  };
+}
+
+export function formatPruneTagsProposal(p: PruneTagsProposal): string {
+  const lines: string[] = [];
+  lines.push(`Tag-prune proposal for ${p.agentId}`);
+  lines.push("=".repeat(`Tag-prune proposal for ${p.agentId}`.length));
+  lines.push(`  Registry tags (before): ${p.registryTagsBefore.length}`);
+  lines.push(`  Attributable sections:  ${p.attributableSections}`);
+
+  // Empty-result branch (zero sections OR every section lacks tag provenance):
+  // skip the orphan/lesson-backed breakdown (they'd render as misleading
+  // 0-of-N or N-of-N counts) and surface the notes line as the headline.
+  const emptyResult = p.sectionTagsUnion.length === 0;
+  if (emptyResult) {
+    lines.push(`  Final tag set (${p.finalTags.length}): unchanged`);
+    if (p.notes) {
+      lines.push("");
+      lines.push(`  Notes: ${p.notes}`);
+    }
+    return lines.join("\n");
+  }
+
+  lines.push(`  Section-tags union:     ${p.sectionTagsUnion.length}`);
+  lines.push(`  Orphan tags (drop):     ${p.orphanTags.length}`);
+  lines.push(`  Lesson-backed (keep):   ${p.registryTagsBefore.length - p.orphanTags.length}`);
+
+  if (p.generalizationClusters.length > 0) {
+    lines.push("");
+    lines.push(`  Generalization clusters (${p.generalizationClusters.length}):`);
+    for (const c of p.generalizationClusters) {
+      lines.push(`    ${c.from.join(" + ")} -> ${c.to}`);
+      lines.push(`      why: ${c.rationale}`);
+    }
+    if (p.ungeneralizedKept.length > 0) {
+      lines.push(
+        `  Ungeneralized (${p.ungeneralizedKept.length}): ${p.ungeneralizedKept.join(", ")}`,
+      );
+    }
+  }
+
+  lines.push("");
+  lines.push(`  Final tag set (${p.finalTags.length}): ${p.finalTags.join(", ")}`);
+  if (p.notes) {
+    lines.push("");
+    lines.push(`  Notes: ${p.notes}`);
+  }
+  if (p.orphanTags.length === 0 && p.generalizationClusters.length === 0) {
+    lines.push("");
+    lines.push("  Nothing to prune. Registry tags already match the lesson-backed set.");
+  }
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Two-step token binding.
+// ---------------------------------------------------------------------------
+
+export function hashString(content: string): string {
+  return crypto.createHash("sha256").update(content).digest("hex");
+}
+
+/**
+ * proposalHash = sha256(JSON.stringify(proposalCore) + sha256(currentTags) + sha256(currentClaudeMd))
+ *
+ * `proposalCore` is the deterministic part of the proposal (finalTags +
+ * generalization shape) so re-deriving the hash after stable-sort yields
+ * the same value regardless of LLM chatter (rationale wording, etc. are
+ * captured via finalTags + cluster shape).
+ */
+export function computePruneTagsProposalHash(
+  proposal: PruneTagsProposal,
+  currentTags: string[],
+  currentClaudeMd: string,
+): string {
+  const core = {
+    agentId: proposal.agentId,
+    finalTags: [...proposal.finalTags].sort(),
+    clusters: [...proposal.generalizationClusters]
+      .map((c) => ({ from: [...c.from].sort(), to: c.to }))
+      .sort((a, b) => a.to.localeCompare(b.to)),
+    orphanTags: [...proposal.orphanTags].sort(),
+  };
+  const sortedCurrentTags = [...currentTags].sort();
+  return crypto
+    .createHash("sha256")
+    .update(JSON.stringify(core))
+    .update(hashString(JSON.stringify(sortedCurrentTags)))
+    .update(hashString(currentClaudeMd))
+    .digest("hex");
+}
+
+export interface ApplyPruneTagsInput {
+  agentId: string;
+  proposal: PruneTagsProposal;
+  expectedProposalHash: string;
+  /** Override CLAUDE.md path for tests; defaults to `agentClaudeMdPath`. */
+  claudeMdPathOverride?: string;
+}
+
+export type ApplyPruneTagsResult =
+  | {
+      kind: "applied";
+      tagsBefore: string[];
+      tagsAfter: string[];
+      droppedCount: number;
+      generalizedCount: number;
+    }
+  | {
+      kind: "drift-rejected";
+      reason: "proposal-hash" | "missing-agent" | "archived-agent";
+      details: string;
+    };
+
+export async function applyPruneTags(
+  input: ApplyPruneTagsInput,
+): Promise<ApplyPruneTagsResult> {
+  const filePath = input.claudeMdPathOverride ?? agentClaudeMdPath(input.agentId);
+  let currentClaudeMd = "";
+  try {
+    currentClaudeMd = await fs.readFile(filePath, "utf-8");
+  } catch {
+    // Missing CLAUDE.md is fine for the registry mutation — we still rebind
+    // the hash against an empty file. If the proposal expected non-empty
+    // content, the hash check below will catch the drift.
+  }
+
+  return mutateRegistry(async (reg) => {
+    const agent = reg.agents.find((a) => a.agentId === input.agentId);
+    if (!agent) {
+      return {
+        kind: "drift-rejected" as const,
+        reason: "missing-agent" as const,
+        details: `Agent '${input.agentId}' not found in registry.`,
+      };
+    }
+    if (agent.archived) {
+      return {
+        kind: "drift-rejected" as const,
+        reason: "archived-agent" as const,
+        details: `Agent '${input.agentId}' is archived; cannot mutate tags.`,
+      };
+    }
+    const computed = computePruneTagsProposalHash(
+      input.proposal,
+      agent.tags,
+      currentClaudeMd,
+    );
+    if (computed !== input.expectedProposalHash) {
+      return {
+        kind: "drift-rejected" as const,
+        reason: "proposal-hash" as const,
+        details:
+          "Registry tag list or CLAUDE.md changed between --apply and --confirm. Re-run --apply to generate a fresh proposal + token.",
+      };
+    }
+    const tagsBefore = [...agent.tags].sort();
+    const tagsAfter = [...input.proposal.finalTags];
+    const beforeSet = new Set(tagsBefore);
+    const afterSet = new Set(tagsAfter);
+    let dropped = 0;
+    for (const t of beforeSet) if (!afterSet.has(t)) dropped++;
+    agent.tags = tagsAfter;
+    return {
+      kind: "applied" as const,
+      tagsBefore,
+      tagsAfter,
+      droppedCount: dropped,
+      generalizedCount: input.proposal.generalizationClusters.length,
+    };
+  });
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -424,6 +424,29 @@ export function buildCli(): Command {
         }),
     )
     .addCommand(
+      new Command("prune-tags")
+        .description(
+          "Drop registry tags not backed by any CLAUDE.md section + LLM-generalize survivors into broader categories (#219). Phase 1 (orphan drop) is deterministic; Phase 2 (generalization) is an opt-out LLM call. With --apply: mint a confirm token (15-min TTL); with --confirm <token>: mutate the registry under the per-file lock. Two-step pattern mirrors compact-claude-md / prune-lessons.",
+        )
+        .argument("<agentId>", "Agent to inspect (e.g. agent-92ff)")
+        .option("--json", "Print machine-readable JSON")
+        .option(
+          "--no-generalize",
+          "Phase 1 only: drop orphan tags, skip the LLM-clustering step. Deterministic, no LLM cost.",
+        )
+        .option(
+          "--apply",
+          "Compute the proposal AND mint a confirm token under state/prune-tags-confirm-<token>.json (15-min TTL). Re-invoke with --confirm <token> to mutate the registry.",
+        )
+        .option(
+          "--confirm <token>",
+          "Apply the proposal recorded in the named token, after re-validating against the live registry + CLAUDE.md content.",
+        )
+        .action(async (agentId, opts) => {
+          await cmdAgentsPruneTags(agentId, opts);
+        }),
+    )
+    .addCommand(
       new Command("audit-lessons")
         .description(
           "Score every section of an agent's CLAUDE.md by intrinsic quality (in vacuum — no run history, no comparison across sections). Per-section sonnet calls rate each lesson on the same 0-1 scale as write-time predictedUtility. Advisory only (Phase 1); destructive --apply / --confirm deferred. Combine with `vp-dev agents prune-lessons` for the historical-reinforcement signal.",
@@ -2707,6 +2730,131 @@ async function cmdAgentsPruneLessons(
   process.stdout.write(
     `\nConfirm token: ${token} (15-min TTL, written to state/lesson-prune-confirm-${token}.json)\n` +
       `Apply with:    vp-dev agents prune-lessons ${agentId} --confirm ${token}\n`,
+  );
+}
+
+interface AgentsPruneTagsOpts {
+  json?: boolean;
+  generalize?: boolean; // Commander stores --no-generalize as generalize:false
+  apply?: boolean;
+  confirm?: string;
+}
+
+async function cmdAgentsPruneTags(
+  agentId: string,
+  opts: AgentsPruneTagsOpts,
+): Promise<void> {
+  const {
+    proposePruneTags,
+    formatPruneTagsProposal,
+    computePruneTagsProposalHash,
+    applyPruneTags,
+  } = await import("./agent/pruneTags.js");
+  const {
+    mintToken,
+    writePruneTagsConfirmToken,
+    readPruneTagsConfirmToken,
+    deletePruneTagsConfirmToken,
+  } = await import("./state/pruneTagsConfirm.js");
+  const { agentClaudeMdPath } = await import("./agent/specialization.js");
+
+  if (opts.confirm) {
+    const tokenResult = await readPruneTagsConfirmToken(opts.confirm);
+    if (!tokenResult.ok) {
+      process.stderr.write(`ERROR: ${tokenResult.message}\n`);
+      process.exit(2);
+    }
+    const { record } = tokenResult;
+    if (record.agentId !== agentId) {
+      process.stderr.write(
+        `ERROR: token ${opts.confirm} is bound to ${record.agentId}, not ${agentId}.\n`,
+      );
+      process.exit(2);
+    }
+    const result = await applyPruneTags({
+      agentId,
+      proposal: record.proposal,
+      expectedProposalHash: record.proposalHash,
+    });
+    if (result.kind === "drift-rejected") {
+      process.stderr.write(`ERROR: ${result.details}\n`);
+      process.exit(2);
+    }
+    await deletePruneTagsConfirmToken(opts.confirm);
+    if (opts.json) {
+      process.stdout.write(
+        JSON.stringify({ agentId, token: opts.confirm, result }, null, 2) + "\n",
+      );
+      return;
+    }
+    process.stdout.write(
+      `Pruned ${agentId} tags\n` +
+        `  ${result.tagsBefore.length} -> ${result.tagsAfter.length} ` +
+        `(${result.droppedCount} dropped, ${result.generalizedCount} generalization cluster(s))\n` +
+        `  final: ${result.tagsAfter.join(", ")}\n`,
+    );
+    return;
+  }
+
+  const reg = await loadRegistry();
+  const agent = reg.agents.find((a) => a.agentId === agentId);
+  if (!agent) {
+    process.stderr.write(`ERROR: agent '${agentId}' not found in registry.\n`);
+    process.exit(2);
+  }
+  if (agent.archived) {
+    process.stderr.write(
+      `ERROR: agent '${agentId}' is archived; pruning is for active agents.\n`,
+    );
+    process.exit(2);
+  }
+
+  // Read CLAUDE.md (missing file is fine — proposal handles empty-result path).
+  let claudeMd = "";
+  try {
+    claudeMd = await fs.readFile(agentClaudeMdPath(agentId), "utf-8");
+  } catch {
+    // empty string flows through proposePruneTags' zero-section branch
+  }
+
+  // Commander wires --no-generalize to `generalize: false` (default true).
+  const noGeneralize = opts.generalize === false;
+
+  const proposal = await proposePruneTags({
+    agent,
+    claudeMd,
+    noGeneralize,
+  });
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(proposal, null, 2) + "\n");
+    return;
+  }
+
+  process.stdout.write(formatPruneTagsProposal(proposal) + "\n");
+
+  if (!opts.apply) return;
+
+  // No-op proposals don't mint a token. The "no attributable sections" path
+  // returns finalTags === registryTagsBefore; otherwise compare for any change.
+  const before = [...proposal.registryTagsBefore].sort().join(",");
+  const after = [...proposal.finalTags].sort().join(",");
+  if (before === after) {
+    process.stdout.write("\nNothing to prune; no token minted.\n");
+    return;
+  }
+
+  const proposalHash = computePruneTagsProposalHash(proposal, agent.tags, claudeMd);
+  const token = mintToken();
+  await writePruneTagsConfirmToken({
+    token,
+    agentId,
+    proposal,
+    proposalHash,
+  });
+  process.stdout.write(
+    `\nConfirm token: ${token} (15-min TTL, written to state/prune-tags-confirm-${token}.json)\n` +
+      `Apply with:    vp-dev agents prune-tags ${agentId} --confirm ${token}\n`,
   );
 }
 

--- a/src/state/pruneTagsConfirm.ts
+++ b/src/state/pruneTagsConfirm.ts
@@ -1,0 +1,102 @@
+// Two-step approval token flow for `vp-dev agents prune-tags --apply`.
+//
+// Mirrors `lessonPruneConfirm.ts` (#179's prune-lessons two-step) and
+// `compactConfirm.ts` (#162). The proposalHash binds the proposal to both
+// the agent's current registry tag list AND CLAUDE.md content at plan time;
+// any drift between plan and confirm invalidates the token.
+
+import { promises as fs } from "node:fs";
+import crypto from "node:crypto";
+import path from "node:path";
+import { STATE_DIR, atomicWriteJson } from "./runState.js";
+import type { PruneTagsProposal } from "../agent/pruneTags.js";
+
+const TOKEN_TTL_MS = 15 * 60 * 1000;
+const TOKEN_FILE_PREFIX = "prune-tags-confirm-";
+
+export interface PruneTagsConfirmRecord {
+  token: string;
+  agentId: string;
+  /** sha256(JSON.stringify(proposalCore) + sha256(currentTags) + sha256(currentClaudeMd)). */
+  proposalHash: string;
+  /** The proposal verbatim — re-used at confirm time without re-running the LLM. */
+  proposal: PruneTagsProposal;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export function mintToken(): string {
+  return crypto.randomBytes(8).toString("hex");
+}
+
+function tokenFilePath(token: string): string {
+  if (!/^[a-f0-9]+$/i.test(token)) {
+    throw new Error("Invalid token format: must be hex.");
+  }
+  return path.join(STATE_DIR, `${TOKEN_FILE_PREFIX}${token}.json`);
+}
+
+export async function writePruneTagsConfirmToken(input: {
+  token: string;
+  agentId: string;
+  proposal: PruneTagsProposal;
+  proposalHash: string;
+}): Promise<PruneTagsConfirmRecord> {
+  const now = new Date();
+  const record: PruneTagsConfirmRecord = {
+    token: input.token,
+    agentId: input.agentId,
+    proposalHash: input.proposalHash,
+    proposal: input.proposal,
+    createdAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + TOKEN_TTL_MS).toISOString(),
+  };
+  await atomicWriteJson(tokenFilePath(input.token), record);
+  return record;
+}
+
+export type ReadResult =
+  | { ok: true; record: PruneTagsConfirmRecord }
+  | { ok: false; reason: "missing" | "expired" | "malformed"; message: string };
+
+export async function readPruneTagsConfirmToken(
+  token: string,
+): Promise<ReadResult> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(tokenFilePath(token), "utf-8");
+  } catch {
+    return {
+      ok: false,
+      reason: "missing",
+      message: `No prune-tags token found for ${token}. Re-run with --apply to generate a fresh one.`,
+    };
+  }
+  let record: PruneTagsConfirmRecord;
+  try {
+    record = JSON.parse(raw) as PruneTagsConfirmRecord;
+  } catch {
+    return {
+      ok: false,
+      reason: "malformed",
+      message: `Prune-tags token ${token} is malformed. Re-run with --apply to generate a fresh one.`,
+    };
+  }
+  if (Date.now() > Date.parse(record.expiresAt)) {
+    await deletePruneTagsConfirmToken(token).catch(() => {});
+    return {
+      ok: false,
+      reason: "expired",
+      message: `Prune-tags token ${token} expired at ${record.expiresAt}. Re-run with --apply to generate a fresh one.`,
+    };
+  }
+  return { ok: true, record };
+}
+
+export async function deletePruneTagsConfirmToken(token: string): Promise<void> {
+  try {
+    await fs.unlink(tokenFilePath(token));
+  } catch {
+    // already gone — fine
+  }
+}


### PR DESCRIPTION
Closes #219.

## Summary

- New `vp-dev agents prune-tags <agentId>` subcommand. **Phase 1** drops registry tags not present in any CLAUDE.md section's `tags:` provenance (deterministic). **Phase 2** LLM-generalizes the lesson-backed survivors into broader categories (opt-out via `--no-generalize`).
- Fills the overload-remediation gap for agents like agent-92ff (Alonzo) with `tags=72`, `issuesHandled=20`, but only 2 attributable sections — both `agents split` (needs ≥4 sections) and `agents compact-claude-md` (needs ≥3 per cluster) no-op for this shape.
- Two-step `--apply` / `--confirm <token>` pattern matches `compact-claude-md` / `prune-lessons` exactly. 15-min TTL. `proposalHash` binds proposal + agent.tags + CLAUDE.md content; any drift between apply and confirm rejects with a fresh-`--apply` prompt.

## Approach

Registry-only mutation. No alias table. Sentinels stay as historical audit log.
- **Why**: Jaccard scoring is against `issue.labels` (GitHub-native), not LLM-emitted tags (`src/orchestrator/routing.ts:38,66`). Triage emits `{ready, reason}` only. Renaming `cli-flag-sugar` → `cli-surface` doesn't cost Jaccard reach.
- **Floor protection**: ≥1 tag preserved (`general` reinstated only when set would otherwise be empty); `general` stripped when other tags survive (matches `isGeneralist` policy at `routing.ts:73-79`).
- **Empty-result safety**: zero attributable sections OR every section lacks `tags:` provenance → tags untouched, notes line warns. Distinct from "no orphans found" — addresses the post-split-children foot-gun where `split.ts:458` materializes child sections without `tags:` provenance.

## Files

| File | Lines | Notes |
|---|---|---|
| `src/agent/pruneTags.ts` (new) | 515 | `proposePruneTags`, `applyPruneTags`, `parseSectionTagsUnion`, `applyTagFloor`, `computePruneTagsProposalHash`, `formatPruneTagsProposal`. Phase 2 LLM call mirrors split.ts pattern. |
| `src/state/pruneTagsConfirm.ts` (new) | 102 | Token IO, mirror of `lessonPruneConfirm.ts`. |
| `src/agent/pruneTags.test.ts` (new) | 266 | 22 unit tests covering orphan computation, floor protection, hash drift, idempotency, post-split-children empty-result, multi-issue (compacted) sentinels. |
| `src/cli.ts` (modified) | +148 | `cmdAgentsPruneTags` + addCommand registration parallel to `prune-lessons`. |
| `CLAUDE.md` (modified) | +10 | "Agent overload remediation: pick the right axis" section — decision matrix between split / compact / prune-tags by overload axis. |

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 834/834 pass (22 new in `pruneTags.test.js`)
- [x] Advisory smoke against `agent-92ff` (Alonzo): 72 → 9 lesson-backed, formatted output correct
- [x] Empty-result smoke against `agent-7089` (post-split Saunders): 7 sections but 0 tag-provenance → tags untouched, notes line warns
- [x] `--json` mode renders valid JSON
- [x] `--help` shows full option list
- [ ] Phase 2 + apply/confirm against live agent: covered by unit tests; not run live to avoid mutating Alonzo before reviewer sees the PR