### PR TITLE
fix(run-tests): npm ci in cell clones so hidden tests can resolve project deps

### DIFF
--- a/src/research/curveStudy/testRunner.test.ts
+++ b/src/research/curveStudy/testRunner.test.ts
@@ -446,6 +446,70 @@ test("runHiddenTests: vitest with custom --test-cmd skips the override config wr
   }
 });
 
+test("runHiddenTests: skips npm ci when package.json is absent (synthetic fixtures)", async () => {
+  const { cloneDir, cleanup: cleanClone } = await makeFixtureClone();
+  const { testsDir, cleanup: cleanTests } = await makeTestsDir(1);
+  try {
+    // Fixture has no package.json. The exec stub records whether npm ran.
+    let cmdsRan: string[] = [];
+    const exec: ExecTestCommand = async ({ cmd }) => {
+      cmdsRan.push(cmd);
+      return { stdout: "# pass 1\n# fail 0\n", stderr: "" };
+    };
+    const r = await runHiddenTests({
+      testsDir,
+      cloneDir,
+      framework: "node-test",
+      baselineOnly: true,
+      execTestCommand: exec,
+    });
+    assert.equal(r.passed, 1);
+    // No node_modules exists, but absence of package.json means we skip
+    // install. Stub-recorded commands must not include "npm ci".
+    assert.ok(
+      !cmdsRan.some((c) => c.startsWith("npm ci")),
+      "npm ci should not run when package.json is absent",
+    );
+  } finally {
+    await cleanClone();
+    await cleanTests();
+  }
+});
+
+test("runHiddenTests: skips npm ci when node_modules already present (operator-managed clones)", async () => {
+  const { cloneDir, cleanup: cleanClone } = await makeFixtureClone();
+  const { testsDir, cleanup: cleanTests } = await makeTestsDir(1);
+  try {
+    // Add a stub package.json + a sentinel node_modules dir so the
+    // "needInstall" branch chooses to skip.
+    await fs.writeFile(
+      path.join(cloneDir, "package.json"),
+      JSON.stringify({ name: "fixture", version: "0.0.0" }),
+    );
+    await fs.mkdir(path.join(cloneDir, "node_modules"));
+    let cmdsRan: string[] = [];
+    const exec: ExecTestCommand = async ({ cmd }) => {
+      cmdsRan.push(cmd);
+      return { stdout: "# pass 1\n# fail 0\n", stderr: "" };
+    };
+    const r = await runHiddenTests({
+      testsDir,
+      cloneDir,
+      framework: "node-test",
+      baselineOnly: true,
+      execTestCommand: exec,
+    });
+    assert.equal(r.passed, 1);
+    assert.ok(
+      !cmdsRan.some((c) => c.startsWith("npm ci")),
+      "npm ci should not run when node_modules already exists",
+    );
+  } finally {
+    await cleanClone();
+    await cleanTests();
+  }
+});
+
 test("runHiddenTests: --test-cmd template substitution", async () => {
   const { cloneDir, cleanup: cleanClone } = await makeFixtureClone();
   const { testsDir, cleanup: cleanTests } = await makeTestsDir(1);

--- a/src/research/curveStudy/testRunner.ts
+++ b/src/research/curveStudy/testRunner.ts
@@ -146,6 +146,44 @@ export async function runHiddenTests(input: RunHiddenTestsInput): Promise<RunHid
     }
   }
 
+  // Step 1.5: install dependencies. Hidden tests import from the source
+  // tree (e.g. `compactClaudeMd.ts` → zod), and a fresh `git clone` has no
+  // node_modules — without this, every test errors with `Cannot find
+  // package 'X'`. Skipped when (a) node_modules already exists (operator-
+  // managed clones, idempotent re-runs), or (b) the clone has no
+  // package.json (synthetic test fixtures + corner-case repos that don't
+  // need installs). `npm ci --no-audit --no-fund --silent` is ~2-3s warm.
+  let needInstall = false;
+  try {
+    await fs.access(path.join(input.cloneDir, "package.json"));
+    try {
+      await fs.access(path.join(input.cloneDir, "node_modules"));
+    } catch {
+      needInstall = true;
+    }
+  } catch {
+    // no package.json — skip install entirely
+  }
+  if (needInstall) {
+    try {
+      await execFile("npm", ["ci", "--no-audit", "--no-fund", "--silent"], {
+        cwd: input.cloneDir,
+        timeout: 5 * 60 * 1000,
+        maxBuffer: 32 * 1024 * 1024,
+      });
+    } catch (err) {
+      return {
+        passed: 0,
+        failed: 0,
+        errored: 0,
+        total: 0,
+        applyCleanly,
+        runtimeMs: Date.now() - start,
+        errorReason: `npm ci failed: ${(err as { stderr?: string }).stderr ?? (err as Error).message}`,
+      };
+    }
+  }
+
   // Step 2: copy hidden tests into the clone.
   const destDir = path.join(input.cloneDir, destRelDir);
   const copiedRelPaths: string[] = [];


### PR DESCRIPTION
## Summary
`runHiddenTests` clones at the issue's baseSha then applies the cell's diff and runs the framework, but it never installs project dependencies. Hidden tests import from the source tree (`compactClaudeMd.ts` → zod, etc.); without `node_modules` every test errors with `ERR_MODULE_NOT_FOUND` and the B-score collapses to 0/100 with no signal in the result JSON beyond \`applyCleanly: true\`.

## Smoke evidence (2026-05-07, leg-2 issue #168, agent-916a-trim-6000)
\`applyCleanly: true, total: 100, passed: 0, failed: 100\` — every test errored on \`Cannot find package 'zod' imported from .../compactClaudeMd.ts\`.

## Fix
Run \`npm ci --no-audit --no-fund --silent\` between diff-apply and test-copy. ~2-3s when the npm cache is warm.

Skipped when:
- \`node_modules\` already exists (operator-managed clones, idempotent re-runs).
- The clone has no \`package.json\` (existing synthetic test fixtures don't need installs).

## Test plan
- [x] \`npm test\` — 843 pass (was 841; +2 new tests cover both skip conditions).
- [x] New tests assert npm ci is skipped when package.json is absent and when node_modules already exists.
- [ ] Re-run leg-2 smoke and confirm B-score is non-zero.