### PR TITLE
fix(snapshot-sync): also sync section-tags.json sidecar files

### DIFF
--- a/src/agent/snapshotSync.test.ts
+++ b/src/agent/snapshotSync.test.ts
@@ -6,8 +6,10 @@ import path from "node:path";
 import {
   classifyAgent,
   isSynthetic,
+  mergeAgentActions,
   pullSnapshot,
   pushSnapshot,
+  SYNCED_AGENT_FILES,
   SYNTHETIC_AGENT_PATTERNS,
 } from "./snapshotSync.js";
 
@@ -32,9 +34,23 @@ async function writeAgent(root: string, id: string, body: string): Promise<void>
   await fs.writeFile(path.join(dir, "CLAUDE.md"), body, "utf-8");
 }
 
+async function writeSidecar(root: string, id: string, body: string): Promise<void> {
+  const dir = path.join(root, id);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, "section-tags.json"), body, "utf-8");
+}
+
 async function readAgent(root: string, id: string): Promise<string | null> {
   try {
     return await fs.readFile(path.join(root, id, "CLAUDE.md"), "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+async function readSidecar(root: string, id: string): Promise<string | null> {
+  try {
+    return await fs.readFile(path.join(root, id, "section-tags.json"), "utf-8");
   } catch {
     return null;
   }
@@ -278,5 +294,257 @@ describe("pushSnapshot", () => {
     assert.deepEqual(result.summary.added, []);
     assert.deepEqual(result.summary.excluded, []);
     assert.match(result.branch, /^refresh-snapshot-\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe("mergeAgentActions", () => {
+  it("dest didn't exist + any add → add (fresh agent dir)", () => {
+    assert.equal(mergeAgentActions(["add", "add"], false), "add");
+    assert.equal(mergeAgentActions(["add"], false), "add");
+  });
+
+  it("dest didn't exist + only unchanged → unchanged (degenerate case)", () => {
+    assert.equal(mergeAgentActions(["unchanged"], false), "unchanged");
+  });
+
+  it("dest existed + any add → update (sidecar landed alongside existing CLAUDE.md)", () => {
+    assert.equal(mergeAgentActions(["unchanged", "add"], true), "update");
+    assert.equal(mergeAgentActions(["add"], true), "update");
+  });
+
+  it("dest existed + any update → update", () => {
+    assert.equal(mergeAgentActions(["update", "unchanged"], true), "update");
+    assert.equal(mergeAgentActions(["unchanged", "update"], true), "update");
+  });
+
+  it("dest existed + skip beats unchanged", () => {
+    assert.equal(mergeAgentActions(["skip", "unchanged"], true), "skip");
+  });
+
+  it("dest existed + every file unchanged → unchanged", () => {
+    assert.equal(mergeAgentActions(["unchanged", "unchanged"], true), "unchanged");
+  });
+
+  it("exposes the synced filename set", () => {
+    assert.deepEqual([...SYNCED_AGENT_FILES], ["CLAUDE.md", "section-tags.json"]);
+  });
+});
+
+describe("pullSnapshot — section-tags.json sidecar", () => {
+  it("copies the sidecar alongside CLAUDE.md when adding a new agent", async () => {
+    const { cloneDir, remoteAgentsDir, localAgentsDir } = await makeTempLayout();
+    await writeAgent(remoteAgentsDir, "agent-aaaa", "remote-body");
+    await writeSidecar(remoteAgentsDir, "agent-aaaa", '{"version":1,"sections":{}}');
+
+    const summary = await pullSnapshot({
+      cloneDir,
+      agentsRoot: localAgentsDir,
+      skipFetch: true,
+    });
+
+    assert.deepEqual(summary.added, ["agent-aaaa"]);
+    assert.equal(await readAgent(localAgentsDir, "agent-aaaa"), "remote-body");
+    assert.equal(await readSidecar(localAgentsDir, "agent-aaaa"), '{"version":1,"sections":{}}');
+  });
+
+  it("tolerates a missing sidecar on the source (early-life agent)", async () => {
+    const { cloneDir, remoteAgentsDir, localAgentsDir } = await makeTempLayout();
+    await writeAgent(remoteAgentsDir, "agent-aaaa", "remote-body");
+    // No sidecar on remote.
+
+    const summary = await pullSnapshot({
+      cloneDir,
+      agentsRoot: localAgentsDir,
+      skipFetch: true,
+    });
+
+    assert.deepEqual(summary.added, ["agent-aaaa"]);
+    assert.equal(await readAgent(localAgentsDir, "agent-aaaa"), "remote-body");
+    assert.equal(await readSidecar(localAgentsDir, "agent-aaaa"), null);
+  });
+
+  it("overwrites both files under policy=overwrite", async () => {
+    const { cloneDir, remoteAgentsDir, localAgentsDir } = await makeTempLayout();
+    await writeAgent(remoteAgentsDir, "agent-aaaa", "remote-body");
+    await writeSidecar(remoteAgentsDir, "agent-aaaa", '{"v":"remote"}');
+    await writeAgent(localAgentsDir, "agent-aaaa", "local-body");
+    await writeSidecar(localAgentsDir, "agent-aaaa", '{"v":"local"}');
+
+    const summary = await pullSnapshot({
+      cloneDir,
+      agentsRoot: localAgentsDir,
+      policy: "overwrite",
+      skipFetch: true,
+    });
+
+    assert.deepEqual(summary.updated, ["agent-aaaa"]);
+    assert.equal(await readAgent(localAgentsDir, "agent-aaaa"), "remote-body");
+    assert.equal(await readSidecar(localAgentsDir, "agent-aaaa"), '{"v":"remote"}');
+  });
+
+  it("under skip-existing leaves both files alone when both differ", async () => {
+    const { cloneDir, remoteAgentsDir, localAgentsDir } = await makeTempLayout();
+    await writeAgent(remoteAgentsDir, "agent-aaaa", "remote-body");
+    await writeSidecar(remoteAgentsDir, "agent-aaaa", '{"v":"remote"}');
+    await writeAgent(localAgentsDir, "agent-aaaa", "local-body");
+    await writeSidecar(localAgentsDir, "agent-aaaa", '{"v":"local"}');
+
+    const summary = await pullSnapshot({
+      cloneDir,
+      agentsRoot: localAgentsDir,
+      skipFetch: true,
+    });
+
+    assert.deepEqual(summary.skipped, ["agent-aaaa"]);
+    assert.equal(await readAgent(localAgentsDir, "agent-aaaa"), "local-body");
+    assert.equal(await readSidecar(localAgentsDir, "agent-aaaa"), '{"v":"local"}');
+  });
+
+  it("reports updated when only the sidecar diverges (CLAUDE.md unchanged)", async () => {
+    const { cloneDir, remoteAgentsDir, localAgentsDir } = await makeTempLayout();
+    await writeAgent(remoteAgentsDir, "agent-aaaa", "shared-body");
+    await writeSidecar(remoteAgentsDir, "agent-aaaa", '{"v":"remote"}');
+    await writeAgent(localAgentsDir, "agent-aaaa", "shared-body");
+    await writeSidecar(localAgentsDir, "agent-aaaa", '{"v":"local"}');
+
+    const summary = await pullSnapshot({
+      cloneDir,
+      agentsRoot: localAgentsDir,
+      policy: "overwrite",
+      skipFetch: true,
+    });
+
+    assert.deepEqual(summary.updated, ["agent-aaaa"]);
+    assert.equal(await readSidecar(localAgentsDir, "agent-aaaa"), '{"v":"remote"}');
+  });
+
+  it("dry-run does not write the sidecar", async () => {
+    const { cloneDir, remoteAgentsDir, localAgentsDir } = await makeTempLayout();
+    await writeAgent(remoteAgentsDir, "agent-aaaa", "remote-body");
+    await writeSidecar(remoteAgentsDir, "agent-aaaa", '{"v":"remote"}');
+
+    const summary = await pullSnapshot({
+      cloneDir,
+      agentsRoot: localAgentsDir,
+      dryRun: true,
+      skipFetch: true,
+    });
+
+    assert.deepEqual(summary.added, ["agent-aaaa"]);
+    assert.equal(await readAgent(localAgentsDir, "agent-aaaa"), null);
+    assert.equal(await readSidecar(localAgentsDir, "agent-aaaa"), null);
+  });
+});
+
+describe("pushSnapshot — section-tags.json sidecar", () => {
+  // Push tests use apply=false to avoid needing a real git clone — the
+  // existing pushSnapshot suite uses the same convention. A separate
+  // apply=true test covers the actual remote write under git.
+
+  it("counts the sidecar in the per-agent verdict when adding a fresh agent", async () => {
+    const { cloneDir, localAgentsDir } = await makeTempLayout();
+    await writeAgent(localAgentsDir, "agent-aaaa", "local-body");
+    await writeSidecar(localAgentsDir, "agent-aaaa", '{"v":"local"}');
+
+    const result = await pushSnapshot({
+      cloneDir,
+      agentsRoot: localAgentsDir,
+      apply: false,
+      skipFetch: true,
+    });
+
+    assert.deepEqual(result.summary.added, ["agent-aaaa"]);
+  });
+
+  it("tolerates a missing local sidecar (early-life agent)", async () => {
+    const { cloneDir, localAgentsDir } = await makeTempLayout();
+    await writeAgent(localAgentsDir, "agent-aaaa", "local-body");
+    // No sidecar locally.
+
+    const result = await pushSnapshot({
+      cloneDir,
+      agentsRoot: localAgentsDir,
+      apply: false,
+      skipFetch: true,
+    });
+
+    assert.deepEqual(result.summary.added, ["agent-aaaa"]);
+  });
+
+  it("reports updated when only the sidecar diverges", async () => {
+    const { cloneDir, remoteAgentsDir, localAgentsDir } = await makeTempLayout();
+    await writeAgent(remoteAgentsDir, "agent-aaaa", "shared-body");
+    await writeSidecar(remoteAgentsDir, "agent-aaaa", '{"v":"remote"}');
+    await writeAgent(localAgentsDir, "agent-aaaa", "shared-body");
+    await writeSidecar(localAgentsDir, "agent-aaaa", '{"v":"local"}');
+
+    const result = await pushSnapshot({
+      cloneDir,
+      agentsRoot: localAgentsDir,
+      apply: false,
+      skipFetch: true,
+    });
+
+    assert.deepEqual(result.summary.updated, ["agent-aaaa"]);
+  });
+
+  it("reports unchanged when both files are byte-identical", async () => {
+    const { cloneDir, remoteAgentsDir, localAgentsDir } = await makeTempLayout();
+    await writeAgent(remoteAgentsDir, "agent-aaaa", "shared-body");
+    await writeSidecar(remoteAgentsDir, "agent-aaaa", '{"v":"shared"}');
+    await writeAgent(localAgentsDir, "agent-aaaa", "shared-body");
+    await writeSidecar(localAgentsDir, "agent-aaaa", '{"v":"shared"}');
+
+    const result = await pushSnapshot({
+      cloneDir,
+      agentsRoot: localAgentsDir,
+      apply: false,
+      skipFetch: true,
+    });
+
+    assert.deepEqual(result.summary.unchanged, ["agent-aaaa"]);
+  });
+
+  it("writes the sidecar to clone under apply=true (git-initialized clone)", async () => {
+    const { cloneDir, remoteAgentsDir, localAgentsDir } = await makeTempLayout();
+    // Initialize the clone as a git repo with a base commit so apply=true's
+    // commit step has something to work against. The push step inside
+    // pushSnapshot is gated by skipFetch=true so we won't hit the network.
+    await fs.mkdir(remoteAgentsDir, { recursive: true });
+    const { execFile: execFileCb } = await import("node:child_process");
+    const { promisify } = await import("node:util");
+    const execFileP = promisify(execFileCb);
+    await execFileP("git", ["init", "-q", "-b", "main"], { cwd: cloneDir });
+    await execFileP("git", ["config", "user.email", "test@local"], { cwd: cloneDir });
+    await execFileP("git", ["config", "user.name", "Test"], { cwd: cloneDir });
+    await fs.writeFile(path.join(cloneDir, "README.md"), "seed", "utf-8");
+    await execFileP("git", ["add", "-A"], { cwd: cloneDir });
+    await execFileP("git", ["commit", "-q", "-m", "seed"], { cwd: cloneDir });
+
+    await writeAgent(localAgentsDir, "agent-aaaa", "local-body");
+    await writeSidecar(localAgentsDir, "agent-aaaa", '{"v":"local"}');
+
+    // apply=true would also try `git push` and `gh pr create`; bypass that
+    // path by stopping after the file write. We can't easily stub gh, so
+    // assert by intercepting before the git operations: pushSnapshot only
+    // runs the file copy synchronously when apply=true, and the failure is
+    // at `git push`. Catch and inspect.
+    let writeReached = false;
+    try {
+      await pushSnapshot({
+        cloneDir,
+        agentsRoot: localAgentsDir,
+        apply: true,
+        skipFetch: true,
+      });
+      writeReached = true;
+    } catch {
+      // git push to non-existent remote will fail; that's fine for this test.
+      writeReached = true;
+    }
+    assert.equal(writeReached, true);
+    // The remote file was written before the git operations failed.
+    assert.equal(await readAgent(remoteAgentsDir, "agent-aaaa"), "local-body");
+    assert.equal(await readSidecar(remoteAgentsDir, "agent-aaaa"), '{"v":"local"}');
   });
 });

--- a/src/agent/snapshotSync.ts
+++ b/src/agent/snapshotSync.ts
@@ -1,17 +1,25 @@
-// Sync per-agent CLAUDE.md files between the local working tree (`agents/`)
-// and the snapshot repo (default: szhygulin/vaultpilot-dev-agents).
+// Sync per-agent CLAUDE.md + section-tags.json files between the local
+// working tree (`agents/`) and the snapshot repo (default:
+// szhygulin/vaultpilot-dev-agents).
 //
 // Local `agents/` is gitignored — it's the live store the orchestrator's
 // summarizer rewrites after every successful run. The snapshot repo is a
 // point-in-time mirror committed via PR. These two are kept decoupled so
 // the summarizer's writes don't fight a checked-out tree.
 //
-// pullSnapshot: clone (or refresh) the snapshot, then copy CLAUDE.mds DOWN
-// into local agents/. Default policy is `skip-existing` so a pull never
-// clobbers a run-in-progress's freshly-summarized memory; `overwrite`
-// replaces local content under the same per-file lock the summarizer uses.
+// Each agent has up to two synced files: `CLAUDE.md` (the per-agent prompt
+// memory) and `section-tags.json` (the sidecar holding per-section operator
+// metadata, post-`refactor/tags-to-sidecar`). Both files travel together so
+// pulling a fresh snapshot also brings the sidecar entries that match the
+// current sentinel set; absent sidecars (early-life agents) are tolerated.
 //
-// pushSnapshot: clone (or refresh) the snapshot, copy local CLAUDE.mds UP,
+// pullSnapshot: clone (or refresh) the snapshot, then copy each agent's
+// files DOWN into local agents/. Default policy is `skip-existing` so a
+// pull never clobbers a run-in-progress's freshly-summarized memory;
+// `overwrite` replaces local content under the same per-file lock the
+// summarizer uses.
+//
+// pushSnapshot: clone (or refresh) the snapshot, copy local files UP,
 // branch + commit + open a PR via gh. Synthetic curve-redo agents
 // (`agent-916a-trim-*`, `agent-9180`–`agent-9189`) are excluded by default
 // per the snapshot README's stated policy. Without --apply it's a dry run.
@@ -37,6 +45,17 @@ export const SYNTHETIC_AGENT_PATTERNS: readonly RegExp[] = [
 ];
 
 export type ConflictPolicy = "skip-existing" | "overwrite";
+
+/**
+ * Per-agent files synced between the local working tree and the snapshot
+ * repo. CLAUDE.md is the prompt memory; section-tags.json is the sidecar
+ * holding per-section operator metadata (post-`refactor/tags-to-sidecar`).
+ * Order matters for tests: the agent's "added/updated/unchanged" verdict
+ * derives from the highest-precedence action across files, with CLAUDE.md
+ * checked first as the canonical signal that the agent dir exists.
+ */
+export const SYNCED_AGENT_FILES = ["CLAUDE.md", "section-tags.json"] as const;
+export type SyncedAgentFile = (typeof SYNCED_AGENT_FILES)[number];
 
 export interface SyncSummary {
   /** Agents copied because they did not exist on the destination. */
@@ -87,6 +106,39 @@ export function classifyAgent(input: {
   if (input.sourceBytes.equals(input.destBytes)) return "unchanged";
   if (input.direction === "push") return "update";
   return input.policy === "overwrite" ? "update" : "skip";
+}
+
+/**
+ * Reduce per-file actions to a single per-agent verdict for SyncSummary
+ * bucketing.
+ *
+ * The verdict reflects the operator's mental model "what happened to this
+ * agent's directory?", which depends on whether the destination dir already
+ * existed (`destAgentExisted`). When the dir didn't exist, the only useful
+ * verdict is "add" — bringing in CLAUDE.md plus any optional sidecar files
+ * is a single creation event. When the dir did exist, "add"-of-a-new-file
+ * (e.g. a new sidecar landing alongside an existing CLAUDE.md) reads as an
+ * update of the agent, not as a fresh creation.
+ *
+ * Precedence within an existing-dir agent: update > skip > unchanged. "skip"
+ * wins over "unchanged" so a skip-existing pull that left a real difference
+ * untouched is still reported as skipped (tells the operator they chose to
+ * leave a divergence alone).
+ */
+export function mergeAgentActions(
+  actions: readonly SyncAction[],
+  destAgentExisted: boolean,
+): SyncAction {
+  if (!destAgentExisted) {
+    // Dir didn't exist before; per-file "skip" is unreachable here (skip
+    // requires a destBytes presence — which means the dir existed). So the
+    // only meaningful actions are "add" and "unchanged"; treat the verdict
+    // as "add" if any file was actually written.
+    return actions.includes("add") ? "add" : "unchanged";
+  }
+  if (actions.includes("update") || actions.includes("add")) return "update";
+  if (actions.includes("skip")) return "skip";
+  return "unchanged";
 }
 
 async function pathExists(p: string): Promise<boolean> {
@@ -174,33 +226,49 @@ export async function pullSnapshot(opts: PullOptions = {}): Promise<SyncSummary>
   const remoteAgents = await listAgentDirs(remoteAgentsDir);
 
   for (const agentId of remoteAgents) {
-    const remoteFile = path.join(remoteAgentsDir, agentId, "CLAUDE.md");
-    const localFile = path.join(agentsRoot, agentId, "CLAUDE.md");
+    const fileActions: SyncAction[] = [];
+    let claudeMdSourcePresent = false;
+    let claudeMdDestExisted = false;
 
-    const [sourceBytes, destBytes] = await Promise.all([
-      readFileOrNull(remoteFile),
-      readFileOrNull(localFile),
-    ]);
-    if (sourceBytes === null) continue;
+    for (const fileName of SYNCED_AGENT_FILES) {
+      const remoteFile = path.join(remoteAgentsDir, agentId, fileName);
+      const localFile = path.join(agentsRoot, agentId, fileName);
 
-    const action = classifyAgent({ sourceBytes, destBytes, policy, direction: "pull" });
-    if (action === "unchanged") {
-      summary.unchanged.push(agentId);
-      continue;
-    }
-    if (action === "skip") {
-      summary.skipped.push(agentId);
-      continue;
+      const [sourceBytes, destBytes] = await Promise.all([
+        readFileOrNull(remoteFile),
+        readFileOrNull(localFile),
+      ]);
+      if (fileName === "CLAUDE.md") {
+        claudeMdSourcePresent = sourceBytes !== null;
+        claudeMdDestExisted = destBytes !== null;
+      }
+
+      // Skip files absent from the source: an early-life agent without a
+      // sidecar shouldn't drag the agent's verdict away from "unchanged" /
+      // "added". The merge precedence assumes per-file actions reflect real
+      // source-side state, so don't pollute it with absences.
+      if (sourceBytes === null) continue;
+
+      const action = classifyAgent({ sourceBytes, destBytes, policy, direction: "pull" });
+      fileActions.push(action);
+
+      if ((action === "add" || action === "update") && !dryRun) {
+        await fs.mkdir(path.dirname(localFile), { recursive: true });
+        await withFileLock(localFile, async () => {
+          await fs.writeFile(localFile, sourceBytes);
+        });
+      }
     }
 
-    if (!dryRun) {
-      await fs.mkdir(path.dirname(localFile), { recursive: true });
-      await withFileLock(localFile, async () => {
-        await fs.writeFile(localFile, sourceBytes);
-      });
-    }
-    if (action === "add") summary.added.push(agentId);
-    else summary.updated.push(agentId);
+    // Skip the agent entirely if its canonical CLAUDE.md is absent on the
+    // source — a stray sidecar without a CLAUDE.md is not a real agent.
+    if (!claudeMdSourcePresent) continue;
+
+    const merged = mergeAgentActions(fileActions, claudeMdDestExisted);
+    if (merged === "add") summary.added.push(agentId);
+    else if (merged === "update") summary.updated.push(agentId);
+    else if (merged === "skip") summary.skipped.push(agentId);
+    else summary.unchanged.push(agentId);
   }
 
   return summary;
@@ -260,26 +328,45 @@ export async function pushSnapshot(opts: PushOptions = {}): Promise<PushResult> 
       summary.excluded.push(agentId);
       continue;
     }
-    const localFile = path.join(agentsRoot, agentId, "CLAUDE.md");
-    const remoteFile = path.join(remoteAgentsDir, agentId, "CLAUDE.md");
 
-    const [sourceBytes, destBytes] = await Promise.all([
-      readFileOrNull(localFile),
-      readFileOrNull(remoteFile),
-    ]);
-    if (sourceBytes === null) continue;
+    const fileActions: SyncAction[] = [];
+    let claudeMdSourcePresent = false;
+    let claudeMdDestExisted = false;
 
-    const action = classifyAgent({ sourceBytes, destBytes, policy: "overwrite", direction: "push" });
-    if (action === "unchanged") {
-      summary.unchanged.push(agentId);
-      continue;
+    for (const fileName of SYNCED_AGENT_FILES) {
+      const localFile = path.join(agentsRoot, agentId, fileName);
+      const remoteFile = path.join(remoteAgentsDir, agentId, fileName);
+
+      const [sourceBytes, destBytes] = await Promise.all([
+        readFileOrNull(localFile),
+        readFileOrNull(remoteFile),
+      ]);
+      if (fileName === "CLAUDE.md") {
+        claudeMdSourcePresent = sourceBytes !== null;
+        claudeMdDestExisted = destBytes !== null;
+      }
+
+      // Same source-absent skip as pull — keeps the per-agent verdict tied
+      // to files that actually exist locally.
+      if (sourceBytes === null) continue;
+
+      const action = classifyAgent({ sourceBytes, destBytes, policy: "overwrite", direction: "push" });
+      fileActions.push(action);
+
+      if ((action === "add" || action === "update") && apply) {
+        await fs.mkdir(path.dirname(remoteFile), { recursive: true });
+        await fs.writeFile(remoteFile, sourceBytes);
+      }
     }
-    if (apply) {
-      await fs.mkdir(path.dirname(remoteFile), { recursive: true });
-      await fs.writeFile(remoteFile, sourceBytes);
-    }
-    if (action === "add") summary.added.push(agentId);
-    else if (action === "update") summary.updated.push(agentId);
+
+    // Skip if local CLAUDE.md is missing — same convention as pull.
+    if (!claudeMdSourcePresent) continue;
+
+    const merged = mergeAgentActions(fileActions, claudeMdDestExisted);
+    if (merged === "add") summary.added.push(agentId);
+    else if (merged === "update") summary.updated.push(agentId);
+    else if (merged === "unchanged") summary.unchanged.push(agentId);
+    // "skip" is unreachable for push (direction=push always returns add/update/unchanged), so we don't bucket it.
   }
 
   if (!apply) return { summary, branch };


### PR DESCRIPTION
## Summary

Closes the tooling gap left by [#240](https://github.com/szhygulin/vaultpilot-dev-framework/pull/240). That PR moved section tags from CLAUDE.md sentinels to per-agent `section-tags.json` sidecars, but `vp-dev agents pull-snapshot` / `push-snapshot` only sync `CLAUDE.md` — so pulling a fresh snapshot brought cleaned CLAUDE.mds without the sidecars, and pushing left local sidecars behind. The companion snapshot-repo PR ([vaultpilot-dev-agents#2](https://github.com/szhygulin/vaultpilot-dev-agents/pull/2)) added 30 `section-tags.json` files to the snapshot, none of which the sync tool knows about.

## What changed

- Both `pullSnapshot` and `pushSnapshot` now iterate the per-agent file set `["CLAUDE.md", "section-tags.json"]`. Per-file sync logic stays in `classifyAgent` unchanged.
- New `mergeAgentActions(actions, destAgentExisted)` reduces per-file actions to a per-agent `SyncSummary` bucket. Verdict semantics reflect "what happened to the agent's directory":
  - Dir didn't exist locally → `add` (any per-file `add`).
  - Dir existed + any file added/updated → `update` (so a sidecar landing alongside an unchanged CLAUDE.md reads as "updated", not "added").
  - Dir existed + any file `skip`ped (skip-existing policy with a real source-side difference) → `skip`.
  - Dir existed + every file unchanged → `unchanged`.
- Missing sidecars on either side are tolerated (early-life agents): a `null` source contributes no per-file action.

## Smoke

```
node dist/bin/vp-dev.js agents pull-snapshot --policy overwrite --dry-run --json
```

against the live `.claude/agents-snapshot` clone (after pulling `vaultpilot-dev-agents#2`) reports `30 updated + 6 unchanged` — exactly matching the snapshot repo's diff (30 agents gained a sidecar; 6 early-life agents had no prior tags and were already clean).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 908/908 (16 new tests across `mergeAgentActions`, pull-sidecar, push-sidecar)
- [x] End-to-end smoke against live snapshot (numbers above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)