### PR TITLE
docs(plan): correct misattributed flag in curve-redo specialist followup

### DIFF
--- a/feature-plans/curve-redo-specialist-followup-plan.md
+++ b/feature-plans/curve-redo-specialist-followup-plan.md
@@ -11,7 +11,7 @@ Hypothesis: per-issue mean Q (specialist arm) > per-issue mean Q (trim arm), pai
 ## Design summary
 
 - **Picker**: `pickAgents()` from `src/orchestrator/orchestrator.ts:283` called as a library, with the 18 trim agents filtered out via a `regOverride` copy (no registry mutation). 1 agent picked per issue. `general` fallback / fresh mint accepted as treatment, stratified by rationale in the analysis.
-- **Dispatch**: Thin shell loop per `research/curve-redo-data/dispatch-leg1.sh`, NOT `vp-dev research bench-specialists` — the bench command's `runBenchDispatch` (`src/research/specialistBench/dispatch.ts:188-209`) hardcodes argv and doesn't plumb the `--no-target-claude-md` / `--capture-diff-path` / `--model` / `--replay-base-sha` flags.
+- **Dispatch**: Thin shell loop per `research/curve-redo-data/dispatch-leg1.sh`, NOT `vp-dev research bench-specialists` — the bench command's `runBenchDispatch` (`src/research/specialistBench/dispatch.ts:188-209`) hardcodes argv and doesn't plumb the `--capture-diff-path` / `--model` / `--replay-base-sha` flags.
 - **Replicates**: same agent for all 3 replicates (deterministic pick). Runs sequentially on the same per-agent clone to avoid worktree races; agents in parallel up to 4-wide.
 - **Cell ID**: `bench-r{N}-<agentId>-<issueId>` — the `bench-r{N}-` prefix follows `specialistBench/dispatch.ts:145`'s convention so the existing aggregator can group replicates.
 - **Score path**: reuses leg-1 testRunner + reasoningJudge end-to-end (PRs [#228](https://github.com/szhygulin/vaultpilot-dev-framework/pull/228) + [#229](https://github.com/szhygulin/vaultpilot-dev-framework/pull/229) already merged). Symlinked `node_modules` from canonical clones; `npm ci` auto-runs as safety net.


### PR DESCRIPTION
Closes #236.

## Summary

The curve-redo specialist-followup plan listed `--no-target-claude-md` among flags that `runBenchDispatch` doesn't plumb. But `src/research/specialistBench/dispatch.ts:207` already includes `--no-target-claude-md` in the hardcoded argv (verified: line 207 in the current `defaultSpawnCell`).

The genuinely missing flags are `--capture-diff-path` / `--model` / `--replay-base-sha` — three, not four. The implementation decision (write a fresh dispatch script in [PR #234](https://github.com/szhygulin/vaultpilot-development-agents/pull/234) rather than reuse `runBenchDispatch`) is unchanged; only the rationale list is wrong, and a future implementer reading the plan would have to re-verify the `--no-target-claude-md` claim against source.

## Change

One-line edit on `feature-plans/curve-redo-specialist-followup-plan.md` line 14: drops `--no-target-claude-md` from the missing-flags enumeration.

## Verification

- `npm run build` passes (tsc clean).
- `npm test` passes (842 subtests, 908 tests).

— Alonzo (agent-92ff)
