### PR TITLE
fix(replay): default capture baseSha to worktree HEAD pre-agent

### DIFF
--- a/feature-plans/curve-redo-bundle/README.md
+++ b/feature-plans/curve-redo-bundle/README.md
@@ -113,6 +113,8 @@ Hidden tests are committed in `feature-plans/curve-redo-bundle/curve-redo-tests/
 
 `vp-dev research curve-study` already hardcodes CLAUDE.md isolation (`suppressTargetClaudeMd: true`) per [#216](https://github.com/szhygulin/vaultpilot-development-agents/pull/216), so no flag needed for that. **But curve-study itself doesn't yet wire `--model` / `--replay-base-sha` / `--capture-diff-path` into the cell spawn.** For the curve-redo experiment, dispatch via a thin shell loop calling `vp-dev spawn` directly (one cell at a time, per-trim parallelism via `&`):
 
+`--capture-diff-path` defaults its diff base to the worktree's HEAD at spawn-start when `--replay-base-sha` isn't set, so leg-1 open-issue cells correctly capture committed agent work without operator-side wiring. Leg-2 closed-issue cells still pass `--replay-base-sha` for the rollback step.
+
 ```bash
 # Leg 1 dispatch script (run on machine 1)
 mkdir -p feature-plans/curve-redo-data/{logs-leg1,diffs-leg1,scores-leg1}

--- a/src/agent/replay.test.ts
+++ b/src/agent/replay.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
-import { applyReplayRollback, captureWorktreeDiff } from "./replay.js";
+import { applyReplayRollback, captureWorktreeDiff, readWorktreeHead } from "./replay.js";
 
 const execFile = promisify(execFileCb);
 
