### PR TITLE
fix(replay): captureWorktreeDiff includes committed work via baseSha

### DIFF
--- a/src/agent/replay.test.ts
+++ b/src/agent/replay.test.ts
@@ -102,6 +102,52 @@ test("captureWorktreeDiff: writes an empty file when worktree is clean", async (
   }
 });
 
+test("captureWorktreeDiff: with baseSha, captures committed work the agent made on its branch", async () => {
+  const { repoRoot, seedSha, cleanup } = await makeFixtureRepo();
+  try {
+    // Simulate the production flow: agent edits files, runs `git commit` on
+    // its branch (worktree clean afterwards), then capture runs.
+    await execFile("git", ["-C", repoRoot, "checkout", "-q", "-b", "agent-branch"]);
+    await fs.writeFile(path.join(repoRoot, "seed.txt"), "agent-edited\n");
+    await fs.writeFile(path.join(repoRoot, "feature.txt"), "new feature file\n");
+    await execFile("git", ["-C", repoRoot, "add", "-A"]);
+    await execFile("git", ["-C", repoRoot, "commit", "-q", "-m", "agent work"]);
+
+    const outPath = path.join(repoRoot, "out", "post-commit.diff");
+    await captureWorktreeDiff({ worktreePath: repoRoot, outPath, baseSha: seedSha });
+
+    const diff = await fs.readFile(outPath, "utf-8");
+    assert.match(diff, /diff --git a\/seed\.txt b\/seed\.txt/);
+    assert.match(diff, /\+agent-edited/);
+    assert.match(diff, /diff --git a\/feature\.txt b\/feature\.txt/);
+    assert.match(diff, /\+new feature file/);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("captureWorktreeDiff: with baseSha, captures committed + uncommitted edits in one diff", async () => {
+  const { repoRoot, seedSha, cleanup } = await makeFixtureRepo();
+  try {
+    await execFile("git", ["-C", repoRoot, "checkout", "-q", "-b", "agent-branch"]);
+    await fs.writeFile(path.join(repoRoot, "seed.txt"), "first edit\n");
+    await execFile("git", ["-C", repoRoot, "add", "-A"]);
+    await execFile("git", ["-C", repoRoot, "commit", "-q", "-m", "first"]);
+    // Leftover uncommitted edit (the agent ran out of turns before committing)
+    await fs.writeFile(path.join(repoRoot, "leftover.txt"), "uncommitted\n");
+
+    const outPath = path.join(repoRoot, "out", "mixed.diff");
+    await captureWorktreeDiff({ worktreePath: repoRoot, outPath, baseSha: seedSha });
+
+    const diff = await fs.readFile(outPath, "utf-8");
+    assert.match(diff, /\+first edit/);
+    assert.match(diff, /diff --git a\/leftover\.txt b\/leftover\.txt/);
+    assert.match(diff, /\+uncommitted/);
+  } finally {
+    await cleanup();
+  }
+});
+
 test("captureWorktreeDiff: creates parent directory of outPath if missing", async () => {
   const { repoRoot, cleanup } = await makeFixtureRepo();
   try {

--- a/src/agent/replay.ts
+++ b/src/agent/replay.ts
@@ -37,14 +37,17 @@ export async function applyReplayRollback(opts: {
 }
 
 /**
- * Capture the worktree's diff (modified + new files) and write it to
- * `outPath`. The output feeds the test-runner and reasoning judge in later
- * phases.
+ * Capture the worktree's diff (modified + new files, committed + uncommitted)
+ * and write it to `outPath`. The output feeds the test-runner and reasoning
+ * judge in later phases.
  *
- * Approach: stage everything with `git add -A`, then emit `git diff --cached`.
- * Staging first ensures newly-created tracked files (which `git diff HEAD`
- * alone would miss) appear in the output. The worktree is about to be torn
- * down by removeWorktree, so the index mutation has no lasting effect.
+ * Approach: stage everything with `git add -A`, then emit `git diff --cached
+ * <baseSha>`. Staging first ensures newly-created tracked files (which a
+ * HEAD-only diff would miss) appear in the output; diffing against the
+ * replay base SHA captures both committed work (the coding agent typically
+ * runs `git commit` on its branch) AND any leftover uncommitted edits in the
+ * same diff. Without `baseSha`, `git diff --cached` is HEAD-relative and
+ * silently drops the entire commit the agent just made.
  *
  * Parent directory of `outPath` is created if missing. `maxBuffer` is set
  * to 32 MiB — diffs from a 50-turn coding-agent run rarely exceed a few KB,
@@ -53,13 +56,12 @@ export async function applyReplayRollback(opts: {
 export async function captureWorktreeDiff(opts: {
   worktreePath: string;
   outPath: string;
+  baseSha?: string;
 }): Promise<void> {
   await fs.mkdir(path.dirname(opts.outPath), { recursive: true });
   await execFile("git", ["-C", opts.worktreePath, "add", "-A"]);
-  const { stdout } = await execFile(
-    "git",
-    ["-C", opts.worktreePath, "diff", "--cached"],
-    { maxBuffer: 32 * 1024 * 1024 },
-  );
+  const args = ["-C", opts.worktreePath, "diff", "--cached"];
+  if (opts.baseSha) args.push(opts.baseSha);
+  const { stdout } = await execFile("git", args, { maxBuffer: 32 * 1024 * 1024 });
   await fs.writeFile(opts.outPath, stdout);
 }

--- a/src/agent/runIssueCore.ts
+++ b/src/agent/runIssueCore.ts
@@ -209,6 +209,7 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
         await captureWorktreeDiff({
           worktreePath: worktree.path,
           outPath: input.replayMode.captureDiffPath,
+          baseSha: input.replayMode.baseSha,
         });
         input.logger.info("agent.replay_diff_captured", {
           agentId: input.agent.agentId,


### PR DESCRIPTION
## Summary

- The curve-redo replay flow's diff capture did `git add -A; git diff --cached`, which is HEAD-relative. When the coding agent committed its work on the cell branch (normal case — `feat/fix(...)` commit before the dry-run-intercepted PR step), the worktree was clean post-commit and the captured diff was **empty**.
- Empty diffs meant downstream phases (testRunner B-score, reasoningJudge A-score) had nothing to apply, silently producing zero-quality cells. Any prior leg-1 dispatch on this code path produced degenerate scoring data.
- Fix: thread `replayMode.baseSha` through to `captureWorktreeDiff` and use `git diff --cached <baseSha>`, which spans committed + uncommitted work since the replay base.

Verified live on issue #157, agent-916a-trim-6000-s8026 (smoke cell): 62-line diff captured (CLAUDE.md + src/cli.ts changes the agent committed) where pre-fix the captured diff was 0 bytes.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `node --test dist/src/agent/replay.test.js` — 7/7 (5 existing + 2 new regression tests for the post-commit capture case)
- [x] Full suite `npm test` — 837/837
- [x] Live smoke cell: pre-fix 0-byte diff, post-fix 62-line diff for the same agent × issue

— claude-opus-4-7