### PR TITLE
fix(cli): plumb --max-cost-usd / VP_DEV_MAX_COST_USD into vp-dev spawn

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -297,6 +297,10 @@ export function buildCli(): Command {
       "--capture-diff-path <path>",
       "Curve-redo replay mode: after the agent finishes, write the worktree's diff (modified + newly-staged tracked files) to this path so downstream test-runner / reasoning-judge phases can score it.",
     )
+    .option(
+      "--max-cost-usd <usd>",
+      "Per-spawn cost ceiling in USD (e.g. 10.0). Forwarded to runIssueCore as the SDK's `maxBudgetUsd` query option so the coding agent hard-stops with `error_max_budget_usd` once cumulative cost crosses this value. Env fallback: VP_DEV_MAX_COST_USD. Mirrors `vp-dev run --max-cost-usd` so per-cell dispatch loops (curve-redo, calibration, batch) can defend in depth against a single runaway agent (#235).",
+    )
     .action(async (opts) => {
       await cmdSpawn(opts);
     });
@@ -3241,6 +3245,13 @@ interface SpawnOpts {
   replayBaseSha?: string;
   /** Curve-redo: optional path to write the post-run worktree diff. */
   captureDiffPath?: string;
+  /**
+   * Per-spawn cost ceiling in USD (#235). Plumbed through `resolveBudgetUsd`
+   * and a `RunCostTracker` into `runIssueCore` so the SDK's `maxBudgetUsd`
+   * query option fires `error_max_budget_usd` once the agent's cumulative
+   * cost crosses this value. Env fallback: VP_DEV_MAX_COST_USD.
+   */
+  maxCostUsd?: string;
 }
 
 async function cmdSpawn(opts: SpawnOpts): Promise<void> {
@@ -3264,6 +3275,16 @@ async function cmdSpawn(opts: SpawnOpts): Promise<void> {
   const runId = `spawn-${new Date().toISOString().replace(/[:.]/g, "-")}-issue-${opts.issue}`;
   const logger = new Logger({ runId, verbose: !!opts.verbose });
   await logger.open();
+  // #235: resolve per-spawn cost ceiling from `--max-cost-usd` flag with
+  // VP_DEV_MAX_COST_USD env fallback. Mirrors `cmdRun` so per-cell dispatch
+  // loops (curve-redo, calibration, batch) get a real per-spawn brake — not
+  // just the wallclock turn budget. The tracker is forwarded into
+  // `runIssueCore` so `runCodingAgent` can derive a per-query
+  // `maxBudgetUsd` via `tracker.remainingBudget()`; `budgetUsd` itself is
+  // forwarded so the summarizer-skip guard in runIssueCore fires when the
+  // ceiling is crossed mid-run.
+  const budgetUsd = resolveBudgetUsd({ flag: opts.maxCostUsd, env: process.env });
+  const costTracker = new RunCostTracker({ budgetUsd });
   logger.info("spawn.started", {
     runId,
     agentId: agent.agentId,
@@ -3272,6 +3293,7 @@ async function cmdSpawn(opts: SpawnOpts): Promise<void> {
     targetRepoPath: repoPath,
     dryRun: !!opts.dryRun,
     skipSummary: !!opts.skipSummary,
+    maxCostUsd: budgetUsd ?? null,
   });
 
   try {
@@ -3321,6 +3343,12 @@ async function cmdSpawn(opts: SpawnOpts): Promise<void> {
       suppressTargetClaudeMd: opts.targetClaudeMd === false,
       model: opts.model,
       replayMode,
+      // #235: thread the per-spawn budget into the SDK's maxBudgetUsd path.
+      // Both fields are honored independently by runIssueCore: costTracker
+      // is consulted by runCodingAgent for `remainingBudget()`, and
+      // budgetUsd guards the post-run summarizer skip.
+      costTracker,
+      budgetUsd,
     });
 
     const out = {
@@ -3334,6 +3362,9 @@ async function cmdSpawn(opts: SpawnOpts): Promise<void> {
       parseError: result.parseError ?? null,
       durationMs: result.durationMs,
       costUsd: result.costUsd ?? null,
+      // #235: surface the resolved per-spawn budget so dispatch loops
+      // can confirm the ceiling actually applied (vs. silently undefined).
+      maxCostUsd: budgetUsd ?? null,
       appendOutcome: result.appendOutcome ?? null,
       summarySkipReason: result.summarySkipReason ?? null,
     };


### PR DESCRIPTION
Closes #235.

## Summary

`vp-dev spawn` accepted no `--max-cost-usd` flag and ignored `VP_DEV_MAX_COST_USD`, so the per-cell cost ceiling that curve-redo dispatch loops (and any batch caller of `vp-dev spawn`) assumed existed was silently unenforced. Only the wallclock turn budget bounded a runaway agent — a pathologically expensive single cell could blow through a loop-level cap by an arbitrary amount before the loop noticed.

This wires the flag through the same path `cmdRun` already uses:
- Register `--max-cost-usd <usd>` Commander option on `spawn`.
- Add `maxCostUsd?: string` to `SpawnOpts`.
- In `cmdSpawn`, call `resolveBudgetUsd` (flag → `VP_DEV_MAX_COST_USD` env fallback → `undefined`), construct a fresh `RunCostTracker`, and forward both `budgetUsd` and `costTracker` into `runIssueCore`.
- Log the resolved budget in `spawn.started` and surface it in the stdout JSON so dispatch loops can confirm the ceiling actually applied (vs. silently undefined).

The SDK's `maxBudgetUsd` query option (already wired through `runCodingAgent` from issue #98) does the rest: it hard-stops the coding agent with `error_max_budget_usd` once cumulative cost crosses the ceiling, and the summarizer-skip guard in `runIssueCore` fires correctly when the budget is exceeded mid-run.

## Scope choice

Issue body listed two options: (1) plumb the flag, (2) document the limitation. Took option (1) per the issue's recommendation and the Best-Architectural-Solution rule — the tracker + budget + SDK enforcement are all already implemented; `spawn` just needed to wire the existing pieces. ~31 lines, no new abstractions.

## Test plan

- [x] `npm run build` clean (no type errors).
- [x] `npm test` passes — 908 tests, 0 fail (existing `costTracker.test.ts` already covers `resolveBudgetUsd` + `RunCostTracker` semantics; this PR only adds wiring at the CLI surface, which is integration territory and matches `cmdRun`'s pattern).
- [x] `vp-dev spawn --help` shows the new `--max-cost-usd <usd>` option with help text matching `vp-dev run`'s convention.
- [ ] Smoke-test on a curve-redo dispatch: confirm a cell with `VP_DEV_MAX_COST_USD=10` actually stops at the ceiling (manual / next dispatch).

— Cook (agent-fe90)
