### PR TITLE
refactor(tags): move section tags from CLAUDE.md sentinels to operator-only sidecar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,9 @@
 ## Per-agent workdir is `agents/<agent-id>/`
 Each coding agent dispatched by the orchestrator runs in its own `agents/<agent-id>/` sandbox. Cross-agent writes corrupt parallel runs.
 - `agents/`, `state/`, `logs/`, `dist/` are all gitignored — local state only. Never push agent transcripts, registry entries, run logs, or compiled output to `origin`.
-- `agents/<agent-id>/CLAUDE.md` is the per-agent memory; `agents/<agent-id>/` may also carry transcripts, summaries, and per-issue artifacts. Boundaries between agents matter: `agent-90e4/` must not write into `agent-51e5/` even if they're operating on the same target repo.
+- `agents/<agent-id>/CLAUDE.md` is the per-agent memory; `agents/<agent-id>/section-tags.json` is the per-section tags sidecar (operator-only metadata, kept out of the agent's prompt context); `agents/<agent-id>/` may also carry transcripts, summaries, and per-issue artifacts. Boundaries between agents matter: `agent-90e4/` must not write into `agent-51e5/` even if they're operating on the same target repo.
 - If a one-off debug run needs scratch files, put them under the per-agent dir or under `claude-work/` (gitignored cross-project). Never the repo root.
+- **Sentinel-tag sidecar (post-`refactor/tags-to-sidecar`)**: `appendBlock` writes section tags to `agents/<id>/section-tags.json` keyed by `deriveStableSectionId(runId, issueIds)`. The sentinel header is now `<!-- run:R issue:#N outcome:O ts:T -->` (no `tags:`). Pre-existing CLAUDE.mds with legacy `tags:` parse fine but should be migrated once via `vp-dev agents migrate-tags-to-sidecar --all` to keep operator-only metadata out of the agent's context.
 
 ## Three-layer push-protection for the target repo is load-bearing
 The orchestrator dispatches coding agents against a `--target-repo` (any GitHub repo with a local clone). Three independent layers prevent an agent from pushing to the target's `main`:

--- a/src/agent/migrateTagsToSidecar.test.ts
+++ b/src/agent/migrateTagsToSidecar.test.ts
@@ -1,0 +1,132 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import {
+  migrateContent,
+  stripLegacyTagsFromLine,
+} from "./migrateTagsToSidecar.js";
+import { deriveStableSectionId } from "../state/lessonUtility.js";
+
+describe("stripLegacyTagsFromLine", () => {
+  it("removes `tags:` from a legacy sentinel line", () => {
+    assert.equal(
+      stripLegacyTagsFromLine(
+        "<!-- run:r1 issue:#42 outcome:implement ts:2026-05-01T00:00:00.000Z tags:auth,refactor -->",
+      ),
+      "<!-- run:r1 issue:#42 outcome:implement ts:2026-05-01T00:00:00.000Z -->",
+    );
+  });
+
+  it("leaves tagless sentinels alone", () => {
+    const line =
+      "<!-- run:r1 issue:#42 outcome:implement ts:2026-05-01T00:00:00.000Z -->";
+    assert.equal(stripLegacyTagsFromLine(line), line);
+  });
+
+  it("leaves non-sentinel lines alone", () => {
+    assert.equal(stripLegacyTagsFromLine("## Heading"), "## Heading");
+    assert.equal(stripLegacyTagsFromLine(""), "");
+  });
+
+  it("works with multi-issue (compacted) sentinels", () => {
+    assert.equal(
+      stripLegacyTagsFromLine(
+        "<!-- run:r1 issue:#100+#101+#102 outcome:compacted ts:2026-05-07T00:00:00Z tags:zeta,eta -->",
+      ),
+      "<!-- run:r1 issue:#100+#101+#102 outcome:compacted ts:2026-05-07T00:00:00Z -->",
+    );
+  });
+});
+
+describe("migrateContent", () => {
+  it("empty / sentinel-free content is a no-op", () => {
+    const r1 = migrateContent("");
+    assert.equal(r1.rewritten, "");
+    assert.equal(r1.legacySentinelsFound, 0);
+    assert.deepEqual(r1.sidecarEntries, {});
+
+    const md = "# Heading\n\nSome body.\n";
+    const r2 = migrateContent(md);
+    assert.equal(r2.rewritten, md);
+    assert.equal(r2.legacySentinelsFound, 0);
+    assert.deepEqual(r2.sidecarEntries, {});
+  });
+
+  it("extracts tags + strips them from legacy sentinels", () => {
+    const md = [
+      "# Seed",
+      "",
+      "<!-- run:r1 issue:#100 outcome:implement ts:2026-05-07T00:00:00Z tags:alpha,beta -->",
+      "## Lesson 100",
+      "body",
+      "",
+      "<!-- run:r2 issue:#101 outcome:implement ts:2026-05-08T00:00:00Z tags:gamma -->",
+      "## Lesson 101",
+      "body",
+      "",
+    ].join("\n");
+
+    const r = migrateContent(md);
+    assert.equal(r.legacySentinelsFound, 2);
+
+    const id100 = deriveStableSectionId("r1", [100]);
+    const id101 = deriveStableSectionId("r2", [101]);
+    assert.deepEqual(r.sidecarEntries[id100], ["alpha", "beta"]);
+    assert.deepEqual(r.sidecarEntries[id101], ["gamma"]);
+
+    assert.ok(!r.rewritten.includes("tags:"));
+    assert.ok(r.rewritten.includes("<!-- run:r1 issue:#100 outcome:implement ts:2026-05-07T00:00:00Z -->"));
+    assert.ok(r.rewritten.includes("<!-- run:r2 issue:#101 outcome:implement ts:2026-05-08T00:00:00Z -->"));
+    assert.ok(r.rewritten.includes("## Lesson 100"));
+    assert.ok(r.rewritten.includes("## Lesson 101"));
+  });
+
+  it("idempotent: re-running on already-migrated content is a no-op", () => {
+    const md = [
+      "# Seed",
+      "",
+      "<!-- run:r1 issue:#100 outcome:implement ts:2026-05-07T00:00:00Z tags:alpha,beta -->",
+      "## Lesson 100",
+      "body",
+      "",
+    ].join("\n");
+    const first = migrateContent(md);
+    const second = migrateContent(first.rewritten);
+    assert.equal(second.legacySentinelsFound, 0);
+    assert.deepEqual(second.sidecarEntries, {});
+    assert.equal(second.rewritten, first.rewritten);
+  });
+
+  it("mixed file (some legacy, some already-migrated) extracts only the legacy", () => {
+    const md = [
+      "# Seed",
+      "",
+      "<!-- run:r1 issue:#100 outcome:implement ts:t1 tags:alpha -->",
+      "## Lesson 100",
+      "body",
+      "",
+      "<!-- run:r2 issue:#101 outcome:implement ts:t2 -->",
+      "## Lesson 101",
+      "body",
+      "",
+    ].join("\n");
+    const r = migrateContent(md);
+    assert.equal(r.legacySentinelsFound, 1);
+    const id100 = deriveStableSectionId("r1", [100]);
+    assert.deepEqual(r.sidecarEntries[id100], ["alpha"]);
+    assert.equal(Object.keys(r.sidecarEntries).length, 1);
+  });
+
+  it("compacted (multi-issue) sentinels resolve to a stable ID over the merged ID set", () => {
+    const md = [
+      "<!-- run:r1 issue:#100+#101+#102 outcome:compacted ts:2026-05-07T00:00:00Z tags:zeta,eta -->",
+      "## Compacted lesson",
+      "body",
+      "",
+    ].join("\n");
+    const r = migrateContent(md);
+    assert.equal(r.legacySentinelsFound, 1);
+    const id = deriveStableSectionId("r1", [100, 101, 102]);
+    assert.deepEqual(r.sidecarEntries[id], ["eta", "zeta"]);
+    assert.ok(!r.rewritten.includes("tags:"));
+  });
+});

--- a/src/agent/migrateTagsToSidecar.ts
+++ b/src/agent/migrateTagsToSidecar.ts
@@ -1,0 +1,166 @@
+// One-shot migration that moves legacy `tags:t1,t2` from sentinel headers
+// in `agents/<id>/CLAUDE.md` into the per-agent sidecar
+// (`agents/<id>/section-tags.json`). Idempotent — re-running on an
+// already-migrated CLAUDE.md is a no-op (the regex finds no `tags:` and the
+// sidecar already holds whatever was there).
+//
+// Strategy: read CLAUDE.md, walk every line; for any sentinel line that
+// matches the legacy regex, capture the tags, derive a stable section ID
+// from `(runId, issueIds)`, accumulate `{stableId: tags}`, then rewrite
+// the line with `tags:...` stripped. After the walk, replace the sidecar
+// with the merged accumulator and atomic-rename the rewritten CLAUDE.md.
+//
+// Holds `withFileLock` on CLAUDE.md throughout so a parallel `appendBlock`
+// can't observe a half-rewritten file. The sidecar write goes through its
+// own lock per `replaceSectionTags`.
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { withFileLock } from "../state/locks.js";
+import { agentClaudeMdPath, AGENTS_ROOT } from "./specialization.js";
+import {
+  extractLegacySentinelTags,
+  parseSentinelHeader,
+} from "../util/sentinels.js";
+import { stableIdForHeader, replaceSectionTags, readSectionTags } from "../state/sectionTags.js";
+
+export interface MigrateResult {
+  agentId: string;
+  /** Number of sentinel lines that carried legacy `tags:`. */
+  legacySentinelsFound: number;
+  /** Number of distinct stable IDs written to the sidecar. */
+  stableIdsWritten: number;
+  /** True if CLAUDE.md was rewritten (any legacy `tags:` removed). */
+  claudeMdRewritten: boolean;
+  /** Pre-migration byte size of CLAUDE.md. */
+  bytesBefore: number;
+  /** Post-migration byte size of CLAUDE.md. */
+  bytesAfter: number;
+}
+
+/** Strip ` tags:t1,t2` from a single sentinel line; return the cleaned line. */
+export function stripLegacyTagsFromLine(line: string): string {
+  // Anchor on the `tags:t1,t2` segment that sits immediately before the
+  // closing ` -->`. Only fires on lines that match the sentinel shape.
+  const m = line.match(
+    /^(<!--\s+run:\S+\s+issue:#\d+(?:\+#\d+)*\s+outcome:[\w-]+\s+ts:\S+?)\s+tags:\S+(\s+-->)$/,
+  );
+  if (!m) return line;
+  return `${m[1]}${m[2]}`;
+}
+
+export interface MigrateContentResult {
+  rewritten: string;
+  /** stable-ID → tag list extracted from legacy sentinels. */
+  sidecarEntries: Record<string, string[]>;
+  /** Number of sentinel lines that carried legacy `tags:`. */
+  legacySentinelsFound: number;
+}
+
+/** Pure migration over a CLAUDE.md string. Used directly by tests. */
+export function migrateContent(claudeMd: string): MigrateContentResult {
+  const lines = claudeMd.split("\n");
+  const sidecarEntries: Record<string, string[]> = {};
+  let legacySentinelsFound = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const tags = extractLegacySentinelTags(line.trim());
+    if (tags.length === 0) continue;
+    const header = parseSentinelHeader(line.trim());
+    if (!header) continue;
+    legacySentinelsFound++;
+    const id = stableIdForHeader(header);
+    sidecarEntries[id] = [...new Set([...(sidecarEntries[id] ?? []), ...tags])].sort();
+    lines[i] = stripLegacyTagsFromLine(line);
+  }
+
+  return {
+    rewritten: lines.join("\n"),
+    sidecarEntries,
+    legacySentinelsFound,
+  };
+}
+
+export async function migrateAgentTagsToSidecar(
+  agentId: string,
+): Promise<MigrateResult> {
+  const filePath = agentClaudeMdPath(agentId);
+
+  return withFileLock(filePath, async () => {
+    let current: string;
+    try {
+      current = await fs.readFile(filePath, "utf-8");
+    } catch (err: unknown) {
+      if ((err as { code?: string }).code === "ENOENT") {
+        return {
+          agentId,
+          legacySentinelsFound: 0,
+          stableIdsWritten: 0,
+          claudeMdRewritten: false,
+          bytesBefore: 0,
+          bytesAfter: 0,
+        };
+      }
+      throw err;
+    }
+    const bytesBefore = Buffer.byteLength(current, "utf-8");
+    const { rewritten, sidecarEntries, legacySentinelsFound } = migrateContent(current);
+
+    if (legacySentinelsFound === 0) {
+      return {
+        agentId,
+        legacySentinelsFound: 0,
+        stableIdsWritten: 0,
+        claudeMdRewritten: false,
+        bytesBefore,
+        bytesAfter: bytesBefore,
+      };
+    }
+
+    // Merge into the sidecar rather than overwrite — preserves any entries
+    // appendBlock has written post-deploy that aren't in the legacy file.
+    const sidecar = await readSectionTags(agentId);
+    const merged: Record<string, string[]> = { ...sidecar.sections };
+    for (const [id, tags] of Object.entries(sidecarEntries)) {
+      const combined = new Set([...(merged[id] ?? []), ...tags]);
+      merged[id] = [...combined].sort();
+    }
+    await replaceSectionTags(agentId, merged);
+
+    const tmp = `${filePath}.tmp.${process.pid}`;
+    await fs.writeFile(tmp, rewritten);
+    await fs.rename(tmp, filePath);
+
+    return {
+      agentId,
+      legacySentinelsFound,
+      stableIdsWritten: Object.keys(sidecarEntries).length,
+      claudeMdRewritten: true,
+      bytesBefore,
+      bytesAfter: Buffer.byteLength(rewritten, "utf-8"),
+    };
+  });
+}
+
+/** Walk `agents/` and migrate every directory that has a CLAUDE.md. */
+export async function migrateAllAgentsTagsToSidecar(): Promise<MigrateResult[]> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(AGENTS_ROOT);
+  } catch (err: unknown) {
+    if ((err as { code?: string }).code === "ENOENT") return [];
+    throw err;
+  }
+  const results: MigrateResult[] = [];
+  for (const name of entries.sort()) {
+    const claudePath = path.join(AGENTS_ROOT, name, "CLAUDE.md");
+    try {
+      await fs.access(claudePath);
+    } catch {
+      continue;
+    }
+    results.push(await migrateAgentTagsToSidecar(name));
+  }
+  return results;
+}

