### PR TITLE
fix(curve-redo): testGenerator emits ../src/ imports, not sibling imports

### DIFF
--- a/src/research/curveStudy/testGenerator.test.ts
+++ b/src/research/curveStudy/testGenerator.test.ts
@@ -197,6 +197,44 @@ test("generateTests: ok=true when all batches return the requested test count", 
   }
 });
 
+test("generateTests: prompt instructs the LLM that tests live at curve-redo-hidden-tests/ and imports must use ../src/ paths", async () => {
+  const { repoPath, cleanup } = await makeRepo();
+  try {
+    const captured: { systemPrompt: string; userPrompt: string }[] = [];
+    const llm: LlmCall = async (args) => {
+      captured.push({ systemPrompt: args.systemPrompt, userPrompt: args.userPrompt });
+      return {
+        raw: JSON.stringify({ tests: [{ filename: "a.test.ts", code: "// noop" }] }),
+        isError: false,
+        costUsd: 0.01,
+      };
+    };
+    await generateTests({
+      issueId: 999,
+      issueTitle: "Capture prompts",
+      issueBody: "Body",
+      repoPath,
+      framework: "node-test",
+      outDir: path.join(repoPath, "tests-out"),
+      batchCount: 1,
+      testsPerBatch: 1,
+      llmCall: llm,
+    });
+    assert.equal(captured.length, 1);
+    const sys = captured[0].systemPrompt;
+    // Test placement is named explicitly so the LLM knows where its output runs from.
+    assert.match(sys, /curve-redo-hidden-tests\//);
+    // Both the do (../src/) and the don't (no sibling) are spelled out.
+    assert.match(sys, /\.\.\/src\//);
+    assert.match(sys, /sibling imports/i);
+    // Style fixture's path style is explicitly NOT to be mimicked.
+    const user = captured[0].userPrompt;
+    assert.match(user, /API\/idiom style, NOT its import-path style/);
+  } finally {
+    await cleanup();
+  }
+});
+
 test("generateTests: ok=false and failures recorded when LLM short-counts a batch", async () => {
   const { repoPath, cleanup } = await makeRepo();
   try {

--- a/src/research/curveStudy/testGenerator.ts
+++ b/src/research/curveStudy/testGenerator.ts
@@ -119,6 +119,11 @@ CRITICAL CONSTRAINTS — violating these wastes the test:
 - Test files MUST compile cleanly. Use the framework's idiomatic test/expect API exactly as the style fixture demonstrates.
 - Filenames are kebab-case ending in \`.test.ts\`. No spaces, no uppercase, no special chars.
 
+IMPORT PATHS — your tests will NOT live next to the impl modules they exercise:
+- Generated tests are placed at \`<cloneRoot>/curve-redo-hidden-tests/<filename>.test.ts\` (a sibling of \`src/\`, not inside it).
+- Use \`../src/<dir>/<module>.js\` to reach impl modules. Never use sibling imports (\`./<module>.js\`) — those would resolve inside \`curve-redo-hidden-tests/\` where no impl files exist.
+- The style fixture below was authored AT a location next to its impl, so its imports may be sibling-style. DO NOT mimic that path style — translate every \`./<x>.js\` to \`../src/<dir>/<x>.js\` based on where the file actually lives in the repo tree. Match its API/idiom style, not its import paths.
+
 OUTPUT FORMAT — strict JSON object, no prose before or after:
 {
   "tests": [
@@ -158,7 +163,7 @@ function buildUserPrompt(args: {
     "Repo tree (depth 2):",
     args.repoTree,
     "",
-    `Style fixture (existing test from this repo at ${args.styleFixturePath} — match this style):`,
+    `Style fixture (existing test from this repo at ${args.styleFixturePath} — match its API/idiom style, NOT its import-path style: this fixture lives next to its impl, but your generated tests live at curve-redo-hidden-tests/, so rewrite any sibling imports to ../src/<dir>/<x>.js):`,
     "```ts",
     args.styleFixture,
     "```",


### PR DESCRIPTION
## Summary

- Hidden tests are placed at `<cloneRoot>/curve-redo-hidden-tests/<filename>.test.ts` by the testRunner. Sibling imports (`./<x>.js`) emitted by the generator resolve to that sandbox dir — where no impl files live — and every test fails with `ERR_MODULE_NOT_FOUND` before any assertion runs.
- Tighten the SYSTEM_PROMPT: spell out the dest path, require `../src/<dir>/<x>.js` for impl imports, flag sibling imports as wrong with a one-line reason.
- Reframe the user-prompt's style-fixture intro to "match its API/idiom style, NOT its import-path style" so the LLM doesn't transcribe the fixture's sibling paths verbatim. (The largest test files in `src/agent/` are colocated with their impl, so they naturally use sibling imports.)

## Why a separate PR from [#225](https://github.com/szhygulin/vaultpilot-development-agents/pull/225)

[#225](https://github.com/szhygulin/vaultpilot-development-agents/pull/225) is the operator-side workaround needed to score the *currently-committed* hidden tests (which have sibling imports baked in). This PR fixes the upstream so future regenerations don't need the workaround. After both land, regenerated corpora can use the default `curve-redo-hidden-tests/` placement uniformly across both legs.

The corpus's `testsDestRelDir` field stays in [#225](https://github.com/szhygulin/vaultpilot-development-agents/pull/225) as an escape hatch for any future case where colocation is genuinely wanted, but it'll be unused by default once tests are regenerated against this PR.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `npm test` — 839/839 pass
- [x] New unit test asserts the prompt names `curve-redo-hidden-tests/`, requires `../src/` imports, flags sibling imports, and the user prompt's style-fixture line distinguishes API style from path style
- [ ] Re-run `vp-dev research generate-tests` against one issue (e.g. #172) post-merge, spot-check that the generated tests use `../src/agent/tightenClaudeMd.js` instead of `./tightenClaudeMd.js` (deferred to whoever cuts the next regeneration; ~$1.20 + 2 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)