@@ -143,6 +143,47 @@ test("captureWorktreeDiff: with baseSha, captures committed + uncommitted edits 
     assert.match(diff, /\+first edit/);
     assert.match(diff, /diff --git a\/leftover\.txt b\/leftover\.txt/);
     assert.match(diff, /\+uncommitted/);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("readWorktreeHead: returns the worktree's current HEAD SHA", async () => {
+  const { repoRoot, seedSha, cleanup } = await makeFixtureRepo();
+  try {
+    const head = await readWorktreeHead(repoRoot);
+    assert.equal(head, seedSha);
+    // Advance HEAD with a second commit and re-read.
+    await fs.writeFile(path.join(repoRoot, "seed.txt"), "second\n");
+    await execFile("git", ["-C", repoRoot, "add", "-A"]);
+    await execFile("git", ["-C", repoRoot, "commit", "-q", "-m", "second"]);
+    const headAfter = await readWorktreeHead(repoRoot);
+    assert.notEqual(headAfter, seedSha);
+    assert.match(headAfter, /^[0-9a-f]{40}$/);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("captureWorktreeDiff: WITHOUT baseSha after commit returns EMPTY diff (the bug runIssueCore's HEAD snapshot works around)", async () => {
+  // This test pins down the bug shape that motivates the runIssueCore
+  // snapshot: when the agent commits its work and capture is invoked
+  // without a baseSha, `git diff --cached` is HEAD-relative and silently
+  // drops the entire commit. The fix lives in runIssueCore (it snapshots
+  // HEAD pre-agent and threads it as baseSha); this test asserts the
+  // failure mode the snapshot prevents.
+  const { repoRoot, cleanup } = await makeFixtureRepo();
+  try {
+    await execFile("git", ["-C", repoRoot, "checkout", "-q", "-b", "agent-branch"]);
+    await fs.writeFile(path.join(repoRoot, "seed.txt"), "agent-edited\n");
+    await execFile("git", ["-C", repoRoot, "add", "-A"]);
+    await execFile("git", ["-C", repoRoot, "commit", "-q", "-m", "agent work"]);
+
+    const outPath = path.join(repoRoot, "out", "no-base.diff");
+    await captureWorktreeDiff({ worktreePath: repoRoot, outPath });
+
+    const diff = await fs.readFile(outPath, "utf-8");
+    assert.equal(diff, "", "without baseSha the agent's commit is silently dropped");
   } finally {
     await cleanup();
   }

--- a/src/agent/replay.ts
+++ b/src/agent/replay.ts
@@ -37,6 +37,18 @@ export async function applyReplayRollback(opts: {
 }
 
 /**
+ * Read the worktree's current HEAD SHA. The orchestrator snapshots HEAD
+ * pre-agent (after any replay rollback) so captureWorktreeDiff has a stable
+ * base even when the caller didn't pass an explicit replay baseSha — without
+ * this, open-issue cells whose agent commits its work emit empty diffs
+ * because `git diff --cached` is HEAD-relative.
+ */
+export async function readWorktreeHead(worktreePath: string): Promise<string> {
+  const { stdout } = await execFile("git", ["-C", worktreePath, "rev-parse", "HEAD"]);
+  return stdout.trim();
+}
+
+/**
  * Capture the worktree's diff (modified + new files, committed + uncommitted)
  * and write it to `outPath`. The output feeds the test-runner and reasoning
  * judge in later phases.

--- a/src/agent/runIssueCore.ts
+++ b/src/agent/runIssueCore.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "node:fs";
 import { ensureAgent, mutateRegistry } from "../state/registry.js";
 import { runCodingAgent } from "./codingAgent.js";
-import { applyReplayRollback, captureWorktreeDiff } from "./replay.js";
+import { applyReplayRollback, captureWorktreeDiff, readWorktreeHead } from "./replay.js";
 import {
   agentClaudeMdPath,
   appendBlock,
@@ -103,6 +103,10 @@ export interface RunIssueCoreInput {
    *   - after the coding agent finishes, the worktree's diff (modified +
    *     newly-staged tracked files) is written to `captureDiffPath` so
    *     downstream test-runner / reasoning-judge phases can score it.
+   *   - the diff capture's base is the supplied `baseSha` if present, else
+   *     the worktree's HEAD SHA snapshotted just before the agent runs.
+   *     Open-issue cells (no `baseSha`) thus capture committed agent work
+   *     without needing operator-side wiring.
    * Undefined for normal callers — preserves pre-curve-redo behavior.
    */
   replayMode?: {
@@ -183,6 +187,19 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
       });
     }
 
+    // Snapshot the worktree HEAD BEFORE the coding agent runs (after any
+    // replay rollback). captureWorktreeDiff diffs against this so committed
+    // work the agent makes on its branch is visible in the captured diff
+    // even when the caller didn't pass an explicit baseSha. Without this
+    // snapshot, `git diff --cached` is HEAD-relative and silently drops the
+    // agent's commit (the worktree is clean post-commit). Skipped when
+    // captureDiffPath is unset to keep normal callers shell-free.
+    let captureBaseSha: string | undefined;
+    if (input.replayMode?.captureDiffPath) {
+      captureBaseSha =
+        input.replayMode.baseSha ?? (await readWorktreeHead(worktree.path));
+    }
+
     const result = await runCodingAgent({
       agent: input.agent,
       issueId: input.issue.id,
@@ -209,7 +226,7 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
         await captureWorktreeDiff({
           worktreePath: worktree.path,
           outPath: input.replayMode.captureDiffPath,
-          baseSha: input.replayMode.baseSha,
+          baseSha: captureBaseSha,
         });
         input.logger.info("agent.replay_diff_captured", {
           agentId: input.agent.agentId,


### PR DESCRIPTION
## Summary

[#223](https://github.com/szhygulin/vaultpilot-development-agents/pull/223) fixed `captureWorktreeDiff` to honor `baseSha` when supplied, but `runIssueCore` only forwarded it when the caller explicitly passed `--replay-base-sha`. Open-issue cells (curve-redo leg-1) omit the flag, so the diff capture fell back to HEAD-relative `git diff --cached` — silently dropping any commit the agent made. This PR snapshots the worktree's HEAD pre-agent and threads it as the default base, fixing the gap.

## Why this needed a follow-up to #223

`#223` made `captureWorktreeDiff` correct **when given a `baseSha`**. Its verification was on issue [#157](https://github.com/szhygulin/vaultpilot-development-agents/issues/157) (leg-2 closed-issue, baseSha set explicitly). For leg-1 open-issue cells, `runIssueCore` still passed `input.replayMode.baseSha` (undefined) to `captureWorktreeDiff`, falling back to the same HEAD-relative diff that drops post-commit work.

## Live evidence (post-mortem from today's killed leg-1 run)

Today's leg-1 dispatch ran 61/108 cells before kill. Cost sunk: $25.58. Decision distribution: 9 implement / 48 pushback / 4 in-flight at kill. **Non-empty diff captures: 0.** Inspecting the clones revealed agents had committed real fixes that the bug dropped:

- `agent-916a-trim-14000-s2016032` on issue #565: `feat(security): emit [READ-ONLY DATA SOURCE] provenance block on advisory read-only tools`
- `agent-916a-trim-22000-s2024032` on issue #565: `feat(security): add Inv #16 read-only data-plane integrity attestation`
- `agent-916a-trim-35000-s37026` on issue #565: `feat(digest): add dataSource provenance field to get_daily_briefing`
- `agent-916a-trim-6000-s8026` on issue #574: `fix(ens): add multi-RPC consensus check to resolve_ens_name and reverse_resolve_ens`

All visible in the clone branches via `git log --all --not main --oneline`; all silently absent from the captured `.diff` files.

## Fix shape

In `runIssueCore`, between the rollback step (when applicable) and the coding-agent run, snapshot the worktree HEAD and thread it to `captureWorktreeDiff` as the diff base. Snapshot happens only when `captureDiffPath` is set, so normal callers stay shell-free. Closed-issue cells continue to pass `--replay-base-sha` for the rollback step; the snapshot resolves to the same SHA either way.

- `src/agent/replay.ts` — add `readWorktreeHead` helper.
- `src/agent/runIssueCore.ts` — snapshot HEAD pre-agent (after any rollback), pass to capture.
- `src/agent/replay.test.ts` — +2 regression tests:
  - `readWorktreeHead` returns the HEAD SHA.
  - `captureWorktreeDiff` WITHOUT baseSha after commit returns empty diff (pins the bug shape this PR works around).
- `feature-plans/curve-redo-bundle/README.md` — one-line Step 3 note explaining the new default.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run build` clean.
- [x] `node --test dist/src/agent/replay.test.js` — 9/9 (7 existing + 2 new).
- [x] `npm test` — 839/839 (was 837, +2 new tests).
- [ ] Re-run leg-1 dispatch (should now capture non-empty diffs for the agents that commit real fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)