### PR TITLE
feat(agents): add pull-snapshot / push-snapshot subcommands

### DIFF
--- a/src/agent/snapshotSync.test.ts
+++ b/src/agent/snapshotSync.test.ts
@@ -1,0 +1,282 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  classifyAgent,
+  isSynthetic,
+  pullSnapshot,
+  pushSnapshot,
+  SYNTHETIC_AGENT_PATTERNS,
+} from "./snapshotSync.js";
+
+async function makeTempLayout(): Promise<{
+  rootDir: string;
+  cloneDir: string;
+  remoteAgentsDir: string;
+  localAgentsDir: string;
+}> {
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "snapshot-sync-test-"));
+  const cloneDir = path.join(rootDir, "clone");
+  const remoteAgentsDir = path.join(cloneDir, "agents");
+  const localAgentsDir = path.join(rootDir, "local-agents");
+  await fs.mkdir(remoteAgentsDir, { recursive: true });
+  await fs.mkdir(localAgentsDir, { recursive: true });
+  return { rootDir, cloneDir, remoteAgentsDir, localAgentsDir };
+}
+
+async function writeAgent(root: string, id: string, body: string): Promise<void> {
+  const dir = path.join(root, id);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, "CLAUDE.md"), body, "utf-8");
+}
+
+async function readAgent(root: string, id: string): Promise<string | null> {
+  try {
+    return await fs.readFile(path.join(root, id, "CLAUDE.md"), "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+describe("isSynthetic", () => {
+  it("matches trim-* curve-redo Phase A agents", () => {
+    assert.equal(isSynthetic("agent-916a-trim-6000-s8026"), true);
+    assert.equal(isSynthetic("agent-916a-trim-58000-s2060032"), true);
+  });
+
+  it("matches 9180-9189 Smoke10 Phase B agents", () => {
+    for (let i = 0; i <= 9; i++) {
+      assert.equal(isSynthetic(`agent-918${i}`), true, `9180+${i}`);
+    }
+  });
+
+  it("does not match real specialists", () => {
+    assert.equal(isSynthetic("agent-916a"), false);
+    assert.equal(isSynthetic("agent-92ff"), false);
+    assert.equal(isSynthetic("agent-9190"), false);
+    assert.equal(isSynthetic("agent-91801"), false);
+  });
+
+  it("honors extra patterns", () => {
+    assert.equal(isSynthetic("agent-foo-test", [/^agent-foo-/]), true);
+    assert.equal(isSynthetic("agent-bar", [/^agent-foo-/]), false);
+  });
+
+  it("exposes its baseline patterns as a readonly array", () => {
+    assert.equal(SYNTHETIC_AGENT_PATTERNS.length, 2);
+  });
+});
+
+describe("classifyAgent", () => {
+  const A = Buffer.from("apple");
+  const B = Buffer.from("banana");
+
+  it("returns add when destination is missing", () => {
+    assert.equal(
+      classifyAgent({ sourceBytes: A, destBytes: null, policy: "skip-existing", direction: "pull" }),
+      "add",
+    );
+  });
+
+  it("returns unchanged on byte-equal content", () => {
+    assert.equal(
+      classifyAgent({ sourceBytes: A, destBytes: Buffer.from("apple"), policy: "overwrite", direction: "pull" }),
+      "unchanged",
+    );
+  });
+
+  it("pull + skip-existing preserves existing local file", () => {
+    assert.equal(
+      classifyAgent({ sourceBytes: A, destBytes: B, policy: "skip-existing", direction: "pull" }),
+      "skip",
+    );
+  });
+
+  it("pull + overwrite replaces existing local file", () => {
+    assert.equal(
+      classifyAgent({ sourceBytes: A, destBytes: B, policy: "overwrite", direction: "pull" }),
+      "update",
+    );
+  });
+
+  it("push always updates on a difference (PR is the gate)", () => {
+    assert.equal(
+      classifyAgent({ sourceBytes: A, destBytes: B, policy: "skip-existing", direction: "push" }),
+      "update",
+    );
+  });
+
+  it("returns skip when source is null", () => {
+    assert.equal(
+      classifyAgent({ sourceBytes: null, destBytes: A, policy: "overwrite", direction: "pull" }),
+      "skip",
+    );
+  });
+});
+
+describe("pullSnapshot", () => {
+  it("adds agents missing locally and leaves existing ones under skip-existing", async () => {
+    const { cloneDir, remoteAgentsDir, localAgentsDir } = await makeTempLayout();
+    await writeAgent(remoteAgentsDir, "agent-aaaa", "remote-aaaa");
+    await writeAgent(remoteAgentsDir, "agent-bbbb", "remote-bbbb");
+    await writeAgent(localAgentsDir, "agent-aaaa", "local-aaaa");
+
+    const summary = await pullSnapshot({
+      cloneDir,
+      agentsRoot: localAgentsDir,
+      skipFetch: true,
+    });
+
+    assert.deepEqual(summary.added, ["agent-bbbb"]);
+    assert.deepEqual(summary.skipped, ["agent-aaaa"]);
+    assert.equal(await readAgent(localAgentsDir, "agent-aaaa"), "local-aaaa");
+    assert.equal(await readAgent(localAgentsDir, "agent-bbbb"), "remote-bbbb");
+  });
+
+  it("overwrites local under policy: overwrite", async () => {
+    const { cloneDir, remoteAgentsDir, localAgentsDir } = await makeTempLayout();
+    await writeAgent(remoteAgentsDir, "agent-aaaa", "remote-aaaa");
+    await writeAgent(localAgentsDir, "agent-aaaa", "local-aaaa");
+
+    const summary = await pullSnapshot({
+      cloneDir,
+      agentsRoot: localAgentsDir,
+      policy: "overwrite",
+      skipFetch: true,
+    });
+
+    assert.deepEqual(summary.updated, ["agent-aaaa"]);
+    assert.equal(await readAgent(localAgentsDir, "agent-aaaa"), "remote-aaaa");
+  });
+
+  it("reports unchanged for byte-identical files without re-writing", async () => {
+    const { cloneDir, remoteAgentsDir, localAgentsDir } = await makeTempLayout();
+    await writeAgent(remoteAgentsDir, "agent-aaaa", "same-bytes");
+    await writeAgent(localAgentsDir, "agent-aaaa", "same-bytes");
+
+    const summary = await pullSnapshot({
+      cloneDir,
+      agentsRoot: localAgentsDir,
+      policy: "overwrite",
+      skipFetch: true,
+    });
+
+    assert.deepEqual(summary.unchanged, ["agent-aaaa"]);
+    assert.deepEqual(summary.updated, []);
+  });
+
+  it("dry-run reports the planned changes without writing", async () => {
+    const { cloneDir, remoteAgentsDir, localAgentsDir } = await makeTempLayout();
+    await writeAgent(remoteAgentsDir, "agent-aaaa", "remote-aaaa");
+
+    const summary = await pullSnapshot({
+      cloneDir,
+      agentsRoot: localAgentsDir,
+      dryRun: true,
+      skipFetch: true,
+    });
+
+    assert.deepEqual(summary.added, ["agent-aaaa"]);
+    assert.equal(await readAgent(localAgentsDir, "agent-aaaa"), null);
+  });
+
+  it("returns an empty summary when the snapshot has no agents", async () => {
+    const { cloneDir, localAgentsDir } = await makeTempLayout();
+    const summary = await pullSnapshot({
+      cloneDir,
+      agentsRoot: localAgentsDir,
+      skipFetch: true,
+    });
+    assert.deepEqual(summary.added, []);
+    assert.deepEqual(summary.skipped, []);
+    assert.deepEqual(summary.unchanged, []);
+  });
+});
+
+describe("pushSnapshot", () => {
+  it("excludes synthetic curve-redo agents by default", async () => {
+    const { cloneDir, localAgentsDir } = await makeTempLayout();
+    await writeAgent(localAgentsDir, "agent-916a", "real");
+    await writeAgent(localAgentsDir, "agent-916a-trim-6000-s8026", "synthetic-A");
+    await writeAgent(localAgentsDir, "agent-9189", "synthetic-B");
+
+    const result = await pushSnapshot({
+      cloneDir,
+      agentsRoot: localAgentsDir,
+      apply: false,
+      skipFetch: true,
+    });
+
+    assert.deepEqual(result.summary.added, ["agent-916a"]);
+    assert.deepEqual(
+      result.summary.excluded.sort(),
+      ["agent-916a-trim-6000-s8026", "agent-9189"].sort(),
+    );
+  });
+
+  it("includes synthetic when --include-synthetic is set", async () => {
+    const { cloneDir, localAgentsDir } = await makeTempLayout();
+    await writeAgent(localAgentsDir, "agent-9189", "synthetic");
+
+    const result = await pushSnapshot({
+      cloneDir,
+      agentsRoot: localAgentsDir,
+      apply: false,
+      includeSynthetic: true,
+      skipFetch: true,
+    });
+
+    assert.deepEqual(result.summary.added, ["agent-9189"]);
+    assert.deepEqual(result.summary.excluded, []);
+  });
+
+  it("reports updated for differing content, unchanged for identical", async () => {
+    const { cloneDir, remoteAgentsDir, localAgentsDir } = await makeTempLayout();
+    await writeAgent(remoteAgentsDir, "agent-aaaa", "old");
+    await writeAgent(remoteAgentsDir, "agent-bbbb", "same");
+    await writeAgent(localAgentsDir, "agent-aaaa", "new");
+    await writeAgent(localAgentsDir, "agent-bbbb", "same");
+    await writeAgent(localAgentsDir, "agent-cccc", "fresh");
+
+    const result = await pushSnapshot({
+      cloneDir,
+      agentsRoot: localAgentsDir,
+      apply: false,
+      skipFetch: true,
+    });
+
+    assert.deepEqual(result.summary.updated, ["agent-aaaa"]);
+    assert.deepEqual(result.summary.unchanged, ["agent-bbbb"]);
+    assert.deepEqual(result.summary.added, ["agent-cccc"]);
+  });
+
+  it("does not write to clone when apply=false", async () => {
+    const { cloneDir, remoteAgentsDir, localAgentsDir } = await makeTempLayout();
+    await writeAgent(remoteAgentsDir, "agent-aaaa", "old");
+    await writeAgent(localAgentsDir, "agent-aaaa", "new");
+
+    await pushSnapshot({
+      cloneDir,
+      agentsRoot: localAgentsDir,
+      apply: false,
+      skipFetch: true,
+    });
+
+    assert.equal(await readAgent(remoteAgentsDir, "agent-aaaa"), "old");
+  });
+
+  it("returns an empty summary when local agents/ is empty", async () => {
+    const { cloneDir, localAgentsDir } = await makeTempLayout();
+    const result = await pushSnapshot({
+      cloneDir,
+      agentsRoot: localAgentsDir,
+      apply: false,
+      skipFetch: true,
+    });
+    assert.deepEqual(result.summary.added, []);
+    assert.deepEqual(result.summary.excluded, []);
+    assert.match(result.branch, /^refresh-snapshot-\d{4}-\d{2}-\d{2}$/);
+  });
+});

--- a/src/agent/snapshotSync.ts
+++ b/src/agent/snapshotSync.ts
@@ -1,0 +1,305 @@
+// Sync per-agent CLAUDE.md files between the local working tree (`agents/`)
+// and the snapshot repo (default: szhygulin/vaultpilot-dev-agents).
+//
+// Local `agents/` is gitignored — it's the live store the orchestrator's
+// summarizer rewrites after every successful run. The snapshot repo is a
+// point-in-time mirror committed via PR. These two are kept decoupled so
+// the summarizer's writes don't fight a checked-out tree.
+//
+// pullSnapshot: clone (or refresh) the snapshot, then copy CLAUDE.mds DOWN
+// into local agents/. Default policy is `skip-existing` so a pull never
+// clobbers a run-in-progress's freshly-summarized memory; `overwrite`
+// replaces local content under the same per-file lock the summarizer uses.
+//
+// pushSnapshot: clone (or refresh) the snapshot, copy local CLAUDE.mds UP,
+// branch + commit + open a PR via gh. Synthetic curve-redo agents
+// (`agent-916a-trim-*`, `agent-9180`–`agent-9189`) are excluded by default
+// per the snapshot README's stated policy. Without --apply it's a dry run.
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { AGENTS_ROOT } from "./specialization.js";
+import { withFileLock } from "../state/locks.js";
+
+const execFileAsync = promisify(execFile);
+
+export const DEFAULT_SNAPSHOT_REPO = "szhygulin/vaultpilot-dev-agents";
+export const DEFAULT_CLONE_DIR = path.resolve(process.cwd(), ".claude", "agents-snapshot");
+
+// Phase A trim-* (issue #179) and Phase B Smoke10 (#234) curve-redo study
+// agents. The snapshot repo's README excludes these; pushSnapshot mirrors
+// that policy unless `--include-synthetic` is passed.
+export const SYNTHETIC_AGENT_PATTERNS: readonly RegExp[] = [
+  /^agent-916a-trim-/,
+  /^agent-918[0-9]$/,
+];
+
+export type ConflictPolicy = "skip-existing" | "overwrite";
+
+export interface SyncSummary {
+  /** Agents copied because they did not exist on the destination. */
+  added: string[];
+  /** Agents whose destination content was replaced. */
+  updated: string[];
+  /** Existing destination agents preserved (skip-existing policy). */
+  skipped: string[];
+  /** Source and destination were byte-identical; no copy. */
+  unchanged: string[];
+  /** Source agents matched an exclude pattern (push only). */
+  excluded: string[];
+}
+
+export function emptySummary(): SyncSummary {
+  return { added: [], updated: [], skipped: [], unchanged: [], excluded: [] };
+}
+
+export function isSynthetic(
+  agentDir: string,
+  extraPatterns: readonly RegExp[] = [],
+): boolean {
+  for (const re of SYNTHETIC_AGENT_PATTERNS) if (re.test(agentDir)) return true;
+  for (const re of extraPatterns) if (re.test(agentDir)) return true;
+  return false;
+}
+
+/**
+ * Decide what action a single agent's sync should produce, given the bytes
+ * (or absence) on each side and the conflict policy. Pure — no I/O — so the
+ * file-by-file decision logic is testable without a real filesystem.
+ *
+ * Direction encodes which side is the source: `pull` copies remote → local,
+ * so the policy gates whether to overwrite an existing local file. `push`
+ * always copies local → remote on a difference (the snapshot is the
+ * destination, and the PR is the human gate).
+ */
+export type SyncAction = "add" | "update" | "skip" | "unchanged";
+
+export function classifyAgent(input: {
+  sourceBytes: Buffer | null;
+  destBytes: Buffer | null;
+  policy: ConflictPolicy;
+  direction: "pull" | "push";
+}): SyncAction {
+  if (input.sourceBytes === null) return "skip";
+  if (input.destBytes === null) return "add";
+  if (input.sourceBytes.equals(input.destBytes)) return "unchanged";
+  if (input.direction === "push") return "update";
+  return input.policy === "overwrite" ? "update" : "skip";
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await fs.stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readFileOrNull(p: string): Promise<Buffer | null> {
+  try {
+    return await fs.readFile(p);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+async function gitExec(cwd: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", args, { cwd });
+  return stdout;
+}
+
+/**
+ * Ensure `cloneDir` is a fresh checkout of `<repo>@origin/main`. Clones via
+ * `gh repo clone` if absent; otherwise fetches and hard-resets. Discards any
+ * local edits inside the clone — callers that want to commit must branch off
+ * `origin/main` before mutating.
+ */
+export async function ensureCloneFresh(cloneDir: string, repo: string): Promise<void> {
+  if (!(await pathExists(cloneDir))) {
+    await fs.mkdir(path.dirname(cloneDir), { recursive: true });
+    await execFileAsync("gh", ["repo", "clone", repo, cloneDir]);
+    return;
+  }
+  if (!(await pathExists(path.join(cloneDir, ".git")))) {
+    throw new Error(
+      `${cloneDir} exists but is not a git repository. Either delete it or pass a different --clone-dir.`,
+    );
+  }
+  await gitExec(cloneDir, ["fetch", "origin", "main"]);
+  await gitExec(cloneDir, ["checkout", "main"]);
+  await gitExec(cloneDir, ["reset", "--hard", "origin/main"]);
+  await gitExec(cloneDir, ["clean", "-fd"]);
+}
+
+async function listAgentDirs(agentsRoot: string): Promise<string[]> {
+  if (!(await pathExists(agentsRoot))) return [];
+  const entries = await fs.readdir(agentsRoot, { withFileTypes: true });
+  return entries
+    .filter((e) => e.isDirectory() && e.name.startsWith("agent-"))
+    .map((e) => e.name)
+    .sort();
+}
+
+export interface PullOptions {
+  repo?: string;
+  cloneDir?: string;
+  policy?: ConflictPolicy;
+  dryRun?: boolean;
+  /** Override AGENTS_ROOT (tests). */
+  agentsRoot?: string;
+  /** Skip ensureCloneFresh — assume `cloneDir` already has the snapshot.
+   *  Used by tests; production callers should leave unset. */
+  skipFetch?: boolean;
+}
+
+export async function pullSnapshot(opts: PullOptions = {}): Promise<SyncSummary> {
+  const repo = opts.repo ?? DEFAULT_SNAPSHOT_REPO;
+  const cloneDir = opts.cloneDir ?? DEFAULT_CLONE_DIR;
+  const agentsRoot = opts.agentsRoot ?? AGENTS_ROOT;
+  const policy: ConflictPolicy = opts.policy ?? "skip-existing";
+  const dryRun = opts.dryRun ?? false;
+
+  if (!opts.skipFetch) await ensureCloneFresh(cloneDir, repo);
+  const remoteAgentsDir = path.join(cloneDir, "agents");
+  if (!(await pathExists(remoteAgentsDir))) {
+    throw new Error(`snapshot repo has no 'agents/' directory at ${remoteAgentsDir}`);
+  }
+
+  await fs.mkdir(agentsRoot, { recursive: true });
+  const summary = emptySummary();
+  const remoteAgents = await listAgentDirs(remoteAgentsDir);
+
+  for (const agentId of remoteAgents) {
+    const remoteFile = path.join(remoteAgentsDir, agentId, "CLAUDE.md");
+    const localFile = path.join(agentsRoot, agentId, "CLAUDE.md");
+
+    const [sourceBytes, destBytes] = await Promise.all([
+      readFileOrNull(remoteFile),
+      readFileOrNull(localFile),
+    ]);
+    if (sourceBytes === null) continue;
+
+    const action = classifyAgent({ sourceBytes, destBytes, policy, direction: "pull" });
+    if (action === "unchanged") {
+      summary.unchanged.push(agentId);
+      continue;
+    }
+    if (action === "skip") {
+      summary.skipped.push(agentId);
+      continue;
+    }
+
+    if (!dryRun) {
+      await fs.mkdir(path.dirname(localFile), { recursive: true });
+      await withFileLock(localFile, async () => {
+        await fs.writeFile(localFile, sourceBytes);
+      });
+    }
+    if (action === "add") summary.added.push(agentId);
+    else summary.updated.push(agentId);
+  }
+
+  return summary;
+}
+
+export interface PushOptions {
+  repo?: string;
+  cloneDir?: string;
+  apply?: boolean;
+  branch?: string;
+  message?: string;
+  body?: string;
+  includeSynthetic?: boolean;
+  extraExcludes?: readonly RegExp[];
+  /** Override AGENTS_ROOT (tests). */
+  agentsRoot?: string;
+  /** Skip ensureCloneFresh — used by tests. */
+  skipFetch?: boolean;
+}
+
+export interface PushResult {
+  summary: SyncSummary;
+  branch: string;
+  prUrl?: string;
+}
+
+function formatSummaryBody(summary: SyncSummary): string {
+  const lines: string[] = ["## Summary", ""];
+  if (summary.added.length) lines.push(`- ${summary.added.length} added: ${summary.added.join(", ")}`);
+  if (summary.updated.length) lines.push(`- ${summary.updated.length} updated: ${summary.updated.join(", ")}`);
+  if (summary.unchanged.length) lines.push(`- ${summary.unchanged.length} unchanged`);
+  if (summary.excluded.length) lines.push(`- ${summary.excluded.length} excluded as synthetic curve-redo agents`);
+  lines.push("", "Generated by `vp-dev agents push-snapshot`.");
+  return lines.join("\n");
+}
+
+export async function pushSnapshot(opts: PushOptions = {}): Promise<PushResult> {
+  const repo = opts.repo ?? DEFAULT_SNAPSHOT_REPO;
+  const cloneDir = opts.cloneDir ?? DEFAULT_CLONE_DIR;
+  const agentsRoot = opts.agentsRoot ?? AGENTS_ROOT;
+  const apply = opts.apply ?? false;
+  const branch = opts.branch ?? `refresh-snapshot-${new Date().toISOString().slice(0, 10)}`;
+
+  if (!opts.skipFetch) await ensureCloneFresh(cloneDir, repo);
+  const remoteAgentsDir = path.join(cloneDir, "agents");
+  await fs.mkdir(remoteAgentsDir, { recursive: true });
+
+  if (apply && !opts.skipFetch) {
+    await gitExec(cloneDir, ["checkout", "-B", branch, "origin/main"]);
+  }
+
+  const summary = emptySummary();
+  const localAgents = await listAgentDirs(agentsRoot);
+
+  for (const agentId of localAgents) {
+    if (!opts.includeSynthetic && isSynthetic(agentId, opts.extraExcludes ?? [])) {
+      summary.excluded.push(agentId);
+      continue;
+    }
+    const localFile = path.join(agentsRoot, agentId, "CLAUDE.md");
+    const remoteFile = path.join(remoteAgentsDir, agentId, "CLAUDE.md");
+
+    const [sourceBytes, destBytes] = await Promise.all([
+      readFileOrNull(localFile),
+      readFileOrNull(remoteFile),
+    ]);
+    if (sourceBytes === null) continue;
+
+    const action = classifyAgent({ sourceBytes, destBytes, policy: "overwrite", direction: "push" });
+    if (action === "unchanged") {
+      summary.unchanged.push(agentId);
+      continue;
+    }
+    if (apply) {
+      await fs.mkdir(path.dirname(remoteFile), { recursive: true });
+      await fs.writeFile(remoteFile, sourceBytes);
+    }
+    if (action === "add") summary.added.push(agentId);
+    else if (action === "update") summary.updated.push(agentId);
+  }
+
+  if (!apply) return { summary, branch };
+
+  await gitExec(cloneDir, ["add", "-A"]);
+  const status = await gitExec(cloneDir, ["status", "--porcelain"]);
+  if (!status.trim()) return { summary, branch };
+
+  const message =
+    opts.message ??
+    `Refresh snapshot — ${summary.added.length} added, ${summary.updated.length} updated`;
+  const commitMsg = `${message}\n\nCo-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>\n`;
+  await gitExec(cloneDir, ["commit", "-m", commitMsg]);
+  await gitExec(cloneDir, ["push", "-u", "origin", branch]);
+
+  const body = opts.body ?? formatSummaryBody(summary);
+  const { stdout: prStdout } = await execFileAsync(
+    "gh",
+    ["pr", "create", "--repo", repo, "--title", message, "--body", body],
+    { cwd: cloneDir },
+  );
+  return { summary, branch, prUrl: prStdout.trim() };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -137,6 +137,13 @@ import {
   type PoolFile,
   type TrimProposal,
 } from "./agent/trimPool.js";
+import {
+  DEFAULT_SNAPSHOT_REPO,
+  pullSnapshot,
+  pushSnapshot,
+  type ConflictPolicy,
+  type SyncSummary,
+} from "./agent/snapshotSync.js";
 import { isValidDomain } from "./util/promotionMarkers.js";
 import {
   loadAllOutcomes,
@@ -515,6 +522,39 @@ export function buildCli(): Command {
         .option("--all", "Include archived (split-parent) agents")
         .action(async (opts) => {
           await cmdAgentsStats(opts);
+        }),
+    )
+    .addCommand(
+      new Command("pull-snapshot")
+        .description(
+          "Sync per-agent CLAUDE.md files DOWN from the snapshot repo (default: szhygulin/vaultpilot-dev-agents) into local agents/. Default policy 'skip-existing' won't clobber a run-in-progress's freshly-summarized memory; --policy overwrite replaces local content under the per-file lock.",
+        )
+        .option("--repo <owner/repo>", "GitHub snapshot repo", DEFAULT_SNAPSHOT_REPO)
+        .option("--clone-dir <path>", "Local clone dir for the snapshot repo (default: .claude/agents-snapshot)")
+        .option("--policy <name>", "Conflict policy: skip-existing | overwrite", "skip-existing")
+        .option("--dry-run", "Print what would be copied without writing")
+        .option("--json", "Print machine-readable JSON")
+        .action(async (opts) => {
+          await cmdAgentsPullSnapshot(opts);
+        }),
+    )
+    .addCommand(
+      new Command("push-snapshot")
+        .description(
+          "Sync local per-agent CLAUDE.md files UP to the snapshot repo. Excludes synthetic curve-redo study agents (agent-916a-trim-*, agent-9180-9189) by default. Without --apply it's a dry run; with --apply it branches off origin/main, commits, pushes, and opens a PR via gh.",
+        )
+        .option("--repo <owner/repo>", "GitHub snapshot repo", DEFAULT_SNAPSHOT_REPO)
+        .option("--clone-dir <path>", "Local clone dir for the snapshot repo (default: .claude/agents-snapshot)")
+        .option("--include-synthetic", "Include synthetic curve-redo agents (default: skip them)")
+        .option(
+          "--apply",
+          "Perform the push: commit + push + open PR. Without this flag, only the diff summary is printed.",
+        )
+        .option("--branch <name>", "Branch name to push (default: refresh-snapshot-YYYY-MM-DD)")
+        .option("--message <text>", "Commit message + PR title")
+        .option("--json", "Print machine-readable JSON")
+        .action(async (opts) => {
+          await cmdAgentsPushSnapshot(opts);
         }),
     );
   program.addCommand(agentsCmd);
@@ -3382,6 +3422,138 @@ async function cmdAgentsStats(opts: AgentsStatsOpts): Promise<void> {
     String(r.medianCiCycles),
   ]);
   printTable(headers, rows);
+}
+
+interface AgentsPullSnapshotOpts {
+  repo: string;
+  cloneDir?: string;
+  policy: string;
+  dryRun?: boolean;
+  json?: boolean;
+}
+
+function summaryStats(summary: SyncSummary): {
+  added: number;
+  updated: number;
+  skipped: number;
+  unchanged: number;
+  excluded: number;
+} {
+  return {
+    added: summary.added.length,
+    updated: summary.updated.length,
+    skipped: summary.skipped.length,
+    unchanged: summary.unchanged.length,
+    excluded: summary.excluded.length,
+  };
+}
+
+async function cmdAgentsPullSnapshot(opts: AgentsPullSnapshotOpts): Promise<void> {
+  if (opts.policy !== "skip-existing" && opts.policy !== "overwrite") {
+    process.stderr.write(
+      `ERROR: --policy must be 'skip-existing' or 'overwrite', got '${opts.policy}'.\n`,
+    );
+    process.exit(2);
+  }
+  let summary: SyncSummary;
+  try {
+    summary = await pullSnapshot({
+      repo: opts.repo,
+      cloneDir: opts.cloneDir,
+      policy: opts.policy as ConflictPolicy,
+      dryRun: opts.dryRun,
+    });
+  } catch (err) {
+    process.stderr.write(`ERROR: ${(err as Error).message}\n`);
+    process.exit(1);
+  }
+
+  if (opts.json) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          repo: opts.repo,
+          policy: opts.policy,
+          dryRun: !!opts.dryRun,
+          counts: summaryStats(summary),
+          ...summary,
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    return;
+  }
+
+  const counts = summaryStats(summary);
+  const verb = opts.dryRun ? "Would pull" : "Pulled";
+  process.stdout.write(
+    `${verb} from ${opts.repo} (policy=${opts.policy}): ` +
+      `${counts.added} added, ${counts.updated} updated, ${counts.skipped} skipped (existing), ${counts.unchanged} unchanged.\n`,
+  );
+  if (summary.added.length) process.stdout.write(`  added:   ${summary.added.join(", ")}\n`);
+  if (summary.updated.length) process.stdout.write(`  updated: ${summary.updated.join(", ")}\n`);
+  if (summary.skipped.length) process.stdout.write(`  skipped: ${summary.skipped.join(", ")}\n`);
+}
+
+interface AgentsPushSnapshotOpts {
+  repo: string;
+  cloneDir?: string;
+  includeSynthetic?: boolean;
+  apply?: boolean;
+  branch?: string;
+  message?: string;
+  json?: boolean;
+}
+
+async function cmdAgentsPushSnapshot(opts: AgentsPushSnapshotOpts): Promise<void> {
+  let result: Awaited<ReturnType<typeof pushSnapshot>>;
+  try {
+    result = await pushSnapshot({
+      repo: opts.repo,
+      cloneDir: opts.cloneDir,
+      includeSynthetic: opts.includeSynthetic,
+      apply: opts.apply,
+      branch: opts.branch,
+      message: opts.message,
+    });
+  } catch (err) {
+    process.stderr.write(`ERROR: ${(err as Error).message}\n`);
+    process.exit(1);
+  }
+
+  if (opts.json) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          repo: opts.repo,
+          apply: !!opts.apply,
+          branch: result.branch,
+          prUrl: result.prUrl,
+          counts: summaryStats(result.summary),
+          ...result.summary,
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    return;
+  }
+
+  const counts = summaryStats(result.summary);
+  const verb = opts.apply ? "Pushed" : "Would push";
+  process.stdout.write(
+    `${verb} to ${opts.repo} (branch=${result.branch}): ` +
+      `${counts.added} added, ${counts.updated} updated, ${counts.unchanged} unchanged, ${counts.excluded} excluded as synthetic.\n`,
+  );
+  if (result.summary.added.length) process.stdout.write(`  added:    ${result.summary.added.join(", ")}\n`);
+  if (result.summary.updated.length) process.stdout.write(`  updated:  ${result.summary.updated.join(", ")}\n`);
+  if (result.summary.excluded.length) process.stdout.write(`  excluded: ${result.summary.excluded.join(", ")}\n`);
+  if (!opts.apply) {
+    process.stdout.write("\nDry run. Re-invoke with --apply to commit + push + open the PR.\n");
+  } else if (result.prUrl) {
+    process.stdout.write(`\nPR opened: ${result.prUrl}\n`);
+  }
 }
 
 interface LessonsListOpts {


### PR DESCRIPTION
## Summary
- New \`vp-dev agents pull-snapshot\` and \`vp-dev agents push-snapshot\` subcommands wire bidirectional sync between local \`agents/\` and the snapshot repo (default \`szhygulin/vaultpilot-dev-agents\`).
- Pull defaults to \`--policy skip-existing\` so a run-in-progress's freshly-summarized CLAUDE.md is never clobbered; \`--policy overwrite\` replaces under the same per-file lock the summarizer uses.
- Push excludes synthetic curve-redo agents (\`agent-916a-trim-*\`, \`agent-9180\`–\`agent-9189\`) by default per the snapshot README's policy; \`--include-synthetic\` opts in. Without \`--apply\` it's a dry run; with \`--apply\` it branches off \`origin/main\`, commits, pushes, opens a PR via \`gh\`.
- Snapshot clone lives at \`.claude/agents-snapshot/\` (gitignored ancestor).

## Architecture
- New \`src/agent/snapshotSync.ts\` with pure helpers (\`isSynthetic\`, \`classifyAgent\`) + I/O wrappers (\`ensureCloneFresh\`, \`pullSnapshot\`, \`pushSnapshot\`).
- New \`src/agent/snapshotSync.test.ts\` — 21 tests covering exclude regex, conflict-policy decision logic, and temp-fs roundtrips for both directions.
- \`src/cli.ts\` adds two subcommands + handlers; mirrors the existing \`vp-dev agents <subcommand>\` pattern (no two-step token gate — push's PR is the human-review gate, and pull's \`skip-existing\` default is the safety story).

## Test plan
- [x] \`npm run typecheck\` passes.
- [x] \`npm run build\` passes.
- [x] \`npm test\` — 870/870 pass (added 21 in snapshotSync.test.ts).
- [x] Empty-result smoke: pull from a clone with empty \`agents/\` returns empty arrays (no \`Infinity\` / \`undefined\` per the project's empty-path discipline).
- [x] Populated smoke: \`vp-dev agents push-snapshot --clone-dir <real-clone>\` against the actual local working tree reproduces the manual [vaultpilot-dev-agents#1](https://github.com/szhygulin/vaultpilot-dev-agents/pull/1) diff exactly: 3 added (Saunders, Faraday, Charles), 11 updated, 1 unchanged (\`agent-916a\`), 28 excluded as synthetic.
- [x] CLI \`--help\` text renders cleanly for both subcommands.