### PR TITLE
fix(replay): strip origin remote on rollback so trim CLAUDE.md sync rules can't undo replay

### DIFF
--- a/src/agent/replay.test.ts
+++ b/src/agent/replay.test.ts
@@ -53,6 +53,42 @@ test("applyReplayRollback: resets worktree HEAD to the supplied base SHA", async
   }
 });
 
+test("applyReplayRollback: strips the `origin` remote so an agent-side rebase to upstream fails fast", async () => {
+  const { repoRoot, seedSha, cleanup } = await makeFixtureRepo();
+  try {
+    // Wire up a fake `origin` and a remote-tracking ref so the rollback has
+    // something to strip. The URL points at the same dir for fetchability.
+    await execFile("git", ["-C", repoRoot, "remote", "add", "origin", repoRoot]);
+    await execFile("git", ["-C", repoRoot, "fetch", "-q", "origin"]);
+    await applyReplayRollback({ worktreePath: repoRoot, baseSha: seedSha });
+    // Verify origin is gone — `git remote get-url origin` should error.
+    await assert.rejects(
+      execFile("git", ["-C", repoRoot, "remote", "get-url", "origin"]),
+      /No such remote|fatal/,
+    );
+    // And `git rebase origin/main` should fail with an invalid-upstream
+    // error rather than silently advancing HEAD past baseSha.
+    await assert.rejects(
+      execFile("git", ["-C", repoRoot, "rebase", "origin/main"]),
+      /invalid upstream|unknown revision|fatal/,
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+test("applyReplayRollback: idempotent across cells reusing the same clone (no-op when origin already absent)", async () => {
+  const { repoRoot, seedSha, cleanup } = await makeFixtureRepo();
+  try {
+    // Fixture has no origin remote — applyReplayRollback must not throw.
+    await applyReplayRollback({ worktreePath: repoRoot, baseSha: seedSha });
+    // Second call (simulating the next cell on the same clone) also fine.
+    await applyReplayRollback({ worktreePath: repoRoot, baseSha: seedSha });
+  } finally {
+    await cleanup();
+  }
+});
+
 test("applyReplayRollback: throws on unknown SHA", async () => {
   const { repoRoot, cleanup } = await makeFixtureRepo();
   try {

--- a/src/agent/replay.ts
+++ b/src/agent/replay.ts
@@ -34,6 +34,20 @@ export async function applyReplayRollback(opts: {
   baseSha: string;
 }): Promise<void> {
   await execFile("git", ["-C", opts.worktreePath, "reset", "--hard", opts.baseSha]);
+  // Replay-mode invariant: the agent must encounter the pre-fix codebase
+  // state. Larger trim CLAUDE.mds carry a "sync to main before work" rule
+  // that, when followed, runs `git rebase origin/main` and undoes the
+  // rollback — corrupting the captured diff with every upstream commit
+  // (smoke 2026-05-07 saw 1433 files in a 58KB-trim cell vs 2 files in a
+  // 6KB-trim cell on the same issue). Strip the `origin` remote so any
+  // sync attempt fails fast. `--dry-run` already intercepts push; replay
+  // never reads from origin afterwards.
+  try {
+    await execFile("git", ["-C", opts.worktreePath, "remote", "remove", "origin"]);
+  } catch {
+    // remote may already be absent (e.g. subsequent cells reusing the same
+    // clone where a prior cell stripped it). Best-effort, idempotent.
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
`applyReplayRollback` resets HEAD to the issue's pre-fix `baseSha`, but the larger trim CLAUDE.mds in the curve-redo experiment carry a generic "sync to main before work" rule. When the agent ran `git rebase origin/main`, it advanced HEAD past `baseSha` onto current main, silently undoing the rollback. The post-run diff (taken against `baseSha`) then included every upstream commit, drowning the agent's actual edits in noise.

## Smoke evidence (2026-05-07, leg-2 dispatch on issue #168)
- 6KB trim (CLAUDE.md without the rebase rule): 2 files in captured diff, the agent's real edits.
- 58KB trim (CLAUDE.md with the rebase rule): **1433 files** in captured diff — all 93 commits between baseSha and current main, plus the agent's edit on top. Envelope reason confirmed the rebase: "all 841 tests pass on the rebased branch".

## Fix
Strip the `origin` remote after the hard reset. `git fetch origin` / `git rebase origin/main` / `git pull` all fail fast with a clear "no such remote" error, the agent moves on without the sync, and the captured diff stays scoped to the agent's real edits.

- `--dry-run` already intercepts push; replay never reads from origin afterwards, so removing it has no other side effects.
- Try/catch + idempotent: per-agent clones run multiple cells serially against the same parent clone; the second cell's removal is a no-op once the first cell has stripped origin.

## Test plan
- [x] npm test — 843 pass (was 841; +2 new replay tests).
- [x] New tests assert origin is gone post-rollback and that subsequent calls don't throw.
- [ ] Re-run leg-2 smoke (small + large trim on issue #168) and confirm the large-trim diff is no longer 1433 files.