### PR TITLE
study(curve-redo): scripts for orchestrator-picked specialists vs. trim baseline

### DIFF
--- a/feature-plans/curve-redo-bundle/specialist-redo/README.md
+++ b/feature-plans/curve-redo-bundle/specialist-redo/README.md
@@ -1,0 +1,68 @@
+# curve-redo specialist follow-up — operator scripts
+
+Implementation of the experiment plan in
+[`feature-plans/curve-redo-specialist-followup-plan.md`](../../curve-redo-specialist-followup-plan.md)
+(merged via [PR #231](https://github.com/szhygulin/vaultpilot-development-agents/pull/231)).
+
+The four scripts here drive the four execution stages:
+
+| Step | Script | Output |
+|------|--------|--------|
+| 1. Pick | `pick-specialists.cjs` | `picks.tsv` |
+| 2. Dispatch (per leg) | `dispatch-specialist-redo.sh <leg>` | `logs-leg<leg>/`, `diffs-leg<leg>/` |
+| 3. Score (per leg) | `score-specialist-redo.sh <leg>` | `scores-leg<leg>/` |
+| 4. Combine + compare | `combine-and-compare.cjs` | `specialist-redo-comparison.json` |
+
+Outputs land under `feature-plans/curve-redo-data/specialist-redo/` (gitignored
+per `.gitignore`). Override the location with `OUT_DIR=<path>` for the shell
+scripts, or `--out`/`--output` for the cjs scripts.
+
+Build first (`npm run build`) — the cjs scripts load `dist/src/...` modules.
+
+## Quick start
+
+```bash
+# 1. Pick — emits picks.tsv. Asserts no trim agents.
+node feature-plans/curve-redo-bundle/specialist-redo/pick-specialists.cjs \
+  --corpus feature-plans/curve-redo-bundle/corpus.json \
+  --out feature-plans/curve-redo-data/specialist-redo/picks.tsv
+
+# 2. Smoke a single cell — the dispatch script's --dry-print shows the
+#    `vp-dev spawn` command without executing.
+bash feature-plans/curve-redo-bundle/specialist-redo/dispatch-specialist-redo.sh 1 --dry-print
+
+# 3. Dispatch leg 1 then leg 2 (~30 min each, sequential per agent's clone).
+bash feature-plans/curve-redo-bundle/specialist-redo/dispatch-specialist-redo.sh 1
+bash feature-plans/curve-redo-bundle/specialist-redo/dispatch-specialist-redo.sh 2
+
+# 4. Score (~15 min total, ~$20 in Opus K=3 grading).
+bash feature-plans/curve-redo-bundle/specialist-redo/score-specialist-redo.sh 1
+bash feature-plans/curve-redo-bundle/specialist-redo/score-specialist-redo.sh 2
+
+# 5. Combine + compare against the merged trim baseline.
+node feature-plans/curve-redo-bundle/specialist-redo/combine-and-compare.cjs \
+  --baseline-leg1-logs   feature-plans/curve-redo-data/leg1-baseline/logs-leg1 \
+  --baseline-leg1-scores feature-plans/curve-redo-data/leg1-baseline/scores-leg1 \
+  --baseline-leg2-logs   feature-plans/curve-redo-data/leg2-baseline/logs-leg2 \
+  --baseline-leg2-scores feature-plans/curve-redo-data/leg2-baseline/scores-leg2 \
+  --treatment-leg1-logs   feature-plans/curve-redo-data/specialist-redo/logs-leg1 \
+  --treatment-leg1-scores feature-plans/curve-redo-data/specialist-redo/scores-leg1 \
+  --treatment-leg2-logs   feature-plans/curve-redo-data/specialist-redo/logs-leg2 \
+  --treatment-leg2-scores feature-plans/curve-redo-data/specialist-redo/scores-leg2 \
+  --picks feature-plans/curve-redo-data/specialist-redo/picks.tsv \
+  --output feature-plans/curve-redo-data/specialist-redo/specialist-redo-comparison.json
+```
+
+## Defense-in-depth cost caps
+
+`dispatch-specialist-redo.sh` honors:
+
+* `VP_DEV_MAX_COST_USD` — per-cell cap (default `$10`).
+* `MAX_TOTAL_COST_USD` — running-sum cap across the loop (default `$200`).
+  Aborts with exit 3 when reached.
+
+## Trim-contamination assertion
+
+`pick-specialists.cjs` filters all `^agent-916a-trim-` agents out of the
+registry view it hands to `pickAgents()` and re-asserts post-pick that no
+trim agent slipped through. Exit 1 on violation.

--- a/feature-plans/curve-redo-bundle/specialist-redo/combine-and-compare.cjs
+++ b/feature-plans/curve-redo-bundle/specialist-redo/combine-and-compare.cjs
@@ -1,0 +1,352 @@
+#!/usr/bin/env node
+// Curve-redo follow-up — Step 8 of feature-plans/curve-redo-specialist-followup-plan.md.
+//
+// Pairs orchestrator-picked specialists (treatment) against the merged trim
+// baseline (control) per issue and runs a one-sided paired Wilcoxon test.
+// Per-cell quality uses the same A+B formula as combine-legs.cjs (judge ∈
+// 0..50 + hidden-test pass rate ∈ 0..50, or 2A for pushback) — no envelope-
+// label shortcut.
+//
+// Usage:
+//   node combine-and-compare.cjs \
+//     --baseline-leg1-logs <dir> --baseline-leg1-scores <dir> \
+//     --baseline-leg2-logs <dir> --baseline-leg2-scores <dir> \
+//     --treatment-leg1-logs <dir> --treatment-leg1-scores <dir> \
+//     --treatment-leg2-logs <dir> --treatment-leg2-scores <dir> \
+//     --picks <picks.tsv> \
+//     --output <comparison.json>
+//
+// Reads built dist/ — run `npm run build` first.
+
+const path = require("node:path");
+const fs = require("node:fs");
+
+function parseArgs() {
+  const args = {};
+  const argv = process.argv.slice(2);
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    if (k.startsWith("--") && i + 1 < argv.length) {
+      args[k.slice(2)] = argv[i + 1];
+      i++;
+    }
+  }
+  return args;
+}
+
+const REQUIRED = [
+  "baseline-leg1-logs",
+  "baseline-leg1-scores",
+  "baseline-leg2-logs",
+  "baseline-leg2-scores",
+  "treatment-leg1-logs",
+  "treatment-leg1-scores",
+  "treatment-leg2-logs",
+  "treatment-leg2-scores",
+  "picks",
+  "output",
+];
+
+const BASELINE_PREFIX = "curveStudy-";
+const TREATMENT_LOG_RE = /^bench-r(\d+)-(agent-[a-z0-9-]+)-(\d+)\.log$/;
+
+function dirExists(p) {
+  try {
+    return fs.statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function readBaselineCells(logsDir, qualityFromAB, scores) {
+  if (!dirExists(logsDir)) return [];
+  const { aggregateLog } = require(path.join(distRoot, "research", "curveStudy", "aggregate.js"));
+  const re = new RegExp(`^${BASELINE_PREFIX}(agent-[a-z0-9-]+)-(\\d+)\\.log$`);
+  const out = [];
+  for (const f of fs.readdirSync(logsDir).sort()) {
+    const m = re.exec(f);
+    if (!m) continue;
+    const agentId = m[1];
+    const issueId = Number(m[2]);
+    const cell = await aggregateLog({
+      logPath: path.join(logsDir, f),
+      agentId,
+      agentSizeBytes: 0,
+      issueId,
+    });
+    if (!cell) continue;
+    const cellKey = `${agentId}-${issueId}`;
+    const sc = scores.get(cellKey);
+    const quality = qualityFromAB({
+      decision: cell.decision,
+      judge: sc?.judge,
+      test: sc?.test,
+    });
+    out.push({
+      arm: "baseline",
+      agentId,
+      issueId,
+      decision: cell.decision,
+      costUsd: cell.costUsd,
+      quality,
+      log: cell.log,
+    });
+  }
+  return out;
+}
+
+async function readTreatmentCells(logsDir, qualityFromAB, scores) {
+  if (!dirExists(logsDir)) return [];
+  const { aggregateLog } = require(path.join(distRoot, "research", "curveStudy", "aggregate.js"));
+  const out = [];
+  for (const f of fs.readdirSync(logsDir).sort()) {
+    const m = TREATMENT_LOG_RE.exec(f);
+    if (!m) continue;
+    const replicate = Number(m[1]);
+    const agentId = m[2];
+    const issueId = Number(m[3]);
+    const cell = await aggregateLog({
+      logPath: path.join(logsDir, f),
+      agentId,
+      agentSizeBytes: 0,
+      issueId,
+    });
+    if (!cell) continue;
+    // Treatment scores live under the bench-r<N>-<agent>-<issue> key (the
+    // dispatch script writes them with that filename stem). cellScores's
+    // loadCellScores derives the key by stripping the -tests.json /
+    // -judge.json suffix, so the prefix is preserved.
+    const cellKey = `bench-r${replicate}-${agentId}-${issueId}`;
+    const sc = scores.get(cellKey);
+    const quality = qualityFromAB({
+      decision: cell.decision,
+      judge: sc?.judge,
+      test: sc?.test,
+    });
+    out.push({
+      arm: "treatment",
+      agentId,
+      issueId,
+      replicate,
+      decision: cell.decision,
+      costUsd: cell.costUsd,
+      quality,
+      log: cell.log,
+    });
+  }
+  return out;
+}
+
+let distRoot;
+
+async function main() {
+  const args = parseArgs();
+  for (const r of REQUIRED) {
+    if (!args[r]) {
+      process.stderr.write(`Missing --${r}\n`);
+      process.stderr.write(`Required flags: ${REQUIRED.map((x) => "--" + x).join(" ")}\n`);
+      process.exit(1);
+    }
+  }
+
+  const repoRoot = path.resolve(__dirname, "..", "..", "..");
+  distRoot = path.join(repoRoot, "dist", "src");
+  const { qualityFromAB } = require(path.join(distRoot, "research", "curveStudy", "cellScores.js"));
+  const { loadCellScores } = require(path.join(distRoot, "research", "curveStudy", "cellScores.js"));
+  const { wilcoxonSignedRankPaired, hedgesG, mean, median, coefficientOfVariation } =
+    require(path.join(distRoot, "research", "specialistBench", "stats.js"));
+
+  // Load all four score directories (baseline × 2 legs, treatment × 2 legs).
+  const [bs1, bs2, ts1, ts2] = await Promise.all([
+    loadCellScores(args["baseline-leg1-scores"]),
+    loadCellScores(args["baseline-leg2-scores"]),
+    loadCellScores(args["treatment-leg1-scores"]),
+    loadCellScores(args["treatment-leg2-scores"]),
+  ]);
+  const baselineScores = new Map([...bs1, ...bs2]);
+  const treatmentScores = new Map([...ts1, ...ts2]);
+
+  // Read both arms.
+  const baselineCells = [
+    ...(await readBaselineCells(args["baseline-leg1-logs"], qualityFromAB, baselineScores)),
+    ...(await readBaselineCells(args["baseline-leg2-logs"], qualityFromAB, baselineScores)),
+  ];
+  const treatmentCells = [
+    ...(await readTreatmentCells(args["treatment-leg1-logs"], qualityFromAB, treatmentScores)),
+    ...(await readTreatmentCells(args["treatment-leg2-logs"], qualityFromAB, treatmentScores)),
+  ];
+
+  // Group by issue.
+  const byIssue = (cells) => {
+    const m = new Map();
+    for (const c of cells) {
+      let b = m.get(c.issueId);
+      if (!b) {
+        b = [];
+        m.set(c.issueId, b);
+      }
+      b.push(c);
+    }
+    return m;
+  };
+  const baselineByIssue = byIssue(baselineCells);
+  const treatmentByIssue = byIssue(treatmentCells);
+
+  // Issues paired in both arms.
+  const pairedIssueIds = [...treatmentByIssue.keys()]
+    .filter((id) => baselineByIssue.has(id))
+    .sort((a, b) => a - b);
+
+  // Picks → rationale lookup for stratification.
+  const picks = new Map();
+  if (fs.existsSync(args.picks)) {
+    const raw = fs.readFileSync(args.picks, "utf-8");
+    const lines = raw.split(/\r?\n/);
+    for (const line of lines) {
+      if (!line || line.startsWith("issueId\t")) continue;
+      const parts = line.split("\t");
+      const issueId = Number(parts[0]);
+      const agentId = parts[1];
+      const rationale = parts[2];
+      if (Number.isFinite(issueId)) picks.set(issueId, { agentId, rationale });
+    }
+  }
+
+  const perIssue = [];
+  for (const issueId of pairedIssueIds) {
+    const tCells = treatmentByIssue.get(issueId);
+    const bCells = baselineByIssue.get(issueId);
+    const tQ = tCells.map((c) => c.quality);
+    const bQ = bCells.map((c) => c.quality);
+    const tCost = tCells.map((c) => c.costUsd);
+    const bCost = bCells.map((c) => c.costUsd);
+    const tMeanQ = mean(tQ);
+    const bMeanQ = mean(bQ);
+    const tMeanCost = mean(tCost);
+    const bMedianCost = median(bCost);
+    const tQualityCv = coefficientOfVariation(tQ);
+    const tCostCv = coefficientOfVariation(tCost);
+    const pick = picks.get(issueId);
+    perIssue.push({
+      issueId,
+      treatmentMeanQuality: tMeanQ,
+      baselineMeanQuality: bMeanQ,
+      dQuality: tMeanQ - bMeanQ,
+      treatmentMeanCostUsd: tMeanCost,
+      baselineMedianCostUsd: bMedianCost,
+      dCost: tMeanCost - bMedianCost,
+      treatmentReplicateCount: tCells.length,
+      baselineCellCount: bCells.length,
+      treatmentQualityCv: tQualityCv,
+      treatmentCostCv: tCostCv,
+      pickedAgentId: pick?.agentId ?? null,
+      pickRationale: pick?.rationale ?? null,
+    });
+  }
+
+  // Primary test: paired Wilcoxon, one-sided "greater" on dQuality.
+  const dQs = perIssue.map((p) => p.dQuality);
+  const dCosts = perIssue.map((p) => p.dCost);
+  const wilcoxonQuality = perIssue.length >= 1
+    ? wilcoxonSignedRankPaired(dQs, "greater")
+    : null;
+  const wilcoxonCost = perIssue.length >= 1
+    ? wilcoxonSignedRankPaired(dCosts, "less")
+    : null;
+  const hedgesQuality = perIssue.length >= 2 ? hedgesG(dQs) : Number.NaN;
+
+  // Stratify by rationale.
+  const byRationale = new Map();
+  for (const p of perIssue) {
+    const r = p.pickRationale ?? "(unmatched)";
+    let bucket = byRationale.get(r);
+    if (!bucket) {
+      bucket = [];
+      byRationale.set(r, bucket);
+    }
+    bucket.push(p);
+  }
+  const stratified = [...byRationale.entries()]
+    .map(([rationale, items]) => ({
+      rationale,
+      issueCount: items.length,
+      meanDQuality: items.length > 0 ? mean(items.map((p) => p.dQuality)) : Number.NaN,
+      meanDCost: items.length > 0 ? mean(items.map((p) => p.dCost)) : Number.NaN,
+    }))
+    .sort((a, b) => a.rationale.localeCompare(b.rationale));
+
+  const output = {
+    generatedAt: new Date().toISOString(),
+    baselineArm: {
+      cellCount: baselineCells.length,
+      uniqueIssues: baselineByIssue.size,
+    },
+    treatmentArm: {
+      cellCount: treatmentCells.length,
+      uniqueIssues: treatmentByIssue.size,
+    },
+    pairedIssueCount: pairedIssueIds.length,
+    perIssue,
+    test: {
+      hypothesis: "median(dQuality = treatment - baseline) > 0",
+      wilcoxonQuality,
+      wilcoxonCost,
+      hedgesGQuality: hedgesQuality,
+    },
+    picksDistribution: stratified,
+  };
+
+  fs.mkdirSync(path.dirname(path.resolve(args.output)), { recursive: true });
+  fs.writeFileSync(args.output, JSON.stringify(output, null, 2) + "\n");
+
+  // Headline (also used by the empty-result smoke check). Avoid raw NaN /
+  // Infinity in output text per CLAUDE.md "smoke-test the empty-result path".
+  const fmt = (x, digits = 3) => (Number.isFinite(x) ? x.toFixed(digits) : "n/a");
+  process.stdout.write(`\n=== specialist-redo paired comparison ===\n`);
+  process.stdout.write(
+    `baseline cells: ${baselineCells.length} (${baselineByIssue.size} issues); ` +
+      `treatment cells: ${treatmentCells.length} (${treatmentByIssue.size} issues)\n`,
+  );
+  process.stdout.write(`paired issues (intersection): ${pairedIssueIds.length}\n\n`);
+  if (perIssue.length === 0) {
+    process.stdout.write(`No paired issues — nothing to test.\n`);
+    process.stdout.write(`Output written to ${args.output}.\n`);
+    return;
+  }
+  process.stdout.write(
+    `issueId\ttreatQ\tbaseQ\tdQ\ttreatCost\tbaseCost\tdCost\trationale\tagent\n`,
+  );
+  for (const p of perIssue) {
+    process.stdout.write(
+      `${p.issueId}\t${fmt(p.treatmentMeanQuality, 1)}\t${fmt(p.baselineMeanQuality, 1)}\t` +
+        `${fmt(p.dQuality, 1)}\t$${fmt(p.treatmentMeanCostUsd, 2)}\t$${fmt(p.baselineMedianCostUsd, 2)}\t` +
+        `$${fmt(p.dCost, 2)}\t${p.pickRationale ?? "?"}\t${p.pickedAgentId ?? "?"}\n`,
+    );
+  }
+  process.stdout.write(`\n`);
+  if (wilcoxonQuality) {
+    process.stdout.write(
+      `Wilcoxon (quality, H1: dQ > 0): n=${wilcoxonQuality.n}, w+=${fmt(wilcoxonQuality.wPlus, 1)}, ` +
+        `z=${fmt(wilcoxonQuality.z, 3)}, p=${fmt(wilcoxonQuality.pValue, 4)}\n`,
+    );
+  }
+  if (wilcoxonCost) {
+    process.stdout.write(
+      `Wilcoxon (cost,    H1: dCost < 0): n=${wilcoxonCost.n}, w+=${fmt(wilcoxonCost.wPlus, 1)}, ` +
+        `z=${fmt(wilcoxonCost.z, 3)}, p=${fmt(wilcoxonCost.pValue, 4)}\n`,
+    );
+  }
+  process.stdout.write(`Hedges' g (quality): ${fmt(hedgesQuality, 3)}\n\n`);
+  process.stdout.write(`Picks distribution / per-rationale stratification:\n`);
+  for (const s of stratified) {
+    process.stdout.write(
+      `  ${s.rationale}: n=${s.issueCount}, mean dQ=${fmt(s.meanDQuality, 1)}, mean dCost=$${fmt(s.meanDCost, 2)}\n`,
+    );
+  }
+  process.stdout.write(`\nOutput written to ${args.output}.\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`${err.stack ?? err}\n`);
+  process.exit(1);
+});

--- a/feature-plans/curve-redo-bundle/specialist-redo/dispatch-specialist-redo.sh
+++ b/feature-plans/curve-redo-bundle/specialist-redo/dispatch-specialist-redo.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# Curve-redo follow-up — Step 6 of feature-plans/curve-redo-specialist-followup-plan.md.
+#
+# For each (issueId, agentId) row in picks.tsv that matches the requested leg,
+# spawns K replicate cells via `vp-dev spawn`. Each cell:
+#   * runs in --dry-run mode (intercepts push/PR)
+#   * suppresses the live target-repo CLAUDE.md (--no-target-claude-md) so the
+#     effective context = picked agent's per-agent CLAUDE.md only — same
+#     isolation contract as leg-1 of curve-redo
+#   * captures the post-run diff via --capture-diff-path so the scorer's
+#     testRunner can apply it
+#   * passes --skip-summary so the agent's CLAUDE.md doesn't drift across
+#     replicates
+#   * uses claude-sonnet-4-6 to match the merged trim baseline's tier
+#   * (closed leg-2 issues only) rolls the worktree to baseSha via
+#     --replay-base-sha and forwards --allow-closed-issue + --issue-body-only
+#
+# Cells run serially. The 2026-05-07 picker dry-run collapsed all 13 issues to
+# a single agent, so cross-agent parallelism was zero-benefit anyway. Adding
+# parallelism is an operator follow-up if/when the picker distribution changes.
+#
+# Usage:
+#   bash dispatch-specialist-redo.sh <leg> [--dry-print]
+#     <leg>          1 or 2
+#     --dry-print    print the spawn commands without executing
+#
+# Required environment / file layout (relative to repo root):
+#   feature-plans/curve-redo-bundle/corpus.json
+#   $OUT_DIR/picks.tsv                          (default OUT_DIR=feature-plans/curve-redo-data/specialist-redo)
+#   $OUT_DIR/logs-leg<leg>/                     (created)
+#   $OUT_DIR/diffs-leg<leg>/                    (created)
+#
+# Cost defense in depth:
+#   * VP_DEV_MAX_COST_USD per cell (caller-overridable, default 10)
+#   * MAX_TOTAL_COST_USD across the loop (caller-overridable, default 200);
+#     dispatch aborts with exit 3 when the running sum (parsed from each
+#     cell's envelope JSON) exceeds the cap.
+
+set -euo pipefail
+
+LEG="${1:-}"
+DRY_PRINT=false
+if [[ "${2:-}" == "--dry-print" ]]; then DRY_PRINT=true; fi
+if [[ "$LEG" != "1" && "$LEG" != "2" ]]; then
+  echo "Usage: $0 <1|2> [--dry-print]" >&2
+  exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+OUT_DIR="${OUT_DIR:-$REPO_ROOT/feature-plans/curve-redo-data/specialist-redo}"
+CORPUS="$REPO_ROOT/feature-plans/curve-redo-bundle/corpus.json"
+PICKS="$OUT_DIR/picks.tsv"
+LOGS_DIR="$OUT_DIR/logs-leg${LEG}"
+DIFFS_DIR="$OUT_DIR/diffs-leg${LEG}"
+
+REPLICATES="${REPLICATES:-3}"
+MODEL="${MODEL:-claude-sonnet-4-6}"
+MAX_TOTAL_COST_USD="${MAX_TOTAL_COST_USD:-200}"
+export VP_DEV_MAX_COST_USD="${VP_DEV_MAX_COST_USD:-10}"
+
+if [[ ! -f "$PICKS" ]]; then
+  echo "ERROR: picks.tsv not found at $PICKS — run pick-specialists.cjs first." >&2
+  exit 2
+fi
+if [[ ! -f "$CORPUS" ]]; then
+  echo "ERROR: corpus.json not found at $CORPUS." >&2
+  exit 2
+fi
+
+mkdir -p "$LOGS_DIR" "$DIFFS_DIR"
+
+echo "[$(date -Iseconds)] dispatch-specialist-redo: leg=$LEG K=$REPLICATES model=$MODEL" >&2
+echo "  out_dir=$OUT_DIR" >&2
+echo "  per-cell cap=\$$VP_DEV_MAX_COST_USD; total cap=\$$MAX_TOTAL_COST_USD" >&2
+
+# Parse corpus once via node — bash JSON is a footgun. Emits one TSV line per
+# leg-matching corpus entry: issueId\trepo\tstate\tdecisionClass\tbaseSha
+CORPUS_TSV="$(node -e '
+  const fs = require("node:fs");
+  const c = JSON.parse(fs.readFileSync(process.argv[1], "utf-8"));
+  const leg = Number(process.argv[2]);
+  for (const i of c.issues) {
+    if (Number(i.leg) !== leg) continue;
+    const sha = i.baseSha || "";
+    const state = i.state || "open";
+    const cls = i.decisionClass || "";
+    process.stdout.write([i.issueId, i.repo, state, cls, sha].join("\t") + "\n");
+  }
+' "$CORPUS" "$LEG")"
+
+if [[ -z "$CORPUS_TSV" ]]; then
+  echo "ERROR: no corpus issues found for leg=$LEG." >&2
+  exit 2
+fi
+
+# Build a per-issue lookup of repo / state / baseSha so we don't re-parse.
+declare -A ISSUE_REPO ISSUE_STATE ISSUE_SHA
+while IFS=$'\t' read -r issueId repo state cls sha; do
+  ISSUE_REPO["$issueId"]="$repo"
+  ISSUE_STATE["$issueId"]="$state"
+  ISSUE_SHA["$issueId"]="$sha"
+done <<<"$CORPUS_TSV"
+
+LEG_ISSUE_IDS=()
+while IFS=$'\t' read -r issueId _ _ _ _; do
+  LEG_ISSUE_IDS+=("$issueId")
+done <<<"$CORPUS_TSV"
+
+# Read picks.tsv (skip header) into an issueId→agentId map for the leg's
+# issues. Pre-asserts: no trim-prefixed agentIds.
+declare -A PICKED
+while IFS=$'\t' read -r issueId agentId rationale score pickedLeg labels; do
+  if [[ "$issueId" == "issueId" ]]; then continue; fi
+  if [[ -z "$agentId" || "$agentId" == "fresh-mint" ]]; then
+    echo "WARN: issue #$issueId has no concrete pick (rationale=$rationale) — skipping." >&2
+    continue
+  fi
+  if [[ "$agentId" =~ ^agent-916a-trim- ]]; then
+    echo "ERROR: trim agent $agentId leaked into picks for issue #$issueId. Re-run pick-specialists.cjs." >&2
+    exit 4
+  fi
+  PICKED["$issueId"]="$agentId"
+done <"$PICKS"
+
+# Resolve the clone path for a target repo. Mirrors `resolveTargetRepoPath` in
+# src/git/worktree.ts: defaults to $HOME/dev/<repo-name>. The whole loop runs
+# serially (one cell at a time), so a single shared clone per repo is safe —
+# `vp-dev spawn` manages its own worktrees inside the clone.
+clone_path_for_repo() {
+  local repo="$1"
+  local name="${repo##*/}"
+  local p; p="${HOME:-/home}/dev/$name"
+  if [[ ! -d "$p/.git" ]]; then
+    echo "ERROR: no clone at $p for repo $repo. Clone it (gh repo clone $repo) before dispatching." >&2
+    return 1
+  fi
+  echo "$p"
+}
+
+# Group dispatch by agent so cells on the same clone serialize naturally.
+declare -A SEEN_AGENTS
+ORDERED_AGENTS=()
+for issueId in "${LEG_ISSUE_IDS[@]}"; do
+  agent="${PICKED[$issueId]:-}"
+  if [[ -z "$agent" ]]; then continue; fi
+  if [[ -z "${SEEN_AGENTS[$agent]:-}" ]]; then
+    SEEN_AGENTS["$agent"]=1
+    ORDERED_AGENTS+=("$agent")
+  fi
+done
+
+cell_count=0
+for agent in "${ORDERED_AGENTS[@]}"; do
+  for issueId in "${LEG_ISSUE_IDS[@]}"; do
+    if [[ "${PICKED[$issueId]:-}" != "$agent" ]]; then continue; fi
+    cell_count=$((cell_count + REPLICATES))
+  done
+done
+
+echo "  unique agents: ${#ORDERED_AGENTS[@]}; cells (issues × K): $cell_count" >&2
+
+total_cost=0
+cells_done=0
+
+# Best-effort cost extractor — mirror specialistBench/dispatch.ts:153-159 so
+# the loop sees the same `costUsd` field the orchestrator emits.
+extract_cost() {
+  local log="$1"
+  python3 -c '
+import json, sys, re
+text = open(sys.argv[1]).read()
+# vp-dev spawn writes a top-level JSON to stdout containing costUsd.
+m = re.search(r"\"costUsd\"\s*:\s*([0-9.]+)", text)
+print(m.group(1) if m else "0")
+' "$log" 2>/dev/null || echo 0
+}
+
+for agent in "${ORDERED_AGENTS[@]}"; do
+  for issueId in "${LEG_ISSUE_IDS[@]}"; do
+    if [[ "${PICKED[$issueId]:-}" != "$agent" ]]; then continue; fi
+    repo="${ISSUE_REPO[$issueId]}"
+    state="${ISSUE_STATE[$issueId]}"
+    sha="${ISSUE_SHA[$issueId]}"
+
+    if ! clone="$(clone_path_for_repo "$repo")"; then
+      exit 5
+    fi
+
+    for r in $(seq 1 "$REPLICATES"); do
+      if (( $(echo "$total_cost >= $MAX_TOTAL_COST_USD" | bc -l) )); then
+        echo "[$(date -Iseconds)] BUDGET EXHAUSTED at \$$total_cost — aborting." >&2
+        exit 3
+      fi
+
+      cell_id="bench-r${r}-${agent}-${issueId}"
+      log_path="$LOGS_DIR/${cell_id}.log"
+      diff_path="$DIFFS_DIR/${cell_id}.diff"
+
+      if [[ -s "$log_path" ]]; then
+        echo "[$(date -Iseconds)] skip (already exists): $cell_id" >&2
+        cells_done=$((cells_done + 1))
+        continue
+      fi
+
+      cmd=(npm run vp-dev -- spawn
+        --agent "$agent"
+        --issue "$issueId"
+        --target-repo "$repo"
+        --target-repo-path "$clone"
+        --dry-run
+        --no-target-claude-md
+        --skip-summary
+        --model "$MODEL"
+        --capture-diff-path "$diff_path")
+
+      if [[ "$state" == "closed" ]]; then
+        cmd+=(--allow-closed-issue --issue-body-only)
+        if [[ -n "$sha" ]]; then
+          cmd+=(--replay-base-sha "$sha")
+        fi
+      fi
+
+      cells_done=$((cells_done + 1))
+      echo "[$(date -Iseconds)] [$cells_done/$cell_count] $cell_id (clone=$clone)" >&2
+
+      if $DRY_PRINT; then
+        printf '  '; printf '%q ' "${cmd[@]}"; echo
+        continue
+      fi
+
+      if ! (cd "$REPO_ROOT" && "${cmd[@]}") >"$log_path" 2>&1; then
+        echo "  WARN: spawn exited non-zero — log preserved at $log_path" >&2
+      fi
+
+      delta="$(extract_cost "$log_path")"
+      total_cost="$(echo "$total_cost + $delta" | bc -l)"
+      echo "  cost: +\$$delta (running \$$total_cost)" >&2
+    done
+  done
+done
+
+echo "[$(date -Iseconds)] dispatch-specialist-redo: leg=$LEG complete. cells=$cells_done total_cost=\$$total_cost" >&2

--- a/feature-plans/curve-redo-bundle/specialist-redo/pick-specialists.cjs
+++ b/feature-plans/curve-redo-bundle/specialist-redo/pick-specialists.cjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+// Curve-redo follow-up — Step 2 of feature-plans/curve-redo-specialist-followup-plan.md.
+//
+// For each issue in the corpus, calls the orchestrator's pickAgents() as a
+// library, with the 18 trim agents filtered out via a regOverride copy (no
+// registry mutation), and writes one row to picks.tsv:
+//
+//   issueId\tagentId\trationale\tscore\tleg
+//
+// Usage:
+//   node feature-plans/curve-redo-bundle/specialist-redo/pick-specialists.cjs \
+//     --corpus feature-plans/curve-redo-bundle/corpus.json \
+//     --out feature-plans/curve-redo-data/specialist-redo/picks.tsv \
+//     [--registry state/agents-registry.json]    # default: state/agents-registry.json
+//     [--target-repo szhygulin/vaultpilot-mcp]   # passed to gh issue view
+//
+// Reads built dist/ — run `npm run build` first.
+
+const path = require("node:path");
+const fs = require("node:fs");
+const { execFileSync } = require("node:child_process");
+
+function parseArgs() {
+  const args = {};
+  const argv = process.argv.slice(2);
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    if (k.startsWith("--") && i + 1 < argv.length) {
+      args[k.slice(2)] = argv[i + 1];
+      i++;
+    }
+  }
+  return args;
+}
+
+function fetchLabels(issueId, repo) {
+  // gh issue view returns {labels:[{name,...}]}; for closed-leg issues the
+  // labels may be empty or stripped. The plan's findings note 8/13 issues have
+  // 0 labels — that collapse is intentional surface-area data, not a bug.
+  try {
+    const out = execFileSync("gh", [
+      "issue",
+      "view",
+      String(issueId),
+      "--repo",
+      repo,
+      "--json",
+      "labels",
+    ], { encoding: "utf-8" });
+    const parsed = JSON.parse(out);
+    return parsed.labels.map((l) => l.name);
+  } catch (err) {
+    process.stderr.write(`WARN: gh issue view failed for ${repo}#${issueId}: ${err.message}\n`);
+    return [];
+  }
+}
+
+async function main() {
+  const args = parseArgs();
+  const required = ["corpus", "out"];
+  for (const r of required) {
+    if (!args[r]) {
+      process.stderr.write(`Missing --${r}\n`);
+      process.stderr.write(
+        "Usage: pick-specialists.cjs --corpus <path> --out <path> [--registry <path>] [--target-repo <owner/repo>]\n",
+      );
+      process.exit(1);
+    }
+  }
+
+  const repoRoot = path.resolve(__dirname, "..", "..", "..");
+  const distRoot = path.join(repoRoot, "dist", "src");
+  const orchestrator = require(path.join(distRoot, "orchestrator", "orchestrator.js"));
+  if (typeof orchestrator.pickAgents !== "function") {
+    process.stderr.write(
+      "ERROR: dist/src/orchestrator/orchestrator.js does not export pickAgents — run `npm run build` first.\n",
+    );
+    process.exit(1);
+  }
+
+  const registryPath = args.registry ?? path.join(repoRoot, "state", "agents-registry.json");
+  const reg = JSON.parse(fs.readFileSync(registryPath, "utf-8"));
+
+  // Filter trim agents BEFORE pickAgents sees them. The trim agents share
+  // agent-916a's tag set and would dominate Jaccard scores against any issue
+  // they'd previously been benchmarked on. Filtering keeps them in the
+  // on-disk registry (no mutation) while excluding them from this picker
+  // call. Plan §"Trim contamination of picks".
+  const TRIM_RE = /^agent-916a-trim-/;
+  const filteredAgents = reg.agents.filter((a) => !TRIM_RE.test(a.agentId));
+  const filteredCount = reg.agents.length - filteredAgents.length;
+  process.stderr.write(
+    `Registry: ${reg.agents.length} total agents, ${filteredCount} trim filtered, ${filteredAgents.length} eligible.\n`,
+  );
+  const regOverride = { ...reg, agents: filteredAgents };
+
+  const corpus = JSON.parse(fs.readFileSync(args.corpus, "utf-8"));
+  if (!Array.isArray(corpus.issues)) {
+    process.stderr.write("ERROR: corpus JSON has no `issues` array.\n");
+    process.exit(1);
+  }
+
+  const rows = [];
+  for (const issue of corpus.issues) {
+    const repo = args["target-repo"] ?? issue.repo;
+    if (!repo) {
+      process.stderr.write(
+        `ERROR: corpus entry for issue #${issue.issueId} has no repo and no --target-repo override.\n`,
+      );
+      process.exit(1);
+    }
+    const labels = fetchLabels(issue.issueId, repo);
+    const issueSummary = {
+      id: issue.issueId,
+      title: issue.title ?? "",
+      labels,
+      // pickAgents accepts both open and closed; state isn't part of the
+      // scoring formula. Closed-leg issues run via --replay-base-sha at
+      // dispatch time. Use the corpus value verbatim.
+      state: issue.state ?? "open",
+    };
+    const result = orchestrator.pickAgents({
+      reg: regOverride,
+      pendingIssues: [issueSummary],
+      maxParallelism: 1,
+    });
+    if (result.reusedAgents.length === 0) {
+      // pickAgents returns no agents when the cap is 0 OR no issues are
+      // pending OR the registry is empty. With cap=1 and one issue, this
+      // means newAgentsToMint=1 — record the fresh-mint intent.
+      rows.push({
+        issueId: issue.issueId,
+        agentId: "fresh-mint",
+        rationale: "fresh-general",
+        score: 0,
+        leg: issue.leg,
+        labels: labels.join(","),
+      });
+      continue;
+    }
+    const picked = result.reusedAgents[0];
+    rows.push({
+      issueId: issue.issueId,
+      agentId: picked.agent.agentId,
+      rationale: picked.rationale,
+      score: picked.score,
+      leg: issue.leg,
+      labels: labels.join(","),
+    });
+  }
+
+  // Plan §"Trim contamination" — assert no trim agent slipped through.
+  const trimPicks = rows.filter((r) => TRIM_RE.test(r.agentId));
+  if (trimPicks.length > 0) {
+    process.stderr.write(
+      `ERROR: ${trimPicks.length} trim agent(s) leaked into picks. regOverride filter is broken.\n`,
+    );
+    for (const r of trimPicks) {
+      process.stderr.write(`  issue #${r.issueId} → ${r.agentId}\n`);
+    }
+    process.exit(1);
+  }
+
+  fs.mkdirSync(path.dirname(path.resolve(args.out)), { recursive: true });
+  const lines = ["issueId\tagentId\trationale\tscore\tleg\tlabels"];
+  for (const r of rows) {
+    lines.push(
+      `${r.issueId}\t${r.agentId}\t${r.rationale}\t${r.score.toFixed(4)}\t${r.leg}\t${r.labels}`,
+    );
+  }
+  fs.writeFileSync(args.out, lines.join("\n") + "\n");
+
+  // Distribution stderr-summary — mirrors the verification check in the plan.
+  const byAgent = new Map();
+  for (const r of rows) {
+    byAgent.set(r.agentId, (byAgent.get(r.agentId) ?? 0) + 1);
+  }
+  const byRationale = new Map();
+  for (const r of rows) {
+    byRationale.set(r.rationale, (byRationale.get(r.rationale) ?? 0) + 1);
+  }
+  process.stderr.write(`\nPicks → ${args.out}\n`);
+  process.stderr.write(`  agents: ${[...byAgent.entries()].map(([a, n]) => `${a}=${n}`).join(", ")}\n`);
+  process.stderr.write(`  rationale: ${[...byRationale.entries()].map(([r, n]) => `${r}=${n}`).join(", ")}\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`${err.stack ?? err}\n`);
+  process.exit(1);
+});

--- a/feature-plans/curve-redo-bundle/specialist-redo/score-specialist-redo.sh
+++ b/feature-plans/curve-redo-bundle/specialist-redo/score-specialist-redo.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# Curve-redo follow-up — Step 7 of feature-plans/curve-redo-specialist-followup-plan.md.
+#
+# For every cell log under $OUT_DIR/logs-leg<leg>/bench-r*-<agent>-<issue>.log:
+#   * parse the spawn log's envelope to get (decision, reason) and the diff
+#     path written by --capture-diff-path during dispatch
+#   * if decision == "implement" AND a non-empty diff exists: invoke
+#     `vp-dev research run-tests` to apply the diff into a fresh clone, run
+#     the issue's hidden-test suite, and write `<cellKey>-tests.json`
+#   * if decision in {implement, pushback}: invoke
+#     `vp-dev research grade-reasoning` for the K=3 Opus blind grade and
+#     write `<cellKey>-judge.json`
+#
+# Cells with envelope.decision == "error" / null produce no score files —
+# combine-and-compare.cjs scores them as 0 per qualityFromAB.
+#
+# Test/judge paths mirror the leg-1 conventions:
+#   $OUT_DIR/scores-leg<leg>/<cellKey>-tests.json
+#   $OUT_DIR/scores-leg<leg>/<cellKey>-judge.json
+# where cellKey == log basename minus the `.log` suffix
+# (`bench-r<N>-<agentId>-<issueId>`).
+#
+# Usage:
+#   bash score-specialist-redo.sh <leg>
+#     <leg>  1 or 2
+
+set -euo pipefail
+
+LEG="${1:-}"
+if [[ "$LEG" != "1" && "$LEG" != "2" ]]; then
+  echo "Usage: $0 <1|2>" >&2
+  exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+OUT_DIR="${OUT_DIR:-$REPO_ROOT/feature-plans/curve-redo-data/specialist-redo}"
+CORPUS="$REPO_ROOT/feature-plans/curve-redo-bundle/corpus.json"
+LOGS_DIR="$OUT_DIR/logs-leg${LEG}"
+DIFFS_DIR="$OUT_DIR/diffs-leg${LEG}"
+SCORES_DIR="$OUT_DIR/scores-leg${LEG}"
+TESTS_BASE="${TESTS_BASE:-$REPO_ROOT/feature-plans/curve-redo-bundle/curve-redo-tests}"
+SCORE_CLONES_DIR="${SCORE_CLONES_DIR:-$OUT_DIR/score-clones-leg${LEG}}"
+
+JUDGE_K="${JUDGE_K:-3}"
+
+if [[ ! -d "$LOGS_DIR" ]]; then
+  echo "ERROR: logs dir not found at $LOGS_DIR — run dispatch-specialist-redo.sh first." >&2
+  exit 2
+fi
+if [[ ! -d "$TESTS_BASE" ]]; then
+  echo "ERROR: hidden-tests dir not found at $TESTS_BASE." >&2
+  exit 2
+fi
+
+mkdir -p "$SCORES_DIR" "$SCORE_CLONES_DIR"
+
+echo "[$(date -Iseconds)] score-specialist-redo: leg=$LEG K=$JUDGE_K" >&2
+echo "  logs=$LOGS_DIR" >&2
+echo "  scores=$SCORES_DIR" >&2
+
+# Per-issue metadata lookup (repo, framework, baseSha, testsDestRelDir).
+declare -A ISSUE_REPO ISSUE_FRAMEWORK ISSUE_SHA ISSUE_TESTS_DEST
+while IFS=$'\t' read -r issueId repo framework state cls sha testsDest; do
+  ISSUE_REPO["$issueId"]="$repo"
+  ISSUE_FRAMEWORK["$issueId"]="$framework"
+  ISSUE_SHA["$issueId"]="$sha"
+  ISSUE_TESTS_DEST["$issueId"]="$testsDest"
+done < <(node -e '
+  const fs = require("node:fs");
+  const c = JSON.parse(fs.readFileSync(process.argv[1], "utf-8"));
+  for (const i of c.issues) {
+    process.stdout.write([
+      i.issueId,
+      i.repo,
+      i.framework,
+      i.state || "open",
+      i.decisionClass || "",
+      i.baseSha || "",
+      i.testsDestRelDir || "",
+    ].join("\t") + "\n");
+  }
+' "$CORPUS")
+
+# Resolve a fresh clone at the issue's baseSha (or origin/main for open
+# issues). Clones are reused per-issue across cells. testRunner copies the
+# diff in and resets between cells, so a single clone per issue is safe.
+# Source defaults to the conventional clone at $HOME/dev/<repo-name>.
+ensure_score_clone() {
+  local issueId="$1" repo="$2" sha="$3"
+  local name="${repo##*/}"
+  local cdir="$SCORE_CLONES_DIR/${name}-${issueId}"
+  if [[ ! -d "$cdir/.git" ]]; then
+    local src="${HOME:-/home}/dev/$name"
+    if [[ -d "$src/.git" ]]; then
+      git clone --quiet "$src" "$cdir" >&2
+    else
+      gh repo clone "$repo" "$cdir" -- --quiet >&2
+    fi
+  fi
+  if [[ -n "$sha" ]]; then
+    (cd "$cdir" && git fetch --quiet origin "$sha" 2>/dev/null || true)
+    (cd "$cdir" && git reset --hard "$sha" --quiet)
+  else
+    (cd "$cdir" && git fetch --quiet origin main && git reset --hard origin/main --quiet)
+  fi
+  echo "$cdir"
+}
+
+# Parse log → emit `<decision>\t<reason-tmp-path-or-empty>` for the cell. The
+# reason text is dumped to a temp file when present so grade-reasoning's
+# --pushback-path has something to read.
+parse_log() {
+  local log="$1" cell_id="$2"
+  python3 -c '
+import json, re, sys, os, tempfile
+text = open(sys.argv[1]).read()
+# Extract the trailing JSON object — the spawn writes a single top-level
+# {runId, agentId, envelope, ...} blob to stdout. Walk anchors mirror
+# curveStudy/aggregate.ts:extractEnvelope.
+obj = None
+for anchor in ("\n{\n", "{\n"):
+    idx = text.rfind(anchor)
+    while idx >= 0:
+        candidate = text[idx:].lstrip()
+        try:
+            obj = json.loads(candidate)
+            break
+        except json.JSONDecodeError:
+            idx = text.rfind(anchor, 0, idx)
+    if obj is not None:
+        break
+
+decision = ""
+reason_path = ""
+if obj is not None:
+    env = obj.get("envelope") or {}
+    decision = env.get("decision") or ""
+    reason = env.get("reason") or ""
+    if decision == "pushback" and reason:
+        cell_id = sys.argv[2]
+        out_dir = sys.argv[3]
+        os.makedirs(out_dir, exist_ok=True)
+        reason_path = os.path.join(out_dir, cell_id + ".pushback.txt")
+        open(reason_path, "w").write(reason)
+sys.stdout.write(decision + "\t" + reason_path + "\n")
+' "$log" "$cell_id" "$SCORES_DIR/.tmp"
+}
+
+shopt -s nullglob
+mapfile -t LOG_FILES < <(printf '%s\n' "$LOGS_DIR"/bench-r*-*.log | sort)
+if [[ ${#LOG_FILES[@]} -eq 0 ]]; then
+  echo "ERROR: no logs found at $LOGS_DIR/bench-r*.log" >&2
+  exit 2
+fi
+
+total=${#LOG_FILES[@]}
+done_count=0
+for log in "${LOG_FILES[@]}"; do
+  done_count=$((done_count + 1))
+  base="$(basename "$log" .log)"
+  # base = bench-r<N>-<agent>-<issue>
+  if [[ ! "$base" =~ ^bench-r[0-9]+-(agent-[a-z0-9-]+)-([0-9]+)$ ]]; then
+    echo "[$done_count/$total] skip (unrecognized name): $base" >&2
+    continue
+  fi
+  agent="${BASH_REMATCH[1]}"
+  issueId="${BASH_REMATCH[2]}"
+  repo="${ISSUE_REPO[$issueId]:-}"
+  framework="${ISSUE_FRAMEWORK[$issueId]:-}"
+  sha="${ISSUE_SHA[$issueId]:-}"
+  testsDest="${ISSUE_TESTS_DEST[$issueId]:-}"
+
+  if [[ -z "$repo" || -z "$framework" ]]; then
+    echo "[$done_count/$total] skip (no corpus entry): $base" >&2
+    continue
+  fi
+
+  echo "[$(date -Iseconds)] [$done_count/$total] $base (decision=parsing)" >&2
+  parsed="$(parse_log "$log" "$base")"
+  decision="${parsed%%$'\t'*}"
+  reason_path="${parsed#*$'\t'}"
+
+  diff_path="$DIFFS_DIR/${base}.diff"
+  tests_dir="$TESTS_BASE/$issueId"
+
+  tests_out="$SCORES_DIR/${base}-tests.json"
+  judge_out="$SCORES_DIR/${base}-judge.json"
+
+  # Run-tests: only when the cell implemented something (non-empty diff).
+  if [[ "$decision" == "implement" && -s "$diff_path" && ! -s "$tests_out" ]]; then
+    if [[ ! -d "$tests_dir" ]]; then
+      echo "  WARN: no hidden tests at $tests_dir — skipping run-tests." >&2
+    else
+      clone="$(ensure_score_clone "$issueId" "$repo" "$sha")"
+      cmd=(npm run vp-dev -- research run-tests
+        --diff-path "$diff_path"
+        --tests-dir "$tests_dir"
+        --clone-dir "$clone"
+        --framework "$framework"
+        --out "$tests_out")
+      if [[ -n "$testsDest" ]]; then
+        cmd+=(--tests-dest-rel-dir "$testsDest")
+      fi
+      echo "  run-tests → $tests_out" >&2
+      (cd "$REPO_ROOT" && "${cmd[@]}" >/dev/null 2>&1) || \
+        echo "  WARN: run-tests exited non-zero (output preserved at $tests_out)" >&2
+    fi
+  fi
+
+  # Grade-reasoning: any decision in {implement, pushback}.
+  if [[ ( "$decision" == "implement" || "$decision" == "pushback" ) && ! -s "$judge_out" ]]; then
+    cmd=(npm run vp-dev -- research grade-reasoning
+      --issue "$issueId"
+      --target-repo "$repo"
+      --decision "$decision"
+      --k "$JUDGE_K"
+      --out "$judge_out")
+    if [[ "$decision" == "implement" && -s "$diff_path" ]]; then
+      cmd+=(--diff-path "$diff_path")
+    elif [[ "$decision" == "pushback" && -n "$reason_path" && -s "$reason_path" ]]; then
+      cmd+=(--pushback-path "$reason_path")
+    fi
+    echo "  grade-reasoning → $judge_out" >&2
+    (cd "$REPO_ROOT" && "${cmd[@]}" >/dev/null 2>&1) || \
+      echo "  WARN: grade-reasoning exited non-zero (output preserved at $judge_out)" >&2
+  fi
+
+  if [[ "$decision" != "implement" && "$decision" != "pushback" ]]; then
+    echo "  skip (decision=$decision)" >&2
+  fi
+done
+
+echo "[$(date -Iseconds)] score-specialist-redo: leg=$LEG complete." >&2


### PR DESCRIPTION
## Summary

Implements the four operator scripts that drive the curve-redo specialist follow-up experiment (plan: [PR #231](https://github.com/szhygulin/vaultpilot-development-agents/pull/231) → `feature-plans/curve-redo-specialist-followup-plan.md`).

- `pick-specialists.cjs` — calls `pickAgents()` with trim agents filtered via `regOverride`; writes `picks.tsv`; asserts no trim agent leaked into picks.
- `dispatch-specialist-redo.sh` — K=3 replicates per (agent, issue) via `vp-dev spawn` with `--no-target-claude-md` / `--capture-diff-path` / `--skip-summary` / `--model claude-sonnet-4-6`; closed issues get `--replay-base-sha` + `--allow-closed-issue` + `--issue-body-only`; per-cell + total-loop cost caps.
- `score-specialist-redo.sh` — `vp-dev research run-tests` + `grade-reasoning` per cell, mirroring leg-1 conventions. Cell key carries the `bench-r<N>-` prefix so baseline keys (no prefix) and treatment keys (prefixed) coexist in one score map.
- `combine-and-compare.cjs` — paired comparator. Per-cell quality via the A+B formula (`qualityFromAB`, mirroring [`combine-legs.cjs:51-73`](../blob/main/feature-plans/curve-redo-bundle/combine-legs.cjs)). Paired Wilcoxon (`alternative="greater"` on dQuality, `"less"` on dCost), Hedges' g, rationale-stratified means.

Scripts live under `feature-plans/curve-redo-bundle/specialist-redo/` (committed for review). Run-time outputs land in the gitignored `feature-plans/curve-redo-data/specialist-redo/` via `OUT_DIR=` override.

This is implementation only — the experiment dispatch, scoring, and writeup are downstream operator work and will land in a separate study PR.

## Test plan

- [x] `bash -n` on both shell scripts; `node --check` on both cjs scripts.
- [x] `npm run typecheck` clean (no source touched).
- [x] `npm run build` clean.
- [x] Empty-result smoke per the project's CLAUDE.md "smoke-test the empty-result path" rule: ran `combine-and-compare.cjs` with empty fixture inputs; output JSON has no NaN/Infinity, headline reports `paired issues: 0` cleanly.
- [x] `dispatch-specialist-redo.sh 1 --dry-print` against fixture picks: emits 6 cells (2 issues × K=3) with the expected `vp-dev spawn` arg list.
- [x] `dispatch-specialist-redo.sh 2 --dry-print` against fixture picks: closed-issue paths add `--allow-closed-issue --issue-body-only --replay-base-sha <sha>` correctly, with the actual SHAs from `corpus.json` (41ad7cea3989 for #157, f9bbe7b9a1de for #168).
- [ ] Live single-cell smoke (operator follow-up, per the plan's Step 4): dispatch one cell on issue #156, verify log has envelope JSON and diff captured.
- [ ] Full dispatch + score + combine end-to-end (operator follow-up, lands in the study PR with results writeup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)