--- a/src/agent/pruneTags.test.ts
+++ b/src/agent/pruneTags.test.ts
@@ -6,68 +6,102 @@ import {
   computePruneTagsProposalHash,
   type PruneTagsProposal,
 } from "./pruneTags.js";
+import { deriveStableSectionId } from "../state/lessonUtility.js";
 
-// Build a minimal CLAUDE.md fixture with N sentinels carrying the supplied
-// tag arrays.
-function buildClaudeMd(sentinels: { runId: string; issueId: number; tags: string[] }[]): string {
+interface SentinelSpec {
+  runId: string;
+  issueId: number;
+  tags: string[];
+}
+
+// Build a tagless CLAUDE.md (sentinels emit no `tags:` post-refactor) plus a
+// parallel `sectionTagsByStableId` map keyed by `deriveStableSectionId(runId,
+// [issueId])`. Mirrors how the production code reads tags from the sidecar.
+function buildFixture(sentinels: SentinelSpec[]): {
+  claudeMd: string;
+  sectionTagsByStableId: Record<string, string[]>;
+} {
   const lines: string[] = ["# Seed", ""];
+  const sectionTagsByStableId: Record<string, string[]> = {};
   for (const s of sentinels) {
-    const tagsPart = s.tags.length > 0 ? ` tags:${[...s.tags].sort().join(",")}` : "";
     lines.push(
-      `<!-- run:${s.runId} issue:#${s.issueId} outcome:implement ts:2026-05-07T00:00:00Z${tagsPart} -->`,
+      `<!-- run:${s.runId} issue:#${s.issueId} outcome:implement ts:2026-05-07T00:00:00Z -->`,
     );
     lines.push(`## Lesson ${s.issueId}`);
     lines.push("body");
     lines.push("");
+    if (s.tags.length > 0) {
+      const id = deriveStableSectionId(s.runId, [s.issueId]);
+      sectionTagsByStableId[id] = [...s.tags].sort();
+    }
   }
-  return lines.join("\n");
+  return { claudeMd: lines.join("\n"), sectionTagsByStableId };
 }
 
 describe("parseSectionTagsUnion", () => {
   it("returns empty union and zero count for an empty file", () => {
-    const { union, sectionCount } = parseSectionTagsUnion("");
+    const { union, sectionCount } = parseSectionTagsUnion("", {});
     assert.equal(union.size, 0);
     assert.equal(sectionCount, 0);
   });
 
   it("returns empty union and zero count when no sentinels present", () => {
     const md = "# Seed\n\nSome prose. No sentinels here.\n";
-    const { union, sectionCount } = parseSectionTagsUnion(md);
+    const { union, sectionCount } = parseSectionTagsUnion(md, {});
     assert.equal(union.size, 0);
     assert.equal(sectionCount, 0);
   });
 
-  it("collects tags across multiple sentinels", () => {
-    const md = buildClaudeMd([
+  it("collects tags from the sidecar across multiple sentinels", () => {
+    const { claudeMd, sectionTagsByStableId } = buildFixture([
       { runId: "r1", issueId: 100, tags: ["alpha", "beta"] },
       { runId: "r2", issueId: 101, tags: ["beta", "gamma"] },
     ]);
-    const { union, sectionCount } = parseSectionTagsUnion(md);
+    const { union, sectionCount } = parseSectionTagsUnion(claudeMd, sectionTagsByStableId);
     assert.equal(sectionCount, 2);
     assert.deepEqual([...union].sort(), ["alpha", "beta", "gamma"]);
   });
 
-  it("counts sentinels without tags but contributes nothing to union (legacy)", () => {
-    const md = buildClaudeMd([
-      { runId: "r1", issueId: 100, tags: [] },
+  it("counts sentinels missing from sidecar but contributes nothing to union", () => {
+    const { claudeMd, sectionTagsByStableId } = buildFixture([
+      { runId: "r1", issueId: 100, tags: [] }, // no sidecar entry
       { runId: "r2", issueId: 101, tags: ["delta"] },
     ]);
-    const { union, sectionCount } = parseSectionTagsUnion(md);
+    const { union, sectionCount } = parseSectionTagsUnion(claudeMd, sectionTagsByStableId);
     assert.equal(sectionCount, 2);
     assert.deepEqual([...union], ["delta"]);
   });
 
-  it("handles multi-issue (compacted) sentinels without crashing", () => {
+  it("handles multi-issue (compacted) sentinels", () => {
+    const compactedStableId = deriveStableSectionId("r1", [100, 101, 102]);
     const md = [
       "# Seed",
       "",
-      "<!-- run:r1 issue:#100+#101+#102 outcome:compacted ts:2026-05-07T00:00:00Z tags:zeta,eta -->",
+      "<!-- run:r1 issue:#100+#101+#102 outcome:compacted ts:2026-05-07T00:00:00Z -->",
       "## Compacted lesson",
       "body",
     ].join("\n");
-    const { union, sectionCount } = parseSectionTagsUnion(md);
+    const sidecar = { [compactedStableId]: ["eta", "zeta"] };
+    const { union, sectionCount } = parseSectionTagsUnion(md, sidecar);
     assert.equal(sectionCount, 1);
     assert.deepEqual([...union].sort(), ["eta", "zeta"]);
+  });
+
+  it("legacy `tags:` in sentinel is silently ignored — sidecar wins", () => {
+    // Existing pre-migration CLAUDE.md still parses; only the sidecar
+    // contributes to the union. Migration cleans the legacy `tags:` later.
+    const md = [
+      "# Seed",
+      "",
+      "<!-- run:r1 issue:#100 outcome:implement ts:2026-05-07T00:00:00Z tags:legacy,one -->",
+      "## Lesson",
+      "body",
+    ].join("\n");
+    const stableId = deriveStableSectionId("r1", [100]);
+    const sidecar = { [stableId]: ["sidecar-tag"] };
+    const { union, sectionCount } = parseSectionTagsUnion(md, sidecar);
+    assert.equal(sectionCount, 1);
+    assert.deepEqual([...union], ["sidecar-tag"]);
   });
 });
 
@@ -110,10 +144,11 @@ describe("proposePruneTags (Phase 1 only)", () => {
   // Lazy import to avoid pulling the SDK at module load.
   async function propose(args: {
     tags: string[];
-    sentinels: { runId: string; issueId: number; tags: string[] }[];
+    sentinels: SentinelSpec[];
     noGeneralize?: boolean;
   }) {
     const { proposePruneTags } = await import("./pruneTags.js");
+    const { claudeMd, sectionTagsByStableId } = buildFixture(args.sentinels);
     return proposePruneTags({
       agent: {
         agentId: "agent-test",
@@ -125,7 +160,8 @@ describe("proposePruneTags (Phase 1 only)", () => {
         errorCount: 0,
         lastActiveAt: "2026-01-01T00:00:00Z",
       },
-      claudeMd: buildClaudeMd(args.sentinels),
+      claudeMd,
+      sectionTagsByStableId,
       noGeneralize: args.noGeneralize ?? true,
     });
   }
@@ -138,10 +174,7 @@ describe("proposePruneTags (Phase 1 only)", () => {
     assert.match(p.notes ?? "", /No attributable sections/);
   });
 
-  it("sections present but no tag provenance (post-split children, pre-#142): tags untouched", async () => {
-    // Sentinels with empty tags array — exactly the shape post-split
-    // children carry from split.ts:458 (no `tags:` field on materialized
-    // sentinels) AND pre-#142 legacy sentinels.
+  it("sections present but no tag provenance (sidecar empty / legacy children): tags untouched", async () => {
     const p = await propose({
       tags: ["alpha", "beta", "gamma"],
       sentinels: [
@@ -167,7 +200,6 @@ describe("proposePruneTags (Phase 1 only)", () => {
   });
 
   it("floor protection: registry of only orphans + general -> ['general']", async () => {
-    // Section has tags but none match the registry.
     const p = await propose({
       tags: ["unrelated", "general"],
       sentinels: [{ runId: "r1", issueId: 1, tags: ["alpha"] }],
@@ -200,7 +232,6 @@ describe("proposePruneTags (Phase 1 only)", () => {
   it("idempotent: re-running on a registry already equal to lesson-backed surfaces zero orphans", async () => {
     const sentinels = [{ runId: "r1", issueId: 1, tags: ["alpha", "beta"] }];
     const first = await propose({ tags: ["alpha", "beta", "orphan"], sentinels });
-    // Imagine apply happened: tags now equal first.finalTags.
     const second = await propose({ tags: first.finalTags, sentinels });
     assert.deepEqual(second.orphanTags, []);
     assert.deepEqual(second.finalTags, first.finalTags);

--- a/src/agent/pruneTags.ts
+++ b/src/agent/pruneTags.ts
@@ -29,6 +29,7 @@ import { claudeBinPath } from "./sdkBinary.js";
 import { mutateRegistry } from "../state/registry.js";
 import { parseJsonEnvelope } from "../util/parseJsonEnvelope.js";
 import { parseSentinelHeader } from "../util/sentinels.js";
+import { deriveStableSectionId } from "../state/lessonUtility.js";
 import { ORCHESTRATOR_MODEL_SPLIT } from "../orchestrator/models.js";
 import type { AgentRecord } from "../types.js";
 
@@ -108,14 +109,16 @@ function clampClusterFields(json: unknown): unknown {
 }
 
 /**
- * Parse a CLAUDE.md and return the union of all `tags:` provenance fields
- * across `<!-- run:... -->` sentinel comments, plus the count of sentinels
- * found. Sentinels written before tag-provenance landed (per #142) lack a
- * `tags:` field; they contribute nothing to the union but still count
- * toward the section total.
+ * Walk a CLAUDE.md to count `<!-- run:... -->` sentinels, and union the
+ * tag arrays for those sentinels from the per-agent sidecar
+ * (`agents/<id>/section-tags.json`). Sections whose stable IDs are absent
+ * from the sidecar contribute nothing to the union but still count toward
+ * the section total — same conservative posture as the legacy in-sentinel
+ * `tags:` reader.
  */
 export function parseSectionTagsUnion(
   claudeMd: string,
+  sectionTagsByStableId: Record<string, string[]>,
 ): { union: Set<string>; sectionCount: number } {
   const union = new Set<string>();
   let sectionCount = 0;
@@ -123,7 +126,13 @@ export function parseSectionTagsUnion(
     const header = parseSentinelHeader(line.trim());
     if (!header) continue;
     sectionCount++;
-    for (const t of header.tags) union.add(t);
+    const ids = header.issueIds && header.issueIds.length > 0
+      ? header.issueIds
+      : [header.issueId];
+    const stableId = deriveStableSectionId(header.runId, ids);
+    const tags = sectionTagsByStableId[stableId];
+    if (!tags) continue;
+    for (const t of tags) union.add(t);
   }
   return { union, sectionCount };
 }
@@ -147,6 +156,12 @@ export interface ProposePruneTagsInput {
   agent: AgentRecord;
   /** The agent's current CLAUDE.md content (or "" if missing). */
   claudeMd: string;
+  /**
+   * Stable-id → tags map from the agent's `section-tags.json` sidecar.
+   * Pass `{}` for agents with no sidecar yet (fresh / un-migrated); they
+   * surface as zero-section-tags-union and the empty-result paths handle it.
+   */
+  sectionTagsByStableId: Record<string, string[]>;
   /** When true, skip Phase 2 (LLM generalization); orphan-drop only. */
   noGeneralize?: boolean;
 }
@@ -160,7 +175,10 @@ export async function proposePruneTags(
   input: ProposePruneTagsInput,
 ): Promise<PruneTagsProposal> {
   const registryTagsBefore = [...new Set(input.agent.tags)].sort();
-  const { union: sectionTagsUnion, sectionCount } = parseSectionTagsUnion(input.claudeMd);
+  const { union: sectionTagsUnion, sectionCount } = parseSectionTagsUnion(
+    input.claudeMd,
+    input.sectionTagsByStableId,
+  );
   const sectionTagsSorted = [...sectionTagsUnion].sort();
 
   const registrySet = new Set(registryTagsBefore);

--- a/src/agent/specialization.ts
+++ b/src/agent/specialization.ts
@@ -8,6 +8,12 @@ import {
   type ExpiryPolicy,
   type SentinelHeader,
 } from "../util/sentinels.js";
+import {
+  dropSectionTagsEntries,
+  readSectionTags,
+  stableIdForHeader,
+  writeSectionTagsEntry,
+} from "../state/sectionTags.js";
 
 export const AGENTS_ROOT = path.resolve(process.cwd(), "agents");
 export const SOFT_CAP_BYTES = 64 * 1024;
@@ -124,11 +130,11 @@ export interface AppendBlockInput {
   targetRepoPath: string;
   /**
    * Tags this issue contributed to the agent's evolving topical
-   * fingerprint (= envelope.memoryUpdate.addTags). Embedded into the
-   * sentinel header as `tags:t1,t2` so future expiry passes can detect
-   * whether subsequent successes are topically related to a stored
-   * failure-lesson. Optional for back-compat; sentinels written without
-   * tags are treated conservatively (never expired) by `expireFailureLessons`.
+   * fingerprint (= envelope.memoryUpdate.addTags). Stored in the sidecar
+   * `agents/<id>/section-tags.json` keyed by stable section ID so the
+   * agent's CLAUDE.md stays free of operator-only metadata. Conservative
+   * on missing tags: a section with empty tags is never expired by
+   * `expireFailureLessons` / `expireSentinels`.
    */
   tags?: string[];
 }
@@ -157,7 +163,6 @@ export async function appendBlock(input: AppendBlockInput): Promise<AppendOutcom
       issueId: input.issueId,
       outcome: input.outcome,
       ts,
-      tags: input.tags,
     });
     const block = [
       "",
@@ -172,6 +177,16 @@ export async function appendBlock(input: AppendBlockInput): Promise<AppendOutcom
     const tmp = `${filePath}.tmp.${process.pid}`;
     await fs.writeFile(tmp, next);
     await fs.rename(tmp, filePath);
+
+    if (input.tags && input.tags.length > 0) {
+      const stableId = stableIdForHeader({
+        runId: input.runId,
+        issueId: input.issueId,
+        outcome: input.outcome,
+        ts,
+      });
+      await writeSectionTagsEntry(input.agentId, stableId, input.tags);
+    }
 
     const totalBytes = Buffer.byteLength(next, "utf-8");
     return {
@@ -189,8 +204,8 @@ export type ExpireOutcome =
 /**
  * Walk the agent's CLAUDE.md and drop sentinel blocks per the supplied
  * policies. Idempotent — re-running on the same content with the same
- * policies is a no-op. Conservative on legacy sentinels with no `tags:`
- * field: those are never expired.
+ * policies is a no-op. Conservative on sections whose sidecar entry is
+ * missing or empty: those are never expired.
  *
  * Wired from `runIssueCore` after a successful implement run, matching
  * the issue's "summarizer rewrites the file after a successful run"
@@ -211,12 +226,19 @@ export async function expireSentinels(
       // forkClaudeMd / appendBlock's job.
       return { kind: "no-op" };
     }
-    const result = expireSentinelsInContent(current, policies);
+    const sidecar = await readSectionTags(agentId);
+    const getTags = (h: SentinelHeader): string[] =>
+      sidecar.sections[stableIdForHeader(h)] ?? [];
+    const result = expireSentinelsInContent(current, policies, getTags);
     if (result.droppedHeaders.length === 0) return { kind: "no-op" };
 
     const tmp = `${filePath}.tmp.${process.pid}`;
     await fs.writeFile(tmp, result.content);
     await fs.rename(tmp, filePath);
+
+    const droppedStableIds = result.droppedHeaders.map(stableIdForHeader);
+    await dropSectionTagsEntries(agentId, droppedStableIds);
+
     return {
       kind: "expired",
       dropped: result.droppedHeaders,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -454,6 +454,18 @@ export function buildCli(): Command {
         }),
     )
     .addCommand(
+      new Command("migrate-tags-to-sidecar")
+        .description(
+          "Move legacy `tags:t1,t2` from sentinel headers in `agents/<id>/CLAUDE.md` into the per-agent `agents/<id>/section-tags.json` sidecar. Idempotent — re-running is a no-op once an agent's CLAUDE.md is clean. Use `--all` to walk every agent under `agents/`, or pass an explicit `<agentId>`.",
+        )
+        .argument("[agentId]", "Single agent to migrate (omit if --all)")
+        .option("--all", "Migrate every directory under `agents/` that has a CLAUDE.md")
+        .option("--json", "Print machine-readable JSON")
+        .action(async (agentId, opts) => {
+          await cmdAgentsMigrateTagsToSidecar(agentId, opts);
+        }),
+    )
+    .addCommand(
       new Command("audit-lessons")
         .description(
           "Score every section of an agent's CLAUDE.md by intrinsic quality (in vacuum — no run history, no comparison across sections). Per-section sonnet calls rate each lesson on the same 0-1 scale as write-time predictedUtility. Advisory only (Phase 1); destructive --apply / --confirm deferred. Combine with `vp-dev agents prune-lessons` for the historical-reinforcement signal.",
@@ -2861,12 +2873,16 @@ async function cmdAgentsPruneTags(
     // empty string flows through proposePruneTags' zero-section branch
   }
 
+  const { readSectionTags } = await import("./state/sectionTags.js");
+  const sidecar = await readSectionTags(agentId);
+
   // Commander wires --no-generalize to `generalize: false` (default true).
   const noGeneralize = opts.generalize === false;
 
   const proposal = await proposePruneTags({
     agent,
     claudeMd,
+    sectionTagsByStableId: sidecar.sections,
     noGeneralize,
   });
 
@@ -2900,6 +2916,63 @@ async function cmdAgentsPruneTags(
     `\nConfirm token: ${token} (15-min TTL, written to state/prune-tags-confirm-${token}.json)\n` +
       `Apply with:    vp-dev agents prune-tags ${agentId} --confirm ${token}\n`,
   );
+}
+
+interface AgentsMigrateTagsToSidecarOpts {
+  all?: boolean;
+  json?: boolean;
+}
+
+async function cmdAgentsMigrateTagsToSidecar(
+  agentId: string | undefined,
+  opts: AgentsMigrateTagsToSidecarOpts,
+): Promise<void> {
+  const { migrateAgentTagsToSidecar, migrateAllAgentsTagsToSidecar } = await import(
+    "./agent/migrateTagsToSidecar.js"
+  );
+
+  if (!opts.all && !agentId) {
+    process.stderr.write(
+      "ERROR: pass <agentId> or --all to migrate-tags-to-sidecar.\n",
+    );
+    process.exit(2);
+  }
+  if (opts.all && agentId) {
+    process.stderr.write(
+      "ERROR: --all and <agentId> are mutually exclusive.\n",
+    );
+    process.exit(2);
+  }
+
+  const results = opts.all
+    ? await migrateAllAgentsTagsToSidecar()
+    : [await migrateAgentTagsToSidecar(agentId as string)];
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(results, null, 2) + "\n");
+    return;
+  }
+
+  if (results.length === 0) {
+    process.stdout.write("No agents found under agents/.\n");
+    return;
+  }
+
+  let totalRewritten = 0;
+  let totalSentinels = 0;
+  for (const r of results) {
+    if (r.claudeMdRewritten) totalRewritten++;
+    totalSentinels += r.legacySentinelsFound;
+    const status = r.claudeMdRewritten
+      ? `migrated ${r.legacySentinelsFound} sentinel(s) -> ${r.stableIdsWritten} sidecar entries (${r.bytesBefore} -> ${r.bytesAfter} bytes)`
+      : "no legacy `tags:` found (already clean or no CLAUDE.md)";
+    process.stdout.write(`${r.agentId}: ${status}\n`);
+  }
+  if (results.length > 1) {
+    process.stdout.write(
+      `\n${totalRewritten}/${results.length} agents migrated; ${totalSentinels} legacy sentinels stripped.\n`,
+    );
+  }
 }
 
 interface AgentsAuditLessonsOpts {

--- a/src/state/sectionTags.test.ts
+++ b/src/state/sectionTags.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, after } from "node:test";
+import { strict as assert } from "node:assert";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import {
+  readSectionTags,
+  writeSectionTagsEntry,
+  replaceSectionTags,
+  dropSectionTagsEntries,
+  sectionTagsPath,
+  stableIdForHeader,
+  SECTION_TAGS_FILE_VERSION,
+} from "./sectionTags.js";
+import { AGENTS_ROOT } from "../agent/specialization.js";
+
+// AGENTS_ROOT is computed from process.cwd() at module load. Tests run from
+// the repo root, so we land under `<repo>/agents/<id>/`.
+function uniqueAgentId(): string {
+  return `agent-test-${process.pid}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+}
+
+async function cleanup(agentId: string): Promise<void> {
+  const dir = path.join(AGENTS_ROOT, agentId);
+  await fs.rm(dir, { recursive: true, force: true });
+}
+
+describe("sectionTags sidecar", () => {
+  const agents: string[] = [];
+
+  after(async () => {
+    for (const id of agents) await cleanup(id);
+  });
+
+  it("readSectionTags returns empty file when sidecar is missing", async () => {
+    const id = uniqueAgentId();
+    agents.push(id);
+    const sidecar = await readSectionTags(id);
+    assert.equal(sidecar.version, SECTION_TAGS_FILE_VERSION);
+    assert.deepEqual(sidecar.sections, {});
+  });
+
+  it("writeSectionTagsEntry persists a single entry, sorted + deduped", async () => {
+    const id = uniqueAgentId();
+    agents.push(id);
+    await writeSectionTagsEntry(id, "stable-1", ["b", "a", "b", "c"]);
+    const sidecar = await readSectionTags(id);
+    assert.deepEqual(sidecar.sections["stable-1"], ["a", "b", "c"]);
+  });
+
+  it("writeSectionTagsEntry merges multiple entries", async () => {
+    const id = uniqueAgentId();
+    agents.push(id);
+    await writeSectionTagsEntry(id, "id-1", ["alpha"]);
+    await writeSectionTagsEntry(id, "id-2", ["beta"]);
+    const sidecar = await readSectionTags(id);
+    assert.deepEqual(sidecar.sections, { "id-1": ["alpha"], "id-2": ["beta"] });
+  });
+
+  it("replaceSectionTags overwrites the whole sidecar", async () => {
+    const id = uniqueAgentId();
+    agents.push(id);
+    await writeSectionTagsEntry(id, "stale-id", ["old"]);
+    await replaceSectionTags(id, { "fresh-id": ["new", "tag"] });
+    const sidecar = await readSectionTags(id);
+    assert.deepEqual(sidecar.sections, { "fresh-id": ["new", "tag"] });
+  });
+
+  it("dropSectionTagsEntries removes specific stable IDs only", async () => {
+    const id = uniqueAgentId();
+    agents.push(id);
+    await replaceSectionTags(id, {
+      keep: ["a"],
+      drop1: ["b"],
+      drop2: ["c"],
+    });
+    await dropSectionTagsEntries(id, ["drop1", "drop2", "non-existent"]);
+    const sidecar = await readSectionTags(id);
+    assert.deepEqual(sidecar.sections, { keep: ["a"] });
+  });
+
+  it("dropSectionTagsEntries on empty drop set is a no-op", async () => {
+    const id = uniqueAgentId();
+    agents.push(id);
+    await replaceSectionTags(id, { id1: ["a"] });
+    await dropSectionTagsEntries(id, []);
+    const sidecar = await readSectionTags(id);
+    assert.deepEqual(sidecar.sections, { id1: ["a"] });
+  });
+
+  it("readSectionTags ignores corrupt JSON gracefully (returns empty file)", async () => {
+    const id = uniqueAgentId();
+    agents.push(id);
+    const filePath = sectionTagsPath(id);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "{not json");
+    await assert.rejects(() => readSectionTags(id));
+  });
+
+  it("stableIdForHeader: single-issue sentinel", () => {
+    const id = stableIdForHeader({
+      runId: "r1",
+      issueId: 42,
+      outcome: "implement",
+      ts: "t1",
+    });
+    assert.match(id, /^[a-f0-9]{64}$/);
+  });
+
+  it("stableIdForHeader: multi-issue (compacted) sentinel uses sorted issue list", () => {
+    const a = stableIdForHeader({
+      runId: "r1",
+      issueId: 100,
+      issueIds: [100, 101, 102],
+      outcome: "compacted",
+      ts: "t1",
+    });
+    const b = stableIdForHeader({
+      runId: "r1",
+      issueId: 101,
+      issueIds: [102, 101, 100],
+      outcome: "compacted",
+      ts: "t1",
+    });
+    assert.equal(a, b);
+  });
+});

--- a/src/state/sectionTags.ts
+++ b/src/state/sectionTags.ts
@@ -1,0 +1,131 @@
+// Per-agent section-tags sidecar.
+//
+// Tags used to live inside the sentinel header of each section in
+// `agents/<id>/CLAUDE.md` (`<!-- run:R issue:#N outcome:O ts:T tags:t1,t2 -->`),
+// which meant every dispatch loaded ~150 bytes of tag metadata per section
+// into the agent's prompt context — pure metadata that the agent never
+// reads. This module stores tags out-of-band in `agents/<id>/section-tags.json`
+// keyed by the section's stable ID (`deriveStableSectionId(runId, issueIds)`),
+// so sentinels stay minimal and tags are visible only to operator tooling.
+//
+// Concurrency: each write goes through `withFileLock` on the sidecar path,
+// independent of the CLAUDE.md lock. `appendBlock` holds both locks (CLAUDE.md
+// outer, sidecar inner) so a parallel `pruneTags --confirm` can't observe a
+// half-written pair.
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { withFileLock, ensureDir } from "./locks.js";
+import { agentClaudeMdPath } from "../agent/specialization.js";
+import { deriveStableSectionId } from "./lessonUtility.js";
+import type { SentinelHeader } from "../util/sentinels.js";
+
+export const SECTION_TAGS_FILE_VERSION = 1;
+
+export interface SectionTagsFile {
+  version: number;
+  sections: Record<string, string[]>;
+}
+
+export function sectionTagsPath(agentId: string): string {
+  return path.join(path.dirname(agentClaudeMdPath(agentId)), "section-tags.json");
+}
+
+export function stableIdForHeader(header: SentinelHeader): string {
+  const ids = header.issueIds && header.issueIds.length > 0
+    ? header.issueIds
+    : [header.issueId];
+  return deriveStableSectionId(header.runId, ids);
+}
+
+export async function readSectionTags(agentId: string): Promise<SectionTagsFile> {
+  const filePath = sectionTagsPath(agentId);
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as Partial<SectionTagsFile>;
+    if (typeof parsed !== "object" || parsed === null) {
+      return { version: SECTION_TAGS_FILE_VERSION, sections: {} };
+    }
+    return {
+      version:
+        typeof parsed.version === "number" ? parsed.version : SECTION_TAGS_FILE_VERSION,
+      sections:
+        parsed.sections && typeof parsed.sections === "object"
+          ? (parsed.sections as Record<string, string[]>)
+          : {},
+    };
+  } catch (err: unknown) {
+    if ((err as { code?: string }).code === "ENOENT") {
+      return { version: SECTION_TAGS_FILE_VERSION, sections: {} };
+    }
+    throw err;
+  }
+}
+
+async function writeSidecarAtomic(
+  filePath: string,
+  data: SectionTagsFile,
+): Promise<void> {
+  await ensureDir(path.dirname(filePath));
+  const tmp = `${filePath}.tmp.${process.pid}`;
+  await fs.writeFile(tmp, JSON.stringify(data, null, 2) + "\n");
+  await fs.rename(tmp, filePath);
+}
+
+export async function writeSectionTagsEntry(
+  agentId: string,
+  stableId: string,
+  tags: string[],
+): Promise<void> {
+  const filePath = sectionTagsPath(agentId);
+  await withFileLock(filePath, async () => {
+    const current = await readSectionTags(agentId);
+    current.sections[stableId] = [...new Set(tags)].sort();
+    await writeSidecarAtomic(filePath, current);
+  });
+}
+
+export async function replaceSectionTags(
+  agentId: string,
+  entries: Record<string, string[]>,
+): Promise<void> {
+  const filePath = sectionTagsPath(agentId);
+  await withFileLock(filePath, async () => {
+    const out: SectionTagsFile = {
+      version: SECTION_TAGS_FILE_VERSION,
+      sections: {},
+    };
+    for (const [stableId, tags] of Object.entries(entries)) {
+      out.sections[stableId] = [...new Set(tags)].sort();
+    }
+    await writeSidecarAtomic(filePath, out);
+  });
+}
+
+export async function dropSectionTagsEntries(
+  agentId: string,
+  stableIds: Iterable<string>,
+): Promise<void> {
+  const drop = new Set(stableIds);
+  if (drop.size === 0) return;
+  const filePath = sectionTagsPath(agentId);
+  await withFileLock(filePath, async () => {
+    const current = await readSectionTags(agentId);
+    let changed = false;
+    for (const id of drop) {
+      if (id in current.sections) {
+        delete current.sections[id];
+        changed = true;
+      }
+    }
+    if (!changed) return;
+    await writeSidecarAtomic(filePath, current);
+  });
+}
+
+export function tagsByHeaderIndex(
+  headers: ReadonlyArray<SentinelHeader>,
+  sidecar: SectionTagsFile,
+): string[][] {
+  return headers.map((h) => sidecar.sections[stableIdForHeader(h)] ?? []);
+}

--- a/src/util/sentinels.test.ts
+++ b/src/util/sentinels.test.ts
@@ -8,34 +8,53 @@ import {
   decideExpiryWithPolicies,
   expireFailureLessonsInContent,
   expireSentinelsInContent,
+  extractLegacySentinelTags,
   formatSentinelHeader,
   parseSentinelHeader,
   resolveExpireK,
   resolveExpiryPolicies,
   type ExpiryPolicy,
+  type SentinelHeader,
 } from "./sentinels.js";
 
-test("parseSentinelHeader: legacy sentinel without tags", () => {
+test("parseSentinelHeader: tagless sentinel", () => {
   const h = parseSentinelHeader(
     "<!-- run:run-1 issue:#42 outcome:failure-lesson ts:2026-05-01T00:00:00.000Z -->",
   );
-  assert.notEqual(h, null);
   assert.deepEqual(h, {
     runId: "run-1",
     issueId: 42,
     outcome: "failure-lesson",
     ts: "2026-05-01T00:00:00.000Z",
-    tags: [],
   });
 });
 
-test("parseSentinelHeader: sentinel with tags", () => {
+test("parseSentinelHeader: legacy `tags:` is silently tolerated and dropped from header", () => {
   const h = parseSentinelHeader(
     "<!-- run:run-1 issue:#42 outcome:implement ts:2026-05-02T00:00:00.000Z tags:auth,refactor -->",
   );
-  assert.notEqual(h, null);
-  assert.deepEqual(h?.tags, ["auth", "refactor"]);
-  assert.equal(h?.outcome, "implement");
+  assert.deepEqual(h, {
+    runId: "run-1",
+    issueId: 42,
+    outcome: "implement",
+    ts: "2026-05-02T00:00:00.000Z",
+  });
+});
+
+test("extractLegacySentinelTags: extracts tags from legacy line for migration", () => {
+  assert.deepEqual(
+    extractLegacySentinelTags(
+      "<!-- run:run-1 issue:#42 outcome:implement ts:2026-05-02T00:00:00.000Z tags:auth,refactor -->",
+    ),
+    ["auth", "refactor"],
+  );
+  assert.deepEqual(
+    extractLegacySentinelTags(
+      "<!-- run:run-1 issue:#42 outcome:implement ts:2026-05-02T00:00:00.000Z -->",
+    ),
+    [],
+  );
+  assert.deepEqual(extractLegacySentinelTags("not a sentinel"), []);
 });
 
 test("parseSentinelHeader: non-sentinel line returns null", () => {
@@ -44,145 +63,130 @@ test("parseSentinelHeader: non-sentinel line returns null", () => {
   assert.equal(parseSentinelHeader(""), null);
 });
 
-test("formatSentinelHeader: round-trip", () => {
+test("formatSentinelHeader: emits no `tags:` field", () => {
   const line = formatSentinelHeader({
     runId: "run-X",
     issueId: 7,
     outcome: "failure-lesson",
     ts: "2026-05-01T00:00:00.000Z",
-    tags: ["b", "a"],
   });
-  // Tags are sorted at format time for stable output.
   assert.equal(
     line,
-    "<!-- run:run-X issue:#7 outcome:failure-lesson ts:2026-05-01T00:00:00.000Z tags:a,b -->",
+    "<!-- run:run-X issue:#7 outcome:failure-lesson ts:2026-05-01T00:00:00.000Z -->",
   );
   const parsed = parseSentinelHeader(line);
-  assert.deepEqual(parsed?.tags, ["a", "b"]);
+  assert.deepEqual(parsed, {
+    runId: "run-X",
+    issueId: 7,
+    outcome: "failure-lesson",
+    ts: "2026-05-01T00:00:00.000Z",
+  });
 });
+
+// Helper: each header gets tags from a `tags` array parallel to the header
+// list. Mirrors how callers (`specialization.ts`) build tagsByIndex from the
+// sidecar.
+function header(
+  outcome: string,
+  i: number,
+  tags?: string[],
+): SentinelHeader & { _tags: string[] } {
+  const h = {
+    runId: `r${i}`,
+    issueId: i,
+    outcome,
+    ts: `t${i}`,
+  } as SentinelHeader & { _tags: string[] };
+  h._tags = tags ?? [];
+  return h;
+}
+
+function tagsOf(headers: Array<SentinelHeader & { _tags: string[] }>): string[][] {
+  return headers.map((h) => h._tags);
+}
 
 test("decideExpiry: drops failure-lesson with K=3 overlapping implements", () => {
   const headers = [
-    {
-      runId: "r1",
-      issueId: 1,
-      outcome: "failure-lesson",
-      ts: "t1",
-      tags: ["auth"],
-    },
-    { runId: "r2", issueId: 2, outcome: "implement", ts: "t2", tags: ["auth"] },
-    {
-      runId: "r3",
-      issueId: 3,
-      outcome: "implement",
-      ts: "t3",
-      tags: ["auth", "x"],
-    },
-    { runId: "r4", issueId: 4, outcome: "implement", ts: "t4", tags: ["auth"] },
+    header("failure-lesson", 1, ["auth"]),
+    header("implement", 2, ["auth"]),
+    header("implement", 3, ["auth", "x"]),
+    header("implement", 4, ["auth"]),
   ];
-  const d = decideExpiry(headers, 3);
+  const d = decideExpiry(headers, tagsOf(headers), 3);
   assert.deepEqual(d.drop, [0]);
 });
 
 test("decideExpiry: keeps failure-lesson with non-overlapping implements", () => {
   const headers = [
-    {
-      runId: "r1",
-      issueId: 1,
-      outcome: "failure-lesson",
-      ts: "t1",
-      tags: ["auth"],
-    },
-    { runId: "r2", issueId: 2, outcome: "implement", ts: "t2", tags: ["docs"] },
-    { runId: "r3", issueId: 3, outcome: "implement", ts: "t3", tags: ["docs"] },
-    { runId: "r4", issueId: 4, outcome: "implement", ts: "t4", tags: ["docs"] },
+    header("failure-lesson", 1, ["auth"]),
+    header("implement", 2, ["docs"]),
+    header("implement", 3, ["docs"]),
+    header("implement", 4, ["docs"]),
   ];
-  const d = decideExpiry(headers, 3);
+  const d = decideExpiry(headers, tagsOf(headers), 3);
   assert.deepEqual(d.drop, []);
 });
 
 test("decideExpiry: keeps failure-lesson with K-1 overlapping implements", () => {
   const headers = [
-    {
-      runId: "r1",
-      issueId: 1,
-      outcome: "failure-lesson",
-      ts: "t1",
-      tags: ["auth"],
-    },
-    { runId: "r2", issueId: 2, outcome: "implement", ts: "t2", tags: ["auth"] },
-    { runId: "r3", issueId: 3, outcome: "implement", ts: "t3", tags: ["auth"] },
+    header("failure-lesson", 1, ["auth"]),
+    header("implement", 2, ["auth"]),
+    header("implement", 3, ["auth"]),
   ];
-  const d = decideExpiry(headers, 3);
+  const d = decideExpiry(headers, tagsOf(headers), 3);
   assert.deepEqual(d.drop, []);
 });
 
 test("decideExpiry: pushback blocks don't count toward expiry", () => {
   const headers = [
-    {
-      runId: "r1",
-      issueId: 1,
-      outcome: "failure-lesson",
-      ts: "t1",
-      tags: ["auth"],
-    },
-    { runId: "r2", issueId: 2, outcome: "implement", ts: "t2", tags: ["auth"] },
-    { runId: "r3", issueId: 3, outcome: "pushback", ts: "t3", tags: ["auth"] },
-    { runId: "r4", issueId: 4, outcome: "pushback", ts: "t4", tags: ["auth"] },
+    header("failure-lesson", 1, ["auth"]),
+    header("implement", 2, ["auth"]),
+    header("pushback", 3, ["auth"]),
+    header("pushback", 4, ["auth"]),
   ];
-  const d = decideExpiry(headers, 3);
+  const d = decideExpiry(headers, tagsOf(headers), 3);
   assert.deepEqual(d.drop, []);
 });
 
-test("decideExpiry: legacy failure-lesson without tags is never dropped", () => {
+test("decideExpiry: candidate with empty tags is never dropped", () => {
   const headers = [
-    {
-      runId: "r1",
-      issueId: 1,
-      outcome: "failure-lesson",
-      ts: "t1",
-      tags: [],
-    },
-    { runId: "r2", issueId: 2, outcome: "implement", ts: "t2", tags: ["auth"] },
-    { runId: "r3", issueId: 3, outcome: "implement", ts: "t3", tags: ["auth"] },
-    { runId: "r4", issueId: 4, outcome: "implement", ts: "t4", tags: ["auth"] },
+    header("failure-lesson", 1, []),
+    header("implement", 2, ["auth"]),
+    header("implement", 3, ["auth"]),
+    header("implement", 4, ["auth"]),
   ];
-  const d = decideExpiry(headers, 3);
+  const d = decideExpiry(headers, tagsOf(headers), 3);
   assert.deepEqual(d.drop, []);
 });
 
 test("decideExpiry: only successes AFTER the lesson count", () => {
   const headers = [
-    { runId: "r0", issueId: 0, outcome: "implement", ts: "t0", tags: ["auth"] },
-    { runId: "r1", issueId: 1, outcome: "implement", ts: "t1", tags: ["auth"] },
-    {
-      runId: "r2",
-      issueId: 2,
-      outcome: "failure-lesson",
-      ts: "t2",
-      tags: ["auth"],
-    },
-    { runId: "r3", issueId: 3, outcome: "implement", ts: "t3", tags: ["auth"] },
+    header("implement", 0, ["auth"]),
+    header("implement", 1, ["auth"]),
+    header("failure-lesson", 2, ["auth"]),
+    header("implement", 3, ["auth"]),
   ];
-  const d = decideExpiry(headers, 3);
-  // Only one subsequent implement → keep.
+  const d = decideExpiry(headers, tagsOf(headers), 3);
   assert.deepEqual(d.drop, []);
 });
 
 test("decideExpiry: K=0 disables expiry", () => {
   const headers = [
-    {
-      runId: "r1",
-      issueId: 1,
-      outcome: "failure-lesson",
-      ts: "t1",
-      tags: ["auth"],
-    },
-    { runId: "r2", issueId: 2, outcome: "implement", ts: "t2", tags: ["auth"] },
+    header("failure-lesson", 1, ["auth"]),
+    header("implement", 2, ["auth"]),
   ];
-  const d = decideExpiry(headers, 0);
+  const d = decideExpiry(headers, tagsOf(headers), 0);
   assert.deepEqual(d.drop, []);
 });
+
+// Helper: build a `getTags` callback by indexing a tags map by the header's
+// issueId — works for tests where every issueId is unique. For tests that
+// share issueIds across blocks (`compacted` outcomes), use a runId-keyed map.
+function getTagsByIssueId(
+  tagsByIssue: Record<number, string[]>,
+): (h: SentinelHeader) => string[] {
+  return (h: SentinelHeader): string[] => tagsByIssue[h.issueId] ?? [];
+}
 
 test("expireFailureLessonsInContent: drops block and is idempotent", () => {
   const content = [
@@ -190,41 +194,41 @@ test("expireFailureLessonsInContent: drops block and is idempotent", () => {
     "",
     "Some prelude text.",
     "",
-    "<!-- run:r1 issue:#1 outcome:failure-lesson ts:2026-05-01T00:00:00.000Z tags:auth -->",
+    "<!-- run:r1 issue:#1 outcome:failure-lesson ts:2026-05-01T00:00:00.000Z -->",
     "## Auth lesson",
     "",
     "Don't reuse session tokens.",
     "",
-    "<!-- run:r2 issue:#2 outcome:implement ts:2026-05-02T00:00:00.000Z tags:auth -->",
+    "<!-- run:r2 issue:#2 outcome:implement ts:2026-05-02T00:00:00.000Z -->",
     "## Auth refactor 1",
     "",
     "Refactor body.",
     "",
-    "<!-- run:r3 issue:#3 outcome:implement ts:2026-05-03T00:00:00.000Z tags:auth -->",
+    "<!-- run:r3 issue:#3 outcome:implement ts:2026-05-03T00:00:00.000Z -->",
     "## Auth refactor 2",
     "",
     "Refactor body.",
     "",
-    "<!-- run:r4 issue:#4 outcome:implement ts:2026-05-04T00:00:00.000Z tags:auth -->",
+    "<!-- run:r4 issue:#4 outcome:implement ts:2026-05-04T00:00:00.000Z -->",
     "## Auth refactor 3",
     "",
     "Refactor body.",
     "",
   ].join("\n");
+  const tagsByIssue = { 1: ["auth"], 2: ["auth"], 3: ["auth"], 4: ["auth"] };
+  const getTags = getTagsByIssueId(tagsByIssue);
 
-  const r1 = expireFailureLessonsInContent(content, 3);
+  const r1 = expireFailureLessonsInContent(content, 3, getTags);
   assert.equal(r1.droppedHeaders.length, 1);
   assert.equal(r1.droppedHeaders[0].outcome, "failure-lesson");
   assert.ok(!r1.content.includes("Auth lesson"));
   assert.ok(r1.content.includes("Auth refactor 1"));
   assert.ok(r1.content.includes("Auth refactor 2"));
   assert.ok(r1.content.includes("Auth refactor 3"));
-  // Prelude must be preserved.
   assert.ok(r1.content.startsWith("# Agent CLAUDE.md\n"));
   assert.ok(r1.content.includes("Some prelude text."));
 
-  // Idempotent: re-applying changes nothing.
-  const r2 = expireFailureLessonsInContent(r1.content, 3);
+  const r2 = expireFailureLessonsInContent(r1.content, 3, getTags);
   assert.equal(r2.droppedHeaders.length, 0);
   assert.equal(r2.content, r1.content);
 });
@@ -233,70 +237,83 @@ test("expireFailureLessonsInContent: preserves non-overlapping lesson", () => {
   const content = [
     "# Agent CLAUDE.md",
     "",
-    "<!-- run:r1 issue:#1 outcome:failure-lesson ts:2026-05-01T00:00:00.000Z tags:auth -->",
+    "<!-- run:r1 issue:#1 outcome:failure-lesson ts:2026-05-01T00:00:00.000Z -->",
     "## Auth lesson",
     "",
     "Don't reuse session tokens.",
     "",
-    "<!-- run:r2 issue:#2 outcome:implement ts:2026-05-02T00:00:00.000Z tags:docs -->",
+    "<!-- run:r2 issue:#2 outcome:implement ts:2026-05-02T00:00:00.000Z -->",
     "## Docs typo 1",
     "",
     "Body.",
     "",
-    "<!-- run:r3 issue:#3 outcome:implement ts:2026-05-03T00:00:00.000Z tags:docs -->",
+    "<!-- run:r3 issue:#3 outcome:implement ts:2026-05-03T00:00:00.000Z -->",
     "## Docs typo 2",
     "",
     "Body.",
     "",
-    "<!-- run:r4 issue:#4 outcome:implement ts:2026-05-04T00:00:00.000Z tags:docs -->",
+    "<!-- run:r4 issue:#4 outcome:implement ts:2026-05-04T00:00:00.000Z -->",
     "## Docs typo 3",
     "",
     "Body.",
     "",
   ].join("\n");
+  const getTags = getTagsByIssueId({
+    1: ["auth"],
+    2: ["docs"],
+    3: ["docs"],
+    4: ["docs"],
+  });
 
-  const r = expireFailureLessonsInContent(content, 3);
+  const r = expireFailureLessonsInContent(content, 3, getTags);
   assert.equal(r.droppedHeaders.length, 0);
   assert.equal(r.content, content);
 });
 
 test("expireFailureLessonsInContent: empty / sentinel-free content is a no-op", () => {
   const empty = "";
-  const r1 = expireFailureLessonsInContent(empty, 3);
+  const getTags = getTagsByIssueId({});
+  const r1 = expireFailureLessonsInContent(empty, 3, getTags);
   assert.equal(r1.content, empty);
   assert.equal(r1.droppedHeaders.length, 0);
 
   const noSentinels = "# Heading\n\nSome body.\n";
-  const r2 = expireFailureLessonsInContent(noSentinels, 3);
+  const r2 = expireFailureLessonsInContent(noSentinels, 3, getTags);
   assert.equal(r2.content, noSentinels);
   assert.equal(r2.droppedHeaders.length, 0);
 });
 
 test("expireFailureLessonsInContent: drops only the lesson, not the success blocks", () => {
   const content = [
-    "<!-- run:r1 issue:#1 outcome:failure-lesson ts:t1 tags:auth -->",
+    "<!-- run:r1 issue:#1 outcome:failure-lesson ts:t1 -->",
     "## Lesson",
     "",
     "L body.",
     "",
-    "<!-- run:r2 issue:#2 outcome:implement ts:t2 tags:auth -->",
+    "<!-- run:r2 issue:#2 outcome:implement ts:t2 -->",
     "## Success 1",
     "",
     "S body.",
     "",
-    "<!-- run:r3 issue:#3 outcome:implement ts:t3 tags:auth -->",
+    "<!-- run:r3 issue:#3 outcome:implement ts:t3 -->",
     "## Success 2",
     "",
     "S body.",
     "",
-    "<!-- run:r4 issue:#4 outcome:implement ts:t4 tags:auth -->",
+    "<!-- run:r4 issue:#4 outcome:implement ts:t4 -->",
     "## Success 3",
     "",
     "S body.",
     "",
   ].join("\n");
+  const getTags = getTagsByIssueId({
+    1: ["auth"],
+    2: ["auth"],
+    3: ["auth"],
+    4: ["auth"],
+  });
 
-  const r = expireFailureLessonsInContent(content, 3);
+  const r = expireFailureLessonsInContent(content, 3, getTags);
   assert.equal(r.droppedHeaders.length, 1);
   assert.ok(!r.content.includes("## Lesson"));
   assert.ok(r.content.includes("## Success 1"));
@@ -344,173 +361,79 @@ const pushbackPreservePolicy: ExpiryPolicy = {
 };
 
 test("decideExpiryWithPolicies: drops success with K newer high-Jaccard implements", () => {
-  // 5 newer implements all sharing tags ["auth"] (Jaccard 1.0 with first).
-  const headers = Array.from({ length: 6 }, (_, i) => ({
-    runId: `r${i}`,
-    issueId: i,
-    outcome: "implement",
-    ts: `t${i}`,
-    tags: ["auth"],
-  }));
-  const d = decideExpiryWithPolicies(headers, [successPolicy]);
-  // Only the very first block has 5 newer; later blocks have <5.
+  const headers = Array.from({ length: 6 }, (_, i) => header("implement", i, ["auth"]));
+  const d = decideExpiryWithPolicies(headers, tagsOf(headers), [successPolicy]);
   assert.deepEqual(d.drop, [0]);
 });
 
 test("decideExpiryWithPolicies: keeps success when Jaccard < 0.5", () => {
-  // Candidate ["auth"]; successors ["auth","x","y","z"] → Jaccard
-  // 1/4 = 0.25, below threshold.
-  const headers: Parameters<typeof decideExpiryWithPolicies>[0] = [
-    { runId: "r0", issueId: 0, outcome: "implement", ts: "t0", tags: ["auth"] },
-    {
-      runId: "r1",
-      issueId: 1,
-      outcome: "implement",
-      ts: "t1",
-      tags: ["auth", "x", "y", "z"],
-    },
-    {
-      runId: "r2",
-      issueId: 2,
-      outcome: "implement",
-      ts: "t2",
-      tags: ["auth", "x", "y", "z"],
-    },
-    {
-      runId: "r3",
-      issueId: 3,
-      outcome: "implement",
-      ts: "t3",
-      tags: ["auth", "x", "y", "z"],
-    },
-    {
-      runId: "r4",
-      issueId: 4,
-      outcome: "implement",
-      ts: "t4",
-      tags: ["auth", "x", "y", "z"],
-    },
-    {
-      runId: "r5",
-      issueId: 5,
-      outcome: "implement",
-      ts: "t5",
-      tags: ["auth", "x", "y", "z"],
-    },
+  const headers = [
+    header("implement", 0, ["auth"]),
+    header("implement", 1, ["auth", "x", "y", "z"]),
+    header("implement", 2, ["auth", "x", "y", "z"]),
+    header("implement", 3, ["auth", "x", "y", "z"]),
+    header("implement", 4, ["auth", "x", "y", "z"]),
+    header("implement", 5, ["auth", "x", "y", "z"]),
   ];
-  const d = decideExpiryWithPolicies(headers, [successPolicy]);
+  const d = decideExpiryWithPolicies(headers, tagsOf(headers), [successPolicy]);
   assert.deepEqual(d.drop, []);
 });
 
 test("decideExpiryWithPolicies: Jaccard ≥ 0.5 with overlap of 1/2 boundary", () => {
-  // Candidate ["a","b"]; successors each ["a","b"] (Jaccard 1.0).
-  const headers = Array.from({ length: 6 }, (_, i) => ({
-    runId: `r${i}`,
-    issueId: i,
-    outcome: "implement",
-    ts: `t${i}`,
-    tags: ["a", "b"],
-  }));
-  const d = decideExpiryWithPolicies(headers, [successPolicy]);
+  const headers = Array.from({ length: 6 }, (_, i) =>
+    header("implement", i, ["a", "b"]),
+  );
+  const d = decideExpiryWithPolicies(headers, tagsOf(headers), [successPolicy]);
   assert.deepEqual(d.drop, [0]);
 });
 
 test("decideExpiryWithPolicies: Jaccard exactly 0.5 dropped (boundary inclusive)", () => {
-  // Candidate ["a","b"]; successors ["a","b","c"] → Jaccard 2/3 ≈ 0.67 ✓.
-  // Candidate ["a","b"]; successors ["a","c"] → Jaccard 1/3 ≈ 0.33 ✗.
-  // For exact 0.5: candidate ["a"]; successor ["a","b"] → 1/2 = 0.5.
-  const headers: Parameters<typeof decideExpiryWithPolicies>[0] = [
-    { runId: "r0", issueId: 0, outcome: "implement", ts: "t0", tags: ["a"] },
-    {
-      runId: "r1",
-      issueId: 1,
-      outcome: "implement",
-      ts: "t1",
-      tags: ["a", "b"],
-    },
-    {
-      runId: "r2",
-      issueId: 2,
-      outcome: "implement",
-      ts: "t2",
-      tags: ["a", "b"],
-    },
-    {
-      runId: "r3",
-      issueId: 3,
-      outcome: "implement",
-      ts: "t3",
-      tags: ["a", "b"],
-    },
-    {
-      runId: "r4",
-      issueId: 4,
-      outcome: "implement",
-      ts: "t4",
-      tags: ["a", "b"],
-    },
-    {
-      runId: "r5",
-      issueId: 5,
-      outcome: "implement",
-      ts: "t5",
-      tags: ["a", "b"],
-    },
+  const headers = [
+    header("implement", 0, ["a"]),
+    header("implement", 1, ["a", "b"]),
+    header("implement", 2, ["a", "b"]),
+    header("implement", 3, ["a", "b"]),
+    header("implement", 4, ["a", "b"]),
+    header("implement", 5, ["a", "b"]),
   ];
-  const d = decideExpiryWithPolicies(headers, [successPolicy]);
+  const d = decideExpiryWithPolicies(headers, tagsOf(headers), [successPolicy]);
   assert.deepEqual(d.drop, [0]);
 });
 
 test("decideExpiryWithPolicies: pushback default policy preserves all", () => {
-  const headers = Array.from({ length: 10 }, (_, i) => ({
-    runId: `r${i}`,
-    issueId: i,
-    outcome: "pushback",
-    ts: `t${i}`,
-    tags: ["scope-creep"],
-  }));
-  const d = decideExpiryWithPolicies(headers, [pushbackPreservePolicy]);
+  const headers = Array.from({ length: 10 }, (_, i) =>
+    header("pushback", i, ["scope-creep"]),
+  );
+  const d = decideExpiryWithPolicies(headers, tagsOf(headers), [
+    pushbackPreservePolicy,
+  ]);
   assert.deepEqual(d.drop, []);
 });
 
 test("decideExpiryWithPolicies: pushback with finite K does drop overlapping", () => {
-  const headers = Array.from({ length: 5 }, (_, i) => ({
-    runId: `r${i}`,
-    issueId: i,
-    outcome: "pushback",
-    ts: `t${i}`,
-    tags: ["scope-creep"],
-  }));
+  const headers = Array.from({ length: 5 }, (_, i) =>
+    header("pushback", i, ["scope-creep"]),
+  );
   const finitePushback: ExpiryPolicy = {
     kind: "pushback",
     k: 3,
     supersededBy: ["pushback"],
     overlap: { mode: "any-shared-tag" },
   };
-  const d = decideExpiryWithPolicies(headers, [finitePushback]);
-  // Indices 0 and 1 each have ≥ 3 newer overlapping pushbacks.
+  const d = decideExpiryWithPolicies(headers, tagsOf(headers), [finitePushback]);
   assert.deepEqual(d.drop, [0, 1]);
 });
 
-test("decideExpiryWithPolicies: legacy implement without tags is never dropped", () => {
+test("decideExpiryWithPolicies: candidate with empty tags is never dropped", () => {
   const headers = [
-    { runId: "r0", issueId: 0, outcome: "implement", ts: "t0", tags: [] },
-    ...Array.from({ length: 5 }, (_, i) => ({
-      runId: `r${i + 1}`,
-      issueId: i + 1,
-      outcome: "implement",
-      ts: `t${i + 1}`,
-      tags: ["auth"],
-    })),
+    header("implement", 0, []),
+    ...Array.from({ length: 5 }, (_, i) => header("implement", i + 1, ["auth"])),
   ];
-  const d = decideExpiryWithPolicies(headers, [successPolicy]);
+  const d = decideExpiryWithPolicies(headers, tagsOf(headers), [successPolicy]);
   assert.deepEqual(d.drop, []);
 });
 
 test("decideExpiryWithPolicies: combined policies preserve cross-kind boundaries", () => {
-  // failure-lesson with overlapping successes → drop.
-  // success block in same domain is the supersession source, NOT a candidate.
-  // pushback block with overlapping pushbacks (K=Infinity) → keep.
   const policies: ExpiryPolicy[] = [
     {
       kind: "failure-lesson",
@@ -521,35 +444,15 @@ test("decideExpiryWithPolicies: combined policies preserve cross-kind boundaries
     successPolicy,
     pushbackPreservePolicy,
   ];
-  const headers: Parameters<typeof decideExpiryWithPolicies>[0] = [
-    {
-      runId: "r0",
-      issueId: 0,
-      outcome: "failure-lesson",
-      ts: "t0",
-      tags: ["auth"],
-    },
-    { runId: "r1", issueId: 1, outcome: "implement", ts: "t1", tags: ["auth"] },
-    { runId: "r2", issueId: 2, outcome: "implement", ts: "t2", tags: ["auth"] },
-    { runId: "r3", issueId: 3, outcome: "implement", ts: "t3", tags: ["auth"] },
-    {
-      runId: "r4",
-      issueId: 4,
-      outcome: "pushback",
-      ts: "t4",
-      tags: ["scope"],
-    },
-    {
-      runId: "r5",
-      issueId: 5,
-      outcome: "pushback",
-      ts: "t5",
-      tags: ["scope"],
-    },
+  const headers = [
+    header("failure-lesson", 0, ["auth"]),
+    header("implement", 1, ["auth"]),
+    header("implement", 2, ["auth"]),
+    header("implement", 3, ["auth"]),
+    header("pushback", 4, ["scope"]),
+    header("pushback", 5, ["scope"]),
   ];
-  const d = decideExpiryWithPolicies(headers, policies);
-  // Only the failure-lesson at index 0 should be dropped.
-  // Implements at 1/2 don't have ≥5 newer; pushbacks preserved.
+  const d = decideExpiryWithPolicies(headers, tagsOf(headers), policies);
   assert.deepEqual(d.drop, [0]);
 });
 
@@ -557,48 +460,54 @@ test("expireSentinelsInContent: drops superseded success block, idempotent", () 
   const content = [
     "# Agent CLAUDE.md",
     "",
-    "<!-- run:r0 issue:#0 outcome:implement ts:2026-05-01T00:00:00.000Z tags:auth -->",
+    "<!-- run:r0 issue:#0 outcome:implement ts:2026-05-01T00:00:00.000Z -->",
     "## Auth lesson 0",
     "",
     "Body 0.",
     "",
-    "<!-- run:r1 issue:#1 outcome:implement ts:2026-05-02T00:00:00.000Z tags:auth -->",
+    "<!-- run:r1 issue:#1 outcome:implement ts:2026-05-02T00:00:00.000Z -->",
     "## Auth lesson 1",
     "",
     "Body 1.",
     "",
-    "<!-- run:r2 issue:#2 outcome:implement ts:2026-05-03T00:00:00.000Z tags:auth -->",
+    "<!-- run:r2 issue:#2 outcome:implement ts:2026-05-03T00:00:00.000Z -->",
     "## Auth lesson 2",
     "",
     "Body 2.",
     "",
-    "<!-- run:r3 issue:#3 outcome:implement ts:2026-05-04T00:00:00.000Z tags:auth -->",
+    "<!-- run:r3 issue:#3 outcome:implement ts:2026-05-04T00:00:00.000Z -->",
     "## Auth lesson 3",
     "",
     "Body 3.",
     "",
-    "<!-- run:r4 issue:#4 outcome:implement ts:2026-05-05T00:00:00.000Z tags:auth -->",
+    "<!-- run:r4 issue:#4 outcome:implement ts:2026-05-05T00:00:00.000Z -->",
     "## Auth lesson 4",
     "",
     "Body 4.",
     "",
-    "<!-- run:r5 issue:#5 outcome:implement ts:2026-05-06T00:00:00.000Z tags:auth -->",
+    "<!-- run:r5 issue:#5 outcome:implement ts:2026-05-06T00:00:00.000Z -->",
     "## Auth lesson 5",
     "",
     "Body 5.",
     "",
   ].join("\n");
+  const getTags = getTagsByIssueId({
+    0: ["auth"],
+    1: ["auth"],
+    2: ["auth"],
+    3: ["auth"],
+    4: ["auth"],
+    5: ["auth"],
+  });
 
-  const r1 = expireSentinelsInContent(content, [successPolicy]);
-  // Block 0 has 5 newer high-Jaccard implements → drop.
+  const r1 = expireSentinelsInContent(content, [successPolicy], getTags);
   assert.equal(r1.droppedHeaders.length, 1);
   assert.equal(r1.droppedHeaders[0].issueId, 0);
   assert.ok(!r1.content.includes("## Auth lesson 0"));
   assert.ok(r1.content.includes("## Auth lesson 1"));
   assert.ok(r1.content.includes("## Auth lesson 5"));
 
-  // Idempotent.
-  const r2 = expireSentinelsInContent(r1.content, [successPolicy]);
+  const r2 = expireSentinelsInContent(r1.content, [successPolicy], getTags);
   assert.equal(r2.droppedHeaders.length, 0);
   assert.equal(r2.content, r1.content);
 });
@@ -607,42 +516,48 @@ test("expireSentinelsInContent: pushback default policy preserves the file", () 
   const content = [
     "# Agent CLAUDE.md",
     "",
-    "<!-- run:r1 issue:#1 outcome:pushback ts:t1 tags:scope -->",
+    "<!-- run:r1 issue:#1 outcome:pushback ts:t1 -->",
     "## P1",
     "",
-    "<!-- run:r2 issue:#2 outcome:pushback ts:t2 tags:scope -->",
+    "<!-- run:r2 issue:#2 outcome:pushback ts:t2 -->",
     "## P2",
     "",
-    "<!-- run:r3 issue:#3 outcome:pushback ts:t3 tags:scope -->",
+    "<!-- run:r3 issue:#3 outcome:pushback ts:t3 -->",
     "## P3",
     "",
-    "<!-- run:r4 issue:#4 outcome:pushback ts:t4 tags:scope -->",
+    "<!-- run:r4 issue:#4 outcome:pushback ts:t4 -->",
     "## P4",
     "",
   ].join("\n");
+  const getTags = getTagsByIssueId({ 1: ["scope"], 2: ["scope"], 3: ["scope"], 4: ["scope"] });
 
-  const r = expireSentinelsInContent(content, [pushbackPreservePolicy]);
+  const r = expireSentinelsInContent(content, [pushbackPreservePolicy], getTags);
   assert.equal(r.droppedHeaders.length, 0);
   assert.equal(r.content, content);
 });
 
 test("expireFailureLessonsInContent: still works as a thin wrapper", () => {
-  // Original behavior: failure-lesson with 3 overlapping implements → drop.
   const content = [
-    "<!-- run:r1 issue:#1 outcome:failure-lesson ts:t1 tags:auth -->",
+    "<!-- run:r1 issue:#1 outcome:failure-lesson ts:t1 -->",
     "## L",
     "",
-    "<!-- run:r2 issue:#2 outcome:implement ts:t2 tags:auth -->",
+    "<!-- run:r2 issue:#2 outcome:implement ts:t2 -->",
     "## S1",
     "",
-    "<!-- run:r3 issue:#3 outcome:implement ts:t3 tags:auth -->",
+    "<!-- run:r3 issue:#3 outcome:implement ts:t3 -->",
     "## S2",
     "",
-    "<!-- run:r4 issue:#4 outcome:implement ts:t4 tags:auth -->",
+    "<!-- run:r4 issue:#4 outcome:implement ts:t4 -->",
     "## S3",
     "",
   ].join("\n");
-  const r = expireFailureLessonsInContent(content, 3);
+  const getTags = getTagsByIssueId({
+    1: ["auth"],
+    2: ["auth"],
+    3: ["auth"],
+    4: ["auth"],
+  });
+  const r = expireFailureLessonsInContent(content, 3, getTags);
   assert.equal(r.droppedHeaders.length, 1);
   assert.equal(r.droppedHeaders[0].outcome, "failure-lesson");
 });

--- a/src/util/sentinels.ts
+++ b/src/util/sentinels.ts
@@ -1,17 +1,24 @@
 // Sentinel comment helpers for per-agent CLAUDE.md.
 //
 // Format written by `appendBlock` in src/agent/specialization.ts:
-//   <!-- run:<runId> issue:#<N> outcome:<X> ts:<ISO> [tags:t1,t2] -->
+//   <!-- run:<runId> issue:#<N> outcome:<X> ts:<ISO> -->
 //
-// Pure functions only — file I/O lives in `specialization.ts`. Tested in
-// `sentinels.test.ts` (node --test glob picks up `dist/src/util/*.test.js`).
-
+// Tags used to be embedded in this header (`tags:t1,t2`); they now live in
+// the per-agent `agents/<id>/section-tags.json` sidecar so that ~150 bytes
+// of operator-only metadata per section don't load into the agent's prompt
+// context. The parser still tolerates legacy `tags:` so un-migrated
+// CLAUDE.mds continue to parse, but the header type doesn't expose them —
+// callers that need the tag set go through `src/state/sectionTags.ts`.
+//
 // `issue:#(\d+(?:\+#\d+)*)` so `outcome:compacted` blocks (issue #162) —
 // which embed multiple source IDs as `issue:#100+#101+#102` — are still
 // located by the expiry walker. Without this, locateSentinels skips the
 // compacted line, the previous block silently absorbs the compacted
 // block's bytes as part of its body, and dropping the previous block on
 // expiry takes the compacted block out as collateral damage.
+//
+// Pure functions only — file I/O lives in `specialization.ts`. Tested in
+// `sentinels.test.ts` (node --test glob picks up `dist/src/util/*.test.js`).
 const SENTINEL_RE =
   /^<!--\s+run:(\S+)\s+issue:#(\d+(?:\+#\d+)*)\s+outcome:([\w-]+)\s+ts:(\S+?)(?:\s+tags:(\S+))?\s+-->$/;
 
@@ -24,22 +31,17 @@ export interface SentinelHeader {
   issueIds?: number[];
   outcome: string;
   ts: string;
-  tags: string[];
 }
 
 export function parseSentinelHeader(line: string): SentinelHeader | null {
   const m = line.match(SENTINEL_RE);
   if (!m) return null;
-  const tagsRaw = m[5];
-  const tags =
-    tagsRaw && tagsRaw.length > 0 ? tagsRaw.split(",").filter(Boolean) : [];
   const issueIds = m[2].split("+").map((tok) => Number(tok.replace(/^#/, "")));
   const header: SentinelHeader = {
     runId: m[1],
     issueId: issueIds[0],
     outcome: m[3],
     ts: m[4],
-    tags,
   };
   // Only set when the sentinel encodes multiple IDs — keeps the
   // single-ID shape deep-equal-comparable to the pre-#162 record shape.
@@ -47,19 +49,27 @@ export function parseSentinelHeader(line: string): SentinelHeader | null {
   return header;
 }
 
+/**
+ * Extract legacy `tags:t1,t2` from a sentinel line, if present. Used by the
+ * one-shot migration to populate `section-tags.json` from un-migrated
+ * CLAUDE.mds. Returns [] for lines that don't match the sentinel shape or
+ * have no legacy tags.
+ */
+export function extractLegacySentinelTags(line: string): string[] {
+  const m = line.match(SENTINEL_RE);
+  if (!m) return [];
+  const raw = m[5];
+  if (!raw) return [];
+  return raw.split(",").filter(Boolean);
+}
+
 export function formatSentinelHeader(input: {
   runId: string;
   issueId: number;
   outcome: string;
   ts: string;
-  tags?: string[];
 }): string {
-  const base = `<!-- run:${input.runId} issue:#${input.issueId} outcome:${input.outcome} ts:${input.ts}`;
-  const tagsPart =
-    input.tags && input.tags.length > 0
-      ? ` tags:${[...input.tags].sort().join(",")}`
-      : "";
-  return `${base}${tagsPart} -->`;
+  return `<!-- run:${input.runId} issue:#${input.issueId} outcome:${input.outcome} ts:${input.ts} -->`;
 }
 
 interface SentinelLocation {
@@ -141,8 +151,10 @@ function tagsOverlap(
  * `policy.supersededBy` satisfy the policy's tag-overlap rule, drop the
  * candidate.
  *
- * Conservative on missing tags: a candidate with `tags: []` is never
- * dropped, and successors with `tags: []` never count toward supersession.
+ * Tags are passed alongside via `tagsByIndex` (parallel to `headers`) — the
+ * caller resolves them from the sidecar (`src/state/sectionTags.ts`).
+ * Conservative on missing tags: a candidate with empty tags is never
+ * dropped, and successors with empty tags never count toward supersession.
  * Idempotent: re-applying on already-pruned content drops nothing.
  *
  * Out-of-order writes are not a concern — blocks accumulate by file
@@ -150,6 +162,7 @@ function tagsOverlap(
  */
 export function decideExpiryWithPolicies(
   headers: SentinelHeader[],
+  tagsByIndex: string[][],
   policies: ExpiryPolicy[],
 ): ExpireDecision {
   const drop: number[] = [];
@@ -161,16 +174,18 @@ export function decideExpiryWithPolicies(
     const policy = policyByKind.get(h.outcome);
     if (!policy) continue;
     if (!Number.isFinite(policy.k) || policy.k <= 0) continue;
-    if (h.tags.length === 0) continue; // legacy / no fingerprint — keep
+    const candidateTagList = tagsByIndex[i] ?? [];
+    if (candidateTagList.length === 0) continue;
 
-    const candidateTags = new Set(h.tags);
+    const candidateTags = new Set(candidateTagList);
     const allowedSuccessors = new Set(policy.supersededBy);
     let overlaps = 0;
     for (let j = i + 1; j < headers.length; j++) {
       const succ = headers[j];
       if (!allowedSuccessors.has(succ.outcome)) continue;
-      if (succ.tags.length === 0) continue;
-      if (tagsOverlap(candidateTags, succ.tags, policy.overlap)) overlaps += 1;
+      const succTags = tagsByIndex[j] ?? [];
+      if (succTags.length === 0) continue;
+      if (tagsOverlap(candidateTags, succTags, policy.overlap)) overlaps += 1;
       if (overlaps >= policy.k) break;
     }
     if (overlaps >= policy.k) drop.push(i);
@@ -182,13 +197,14 @@ export function decideExpiryWithPolicies(
  * Backward-compatible wrapper: decide which `outcome:failure-lesson`
  * blocks to drop using the legacy single-K rule (any-shared-tag overlap
  * against `outcome:implement` successors). Equivalent to
- * `decideExpiryWithPolicies(headers, [failure-lesson policy])`.
+ * `decideExpiryWithPolicies(headers, tagsByIndex, [failure-lesson policy])`.
  */
 export function decideExpiry(
   headers: SentinelHeader[],
+  tagsByIndex: string[][],
   k: number,
 ): ExpireDecision {
-  return decideExpiryWithPolicies(headers, [
+  return decideExpiryWithPolicies(headers, tagsByIndex, [
     {
       kind: "failure-lesson",
       k,
@@ -207,19 +223,22 @@ export interface ExpireResult {
  * Walk content, drop expired sentinel blocks per the supplied policies,
  * return the rewritten content. Idempotent — re-applying on already-pruned
  * content with the same policies drops nothing.
+ *
+ * `getTags(header)` resolves each header's tag list from the caller-owned
+ * sidecar; sentinels.ts stays storage-agnostic.
  */
 export function expireSentinelsInContent(
   content: string,
   policies: ExpiryPolicy[],
+  getTags: (header: SentinelHeader) => string[],
 ): ExpireResult {
   const lines = content.split("\n");
   const located = locateSentinels(lines);
   if (located.length === 0) return { content, droppedHeaders: [] };
 
-  const decision = decideExpiryWithPolicies(
-    located.map((l) => l.header),
-    policies,
-  );
+  const headers = located.map((l) => l.header);
+  const tagsByIndex = headers.map((h) => getTags(h));
+  const decision = decideExpiryWithPolicies(headers, tagsByIndex, policies);
   if (decision.drop.length === 0) return { content, droppedHeaders: [] };
 
   const dropSet = new Set(decision.drop);
@@ -304,15 +323,20 @@ export function dropSentinelsByStableId(
 export function expireFailureLessonsInContent(
   content: string,
   k: number,
+  getTags: (header: SentinelHeader) => string[],
 ): ExpireResult {
-  return expireSentinelsInContent(content, [
-    {
-      kind: "failure-lesson",
-      k,
-      supersededBy: ["implement"],
-      overlap: { mode: "any-shared-tag" },
-    },
-  ]);
+  return expireSentinelsInContent(
+    content,
+    [
+      {
+        kind: "failure-lesson",
+        k,
+        supersededBy: ["implement"],
+        overlap: { mode: "any-shared-tag" },
+      },
+    ],
+    getTags,
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Tags used to live inside the sentinel header of every section in `agents/<id>/CLAUDE.md` (`<!-- run:R issue:#N outcome:O ts:T tags:t1,t2 -->`), which meant ~150 bytes of operator-only metadata per section loaded into the agent's prompt context every dispatch. Tags now live in a per-agent sidecar `agents/<id>/section-tags.json` keyed by `deriveStableSectionId(runId, issueIds)` and never reach the agent's context.

- New: `src/state/sectionTags.ts` (sidecar reader/writer, `stableIdForHeader`)
- New: `src/agent/migrateTagsToSidecar.ts` (one-shot migration, idempotent)
- New CLI: `vp-dev agents migrate-tags-to-sidecar [<agentId> | --all]`
- `SentinelHeader.tags` removed; parser still tolerates legacy `tags:` for un-migrated CLAUDE.mds
- `decideExpiryWithPolicies` / `expireSentinelsInContent` take tags via parallel array / callback so `sentinels.ts` stays storage-agnostic
- `appendBlock` writes to sidecar; `expireSentinels` drops sidecar entries for expired sections
- Full test coverage including compacted-block stable-IDs, idempotence, empty/no-op paths

## Companion: vaultpilot-dev-agents snapshot repo

The `vaultpilot-dev-agents` snapshot repo holds point-in-time copies of CLAUDE.mds. After this PR merges, a follow-up clone-and-`migrate-tags-to-sidecar` pass should be applied there to strip legacy `tags:` from the snapshots and emit `section-tags.json` alongside each.

## Migration path

Operator runs once after merge:

```
vp-dev agents migrate-tags-to-sidecar --all
```

All future `appendBlock` calls write straight to the sidecar.

## Smoke-test

Against agent-92ff's live 47912-byte CLAUDE.md: 11 legacy sentinels migrated to 11 sidecar entries (~1KB savings/agent on this fixture), idempotent re-run is a no-op, `prune-tags` advisory reads from sidecar correctly (same `sectionTagsUnion` count as pre-refactor).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 890 passed / 0 failed
- [x] End-to-end smoke: `migrate-tags-to-sidecar` on a real CLAUDE.md fixture
- [x] End-to-end smoke: `prune-tags` reads from sidecar after migration
- [ ] CI green
- [ ] Operator runs `vp-dev agents migrate-tags-to-sidecar --all` post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)