### PR TITLE
feat(lessons): Phase A — body-Jaccard instrumentation in cmdLessonsReview

### DIFF
--- a/src/agent/bodyJaccardLog.test.ts
+++ b/src/agent/bodyJaccardLog.test.ts
@@ -1,0 +1,170 @@
+// Phase A instrumentation tests (#239 / #201). Asserts the JSONL line shape
+// emitted per pending candidate, plus the documented zero-shape on empty
+// CLAUDE.md per CLAUDE.md "smoke-test the empty-result path before merging".
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import {
+  BODY_JACCARD_LOG_PATH,
+  appendBodyJaccardLogLine,
+  computeBodyJaccardScore,
+  loadComparandClaudeMd,
+  type BodyJaccardLogLine,
+} from "./bodyJaccardLog.js";
+
+let counter = 0;
+async function withTempLogPath<T>(
+  fn: (filePath: string) => Promise<T>,
+): Promise<T> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "bjlog-"));
+  const filePath = path.join(dir, `log-${++counter}.jsonl`);
+  try {
+    return await fn(filePath);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+const SECTION_FIXTURE = [
+  "<!-- run:run-A issue:#10 outcome:implement ts:2026-05-01T00:00:00Z -->",
+  "## First lesson",
+  "",
+  "completely different topic about apples bananas cherries oranges",
+  "",
+  "<!-- run:run-B issue:#11 outcome:implement ts:2026-05-02T00:00:00Z -->",
+  "## Second lesson",
+  "",
+  "shared lesson body about typed-data signing for ledger devices",
+  "",
+  "<!-- run:run-C issue:#12 outcome:implement ts:2026-05-03T00:00:00Z -->",
+  "## Third lesson",
+  "",
+  "yet another orthogonal note about coffee tea espresso latte",
+  "",
+].join("\n");
+
+test("computeBodyJaccardScore: empty CLAUDE.md yields the zero-shape record", () => {
+  const result = computeBodyJaccardScore({
+    candidateBody: "any candidate body whatsoever",
+    claudeMd: "",
+  });
+  assert.equal(result.maxScore, 0);
+  assert.equal(result.sectionsCompared, 0);
+  assert.equal(result.matchedSectionId, null);
+});
+
+test("computeBodyJaccardScore: CLAUDE.md without sentinel headers yields zero", () => {
+  // parseClaudeMdSections only matches summarizer-emitted sentinels; a target
+  // repo's hand-edited CLAUDE.md without any sentinels has zero parseable
+  // sections. The empty-result path must still report cleanly.
+  const result = computeBodyJaccardScore({
+    candidateBody: "candidate body",
+    claudeMd: "# Header\n\nHand-written prose, no sentinels here.\n",
+  });
+  assert.equal(result.maxScore, 0);
+  assert.equal(result.sectionsCompared, 0);
+  assert.equal(result.matchedSectionId, null);
+});
+
+test("computeBodyJaccardScore: counts all sentinel sections and selects the highest scorer", () => {
+  const result = computeBodyJaccardScore({
+    candidateBody:
+      "shared lesson body about typed-data signing for ledger devices",
+    claudeMd: SECTION_FIXTURE,
+  });
+  assert.equal(result.sectionsCompared, 3);
+  assert.equal(result.matchedSectionId, "s1");
+  assert.ok(
+    result.maxScore > 0.9,
+    `expected near-perfect overlap on identical body, got ${result.maxScore}`,
+  );
+});
+
+test("computeBodyJaccardScore: orthogonal candidate scores low against every section", () => {
+  const result = computeBodyJaccardScore({
+    candidateBody:
+      "completely orthogonal vocabulary xyzzy plover frotz quetzal",
+    claudeMd: SECTION_FIXTURE,
+  });
+  assert.equal(result.sectionsCompared, 3);
+  assert.ok(
+    result.maxScore < 0.1,
+    `orthogonal candidate should score low; got ${result.maxScore}`,
+  );
+});
+
+test("loadComparandClaudeMd: returns empty string when target file is missing", async () => {
+  // global tier with a non-existent domain → ENOENT path → empty string,
+  // matching the issue's empty-result acceptance criterion.
+  const content = await loadComparandClaudeMd(
+    "global",
+    `nonexistent-domain-${process.pid}-${++counter}`,
+  );
+  assert.equal(content, "");
+});
+
+test("appendBodyJaccardLogLine: writes the documented JSONL shape, one line per call", async () => {
+  await withTempLogPath(async (filePath) => {
+    const line: BodyJaccardLogLine = {
+      ts: "2026-05-08T12:00:00.000Z",
+      event: "lesson.body_jaccard",
+      candidateAgentId: "agent-test-1",
+      candidateDomain: "typed-data",
+      tier: "target",
+      maxScore: 0.42,
+      matchedSectionId: "s3",
+      sectionsCompared: 12,
+    };
+    await appendBodyJaccardLogLine(line, { filePath });
+    await appendBodyJaccardLogLine(
+      { ...line, candidateAgentId: "agent-test-2", maxScore: 0 },
+      { filePath },
+    );
+    const raw = await fs.readFile(filePath, "utf-8");
+    const lines = raw.trim().split("\n");
+    assert.equal(lines.length, 2);
+    const parsed = JSON.parse(lines[0]);
+    assert.equal(parsed.event, "lesson.body_jaccard");
+    assert.equal(parsed.candidateAgentId, "agent-test-1");
+    assert.equal(parsed.candidateDomain, "typed-data");
+    assert.equal(parsed.tier, "target");
+    assert.equal(parsed.maxScore, 0.42);
+    assert.equal(parsed.matchedSectionId, "s3");
+    assert.equal(parsed.sectionsCompared, 12);
+    const parsed2 = JSON.parse(lines[1]);
+    assert.equal(parsed2.candidateAgentId, "agent-test-2");
+    assert.equal(parsed2.maxScore, 0);
+  });
+});
+
+test("appendBodyJaccardLogLine: zero-shape record from empty CLAUDE.md round-trips through the log", async () => {
+  await withTempLogPath(async (filePath) => {
+    const score = computeBodyJaccardScore({
+      candidateBody: "candidate body content",
+      claudeMd: "",
+    });
+    const line: BodyJaccardLogLine = {
+      ts: "2026-05-08T12:00:00.000Z",
+      event: "lesson.body_jaccard",
+      candidateAgentId: "agent-empty",
+      candidateDomain: "solana",
+      tier: "global",
+      ...score,
+    };
+    await appendBodyJaccardLogLine(line, { filePath });
+    const parsed = JSON.parse((await fs.readFile(filePath, "utf-8")).trim());
+    assert.equal(parsed.maxScore, 0);
+    assert.equal(parsed.sectionsCompared, 0);
+    assert.equal(parsed.matchedSectionId, null);
+    assert.equal(parsed.tier, "global");
+  });
+});
+
+test("BODY_JACCARD_LOG_PATH: lives under STATE_DIR (gitignored)", () => {
+  // Sanity check: the production log file path should be `state/lesson-body-jaccard.jsonl`
+  // so it stays gitignored alongside the rest of the state files.
+  assert.match(BODY_JACCARD_LOG_PATH, /[/\\]state[/\\]lesson-body-jaccard\.jsonl$/);
+});

--- a/src/agent/bodyJaccardLog.ts
+++ b/src/agent/bodyJaccardLog.ts
@@ -1,0 +1,129 @@
+// Phase A instrumentation for #201: log body-Jaccard scores between every
+// pending promote-candidate and the existing sections of the relevant
+// CLAUDE.md so Phase B threshold tuning has ~30d of data to fit against.
+//
+// Phase A is observed-not-enforced — this module only emits JSONL events;
+// it does not influence accept/reject decisions in `cmdLessonsReview`.
+// Caller wraps every invocation in try/catch (fail-soft), so a logging
+// failure cannot block the operator-facing review flow.
+//
+// Comparison shape: candidate-body tokens vs. section-body tokens. This is
+// distinct from `extractCitedStableIds` (candidate-(heading+tags+body) vs
+// section-heading) and `checkLessonNovelty` (heading vs heading); Phase B
+// will decide which signal to gate on. Same `tokenize`/`jaccard` helpers
+// reused from `lessonUtility.ts` so threshold-tuning data stays comparable.
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { ensureDir, withFileLock } from "../state/locks.js";
+import { STATE_DIR } from "../state/runState.js";
+import { parseClaudeMdSections } from "./split.js";
+import { tokenize, jaccard } from "../state/lessonUtility.js";
+import { sharedLessonsPath, type LessonTier } from "./sharedLessons.js";
+
+/** Absolute path to the append-only JSONL log of body-Jaccard observations. */
+export const BODY_JACCARD_LOG_PATH = path.join(
+  STATE_DIR,
+  "lesson-body-jaccard.jsonl",
+);
+
+export interface BodyJaccardScore {
+  /** Highest Jaccard score across every section in the comparand CLAUDE.md. */
+  maxScore: number;
+  /**
+   * `sectionId` (`s0`, `s1`, ...) of the section that produced `maxScore`,
+   * or `null` when no sections were compared (empty CLAUDE.md path).
+   */
+  matchedSectionId: string | null;
+  /** Number of sections enumerated in the comparand. */
+  sectionsCompared: number;
+}
+
+/**
+ * Compare a candidate body against every existing section in the supplied
+ * CLAUDE.md content. Pure / synchronous so tests can exercise it without I/O.
+ *
+ * Empty CLAUDE.md (or no parseable sections) returns `maxScore: 0,
+ * sectionsCompared: 0, matchedSectionId: null` — required by issue #239's
+ * "empty-result path emits zero" acceptance criterion (per CLAUDE.md
+ * "smoke-test the empty-result path before merging").
+ */
+export function computeBodyJaccardScore(input: {
+  candidateBody: string;
+  claudeMd: string;
+}): BodyJaccardScore {
+  const sections = parseClaudeMdSections(input.claudeMd);
+  if (sections.length === 0) {
+    return { maxScore: 0, matchedSectionId: null, sectionsCompared: 0 };
+  }
+  const candidateTokens = tokenize(input.candidateBody);
+  let maxScore = 0;
+  let matchedSectionId: string | null = null;
+  for (const section of sections) {
+    const sectionTokens = tokenize(section.body);
+    const score = jaccard(candidateTokens, sectionTokens);
+    if (score > maxScore) {
+      maxScore = score;
+      matchedSectionId = section.sectionId;
+    }
+  }
+  return { maxScore, matchedSectionId, sectionsCompared: sections.length };
+}
+
+/**
+ * Resolve the comparand CLAUDE.md for a given (tier, domain) pair.
+ *   - target tier: project-root `./CLAUDE.md` (cwd-relative).
+ *   - global tier: `~/.vaultpilot/shared-lessons/<domain>.md` (or its
+ *     XDG-overridden equivalent).
+ *
+ * Missing files resolve to an empty string so the caller's
+ * `computeBodyJaccardScore` produces the documented zero-shape record.
+ */
+export async function loadComparandClaudeMd(
+  tier: LessonTier,
+  domain: string,
+): Promise<string> {
+  const filePath =
+    tier === "target"
+      ? path.resolve(process.cwd(), "CLAUDE.md")
+      : sharedLessonsPath(tier, domain);
+  try {
+    return await fs.readFile(filePath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return "";
+    throw err;
+  }
+}
+
+export interface BodyJaccardLogLine extends BodyJaccardScore {
+  ts: string;
+  event: "lesson.body_jaccard";
+  candidateAgentId: string;
+  candidateDomain: string;
+  tier: LessonTier;
+}
+
+export interface AppendOptions {
+  /**
+   * Override the destination file. Tests use this so each test writes to a
+   * unique path and cleans up without contention. Production callers leave
+   * unset to land in `state/lesson-body-jaccard.jsonl`.
+   */
+  filePath?: string;
+}
+
+/**
+ * Append one observation line to the body-Jaccard JSONL log. Uses the same
+ * lock helper as the rest of `state/` so concurrent reviewers don't tear
+ * lines.
+ */
+export async function appendBodyJaccardLogLine(
+  line: BodyJaccardLogLine,
+  options: AppendOptions = {},
+): Promise<void> {
+  const filePath = options.filePath ?? BODY_JACCARD_LOG_PATH;
+  await ensureDir(path.dirname(filePath));
+  await withFileLock(filePath, async () => {
+    await fs.appendFile(filePath, JSON.stringify(line) + "\n");
+  });
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -121,6 +121,11 @@ import {
   type LessonTier,
 } from "./agent/sharedLessons.js";
 import {
+  appendBodyJaccardLogLine,
+  computeBodyJaccardScore,
+  loadComparandClaudeMd,
+} from "./agent/bodyJaccardLog.js";
+import {
   evaluateLocalClaudeUtilityGate,
   type LocalClaudeUtilityGateResult,
 } from "./agent/localClaudeQueue.js";
@@ -3675,6 +3680,33 @@ async function cmdLessonsReview(opts: LessonsReviewOpts): Promise<void> {
   // a split, and we still want to surface it. The boundary that matters is
   // the human-review gate, not the agent's lifecycle status.
   const pending = await collectPendingCandidates(reg.agents);
+
+  // Phase A instrumentation for #201: log one body-Jaccard observation per
+  // pending candidate so Phase B threshold tuning has data to fit against.
+  // Fail-soft per CLAUDE.md "Fail-soft wiring for state-collection hooks":
+  // a logging error must not abort review — wrap each emit individually.
+  const logTs = new Date().toISOString();
+  for (const p of pending) {
+    try {
+      const claudeMd = await loadComparandClaudeMd(tier, p.candidate.domain);
+      const score = computeBodyJaccardScore({
+        candidateBody: p.candidate.body,
+        claudeMd,
+      });
+      await appendBodyJaccardLogLine({
+        ts: logTs,
+        event: "lesson.body_jaccard",
+        candidateAgentId: p.agentId,
+        candidateDomain: p.candidate.domain,
+        tier,
+        ...score,
+      });
+    } catch (err) {
+      process.stderr.write(
+        `warn: body-Jaccard log emit failed for ${p.agentId} -> ${p.candidate.domain}: ${(err as Error).message}\n`,
+      );
+    }
+  }
 
   if (opts.json) {
     process.stdout.write(

--- a/src/state/lessonUtility.ts
+++ b/src/state/lessonUtility.ts
@@ -370,7 +370,7 @@ const STOP_WORDS = new Set([
   "to", "was", "were", "will", "with", "the", "but", "if", "not", "no", "so",
 ]);
 
-function tokenize(text: string): Set<string> {
+export function tokenize(text: string): Set<string> {
   const out = new Set<string>();
   for (const raw of text.toLowerCase().split(/[^a-z0-9-]+/)) {
     if (raw.length < 3) continue;
@@ -380,7 +380,7 @@ function tokenize(text: string): Set<string> {
   return out;
 }
 
-function jaccard(a: Set<string>, b: Set<string>): number {
+export function jaccard(a: Set<string>, b: Set<string>): number {
   if (a.size === 0 || b.size === 0) return 0;
   let intersect = 0;
   for (const t of a) if (b.has(t)) intersect++;


### PR DESCRIPTION
Closes #239.

## Summary

Phase A of #201: log candidate-vs-existing-section body-Jaccard scores from `cmdLessonsReview` so the data clock starts ~30d toward Phase B threshold tuning. Observed-not-enforced — no behavior change in the accept/reject path.

## Hook

After `collectPendingCandidates`, the review CLI iterates each pending candidate and emits one JSONL line of shape:

```jsonl
{"ts":"...","event":"lesson.body_jaccard","candidateAgentId":"...","candidateDomain":"...","tier":"target","maxScore":0.42,"matchedSectionId":"s3","sectionsCompared":12}
```

Each emit is wrapped in `try/catch` per CLAUDE.md "Fail-soft wiring for state-collection hooks" — a logging error cannot abort review.

## Comparand resolution

- target tier → project-root `./CLAUDE.md`
- global tier → `~/.vaultpilot/shared-lessons/<candidate.domain>.md`

Sections are enumerated via `parseClaudeMdSections` (same regex everything else in this codebase uses for sentinel-bearing sections). Files without sentinel-headers parse to zero sections — including the global pool files, since they use a different sentinel format. Phase B can decide whether to add a pool-aware splitter or stay on `parseClaudeMdSections`; the Phase A data shows what the current splitter sees.

## Persistence

Append-only at `state/lesson-body-jaccard.jsonl`, file-locked, gitignored. Same pattern as `state/outcomes/*.jsonl`.

## Comparison shape (vs. existing helpers)

- `extractCitedStableIds`: candidate-(heading+tags+body) vs section-heading (reinforcement, default 0.6).
- `checkLessonNovelty`: candidate-heading vs section-heading (dedup, default 0.85).
- **this PR**: candidate-body vs section-body. New shape; Phase B will decide which to gate on.

`tokenize` and `jaccard` are now exported from `lessonUtility.ts` so all three signals share identical token-shaping rules — Phase B threshold-tuning data stays comparable.

## Empty-result path

Empty CLAUDE.md, missing comparand file, or no parseable sentinels → `{maxScore: 0, sectionsCompared: 0, matchedSectionId: null}`. Smoke-tested live (`computeBodyJaccardScore` + `vp-dev lessons review --json`) per CLAUDE.md "smoke-test the empty-result path before merging".

## Out of scope (Phase B, tracked at #201)

- Acting on the score (refusing / merging candidates).
- Threshold tuning.
- UI surfacing in the `--pr` flow.
- Pool-aware splitter for global-tier comparand.

## Files (4)

- `src/agent/bodyJaccardLog.ts` — new pure compute + I/O helpers.
- `src/agent/bodyJaccardLog.test.ts` — 8 tests covering populated, empty, orthogonal, and round-trip paths.
- `src/cli.ts` — instrumentation block in `cmdLessonsReview` + imports.
- `src/state/lessonUtility.ts` — export `tokenize` and `jaccard` for reuse.

## Test plan

- [x] `npm run build` — clean tsc.
- [x] `npm test` — 916 passing (8 new in `bodyJaccardLog.test.ts`).
- [x] Live empty-result smoke against `computeBodyJaccardScore` + `vp-dev lessons review --json`.

— Advisory Scope Boundary (agent-916a)
