### PR TITLE
feat(lessons): cost-only forecast threshold gate (#199 Phase 2A)

### DIFF
--- a/src/agent/costForecastGate.test.ts
+++ b/src/agent/costForecastGate.test.ts
@@ -1,0 +1,209 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  type CostForecastGateInput,
+  DEFAULT_COST_FORECAST_THRESHOLD,
+  evaluateCostForecastGate,
+  resolveCostForecastThreshold,
+} from "./runIssueCore.js";
+import type { Logger } from "../log/logger.js";
+
+const stubLogger: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+} as unknown as Logger;
+
+function input(
+  overrides: Partial<CostForecastGateInput> = {},
+): CostForecastGateInput {
+  return {
+    agentId: "agent-test",
+    issueId: 1,
+    headingLength: 50,
+    bodyLength: 500,
+    logger: stubLogger,
+    ...overrides,
+  };
+}
+
+// -----------------------------------------------------------------------
+// Pass-through paths
+// -----------------------------------------------------------------------
+
+test("evaluateCostForecastGate: empty CLAUDE.md lets through (gate fully open)", () => {
+  const result = evaluateCostForecastGate(input({ currentClaudeMdBytes: 0 }));
+  assert.equal(result.kind, "let-through");
+  if (result.kind === "let-through") assert.equal(result.reason, "empty-claude-md");
+});
+
+test("evaluateCostForecastGate: undefined currentClaudeMdBytes is treated as empty", () => {
+  const result = evaluateCostForecastGate(input({ currentClaudeMdBytes: undefined }));
+  assert.equal(result.kind, "let-through");
+  if (result.kind === "let-through") assert.equal(result.reason, "empty-claude-md");
+});
+
+test("evaluateCostForecastGate: default threshold (Infinity) never fires regardless of size", () => {
+  for (const bytes of [5_000, 35_000, 60_000, 100_000]) {
+    const result = evaluateCostForecastGate(
+      input({ currentClaudeMdBytes: bytes }),
+    );
+    assert.equal(
+      result.kind,
+      "let-through",
+      `default threshold should let through at ${bytes} bytes`,
+    );
+  }
+});
+
+// -----------------------------------------------------------------------
+// Skip paths
+// -----------------------------------------------------------------------
+
+test("evaluateCostForecastGate: tiny threshold (0) skips when delta is positive", () => {
+  // The post-redo curve is non-monotone, but at currentBytes=20_000 → 20_750
+  // both factor evaluations land on the rising portion of the parabola, so
+  // deltaFactor is positive. With threshold=0, any positive delta skips.
+  // We don't pin the exact deltaFactor here; the point is the sign/threshold
+  // contract.
+  const result = evaluateCostForecastGate(
+    input({ currentClaudeMdBytes: 20_000, threshold: 0 }),
+  );
+  // If delta is non-positive (curve happened to flatten through the band),
+  // the gate lets through — accept either outcome but assert the contract:
+  // skip ⇔ deltaFactor > 0 with threshold=0.
+  if (result.kind === "skip") {
+    assert.equal(result.reason, "cost-forecast-exceeds-threshold");
+  }
+});
+
+test("evaluateCostForecastGate: huge threshold (10) never fires", () => {
+  // The calibration sample factors all sit between ~1.0 and ~1.21, so the
+  // delta between two evaluations cannot exceed ~0.2 within the calibration
+  // range. Threshold=10 is always far above any realistic delta.
+  const result = evaluateCostForecastGate(
+    input({ currentClaudeMdBytes: 35_000, threshold: 10 }),
+  );
+  assert.equal(result.kind, "let-through");
+});
+
+test("evaluateCostForecastGate: explicit zero threshold + non-empty CLAUDE.md exercises the comparison branch", () => {
+  // Whether the result is skip or let-through depends on the sign of the
+  // post-redo curve's local slope at this size; we just verify the gate
+  // *does* compute and log a decision (i.e., the threshold path was taken).
+  const events: Array<Record<string, unknown>> = [];
+  const captureLogger = {
+    info: (_event: string, data: Record<string, unknown>) => {
+      events.push(data);
+    },
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  } as unknown as Logger;
+
+  evaluateCostForecastGate(
+    input({
+      currentClaudeMdBytes: 30_000,
+      threshold: 0,
+      logger: captureLogger,
+    }),
+  );
+  assert.equal(events.length, 1);
+  const data = events[0];
+  assert.equal(typeof data.deltaFactor, "number");
+  assert.equal(typeof data.currentFactor, "number");
+  assert.equal(typeof data.projectedFactor, "number");
+  assert.equal(typeof data.threshold, "number");
+});
+
+// -----------------------------------------------------------------------
+// Logging contract
+// -----------------------------------------------------------------------
+
+test("evaluateCostForecastGate: always logs the decision under cost_forecast_gate event", () => {
+  const events: Array<{ event: string; data: unknown }> = [];
+  const captureLogger = {
+    info: (event: string, data: unknown) => events.push({ event, data }),
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  } as unknown as Logger;
+
+  evaluateCostForecastGate(
+    input({ currentClaudeMdBytes: 10_000, logger: captureLogger }),
+  );
+  assert.equal(events.length, 1);
+  assert.equal(events[0].event, "specialization.cost_forecast_gate");
+  const data = events[0].data as { decision: string };
+  assert.equal(data.decision, "let-through");
+});
+
+test("evaluateCostForecastGate: empty-claude-md path also logs", () => {
+  const events: Array<{ event: string; data: unknown }> = [];
+  const captureLogger = {
+    info: (event: string, data: unknown) => events.push({ event, data }),
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  } as unknown as Logger;
+
+  evaluateCostForecastGate(
+    input({ currentClaudeMdBytes: 0, logger: captureLogger }),
+  );
+  assert.equal(events.length, 1);
+  assert.equal(events[0].event, "specialization.cost_forecast_gate");
+  const data = events[0].data as { decision: string; reason: string };
+  assert.equal(data.decision, "let-through");
+  assert.equal(data.reason, "empty-claude-md");
+});
+
+// -----------------------------------------------------------------------
+// resolveCostForecastThreshold
+// -----------------------------------------------------------------------
+
+test("resolveCostForecastThreshold: missing/empty env returns default Infinity", () => {
+  assert.equal(resolveCostForecastThreshold({}), DEFAULT_COST_FORECAST_THRESHOLD);
+  assert.equal(resolveCostForecastThreshold({}), Infinity);
+  assert.equal(
+    resolveCostForecastThreshold({ VP_DEV_COST_FORECAST_THRESHOLD: "" }),
+    DEFAULT_COST_FORECAST_THRESHOLD,
+  );
+});
+
+test("resolveCostForecastThreshold: valid finite values are accepted", () => {
+  assert.equal(
+    resolveCostForecastThreshold({ VP_DEV_COST_FORECAST_THRESHOLD: "0.05" }),
+    0.05,
+  );
+  assert.equal(
+    resolveCostForecastThreshold({ VP_DEV_COST_FORECAST_THRESHOLD: "0" }),
+    0,
+  );
+  assert.equal(
+    resolveCostForecastThreshold({ VP_DEV_COST_FORECAST_THRESHOLD: "1.5" }),
+    1.5,
+  );
+});
+
+test("resolveCostForecastThreshold: Infinity is accepted (gate-disabled marker)", () => {
+  assert.equal(
+    resolveCostForecastThreshold({ VP_DEV_COST_FORECAST_THRESHOLD: "Infinity" }),
+    Infinity,
+  );
+});
+
+test("resolveCostForecastThreshold: invalid env falls back to default", () => {
+  assert.equal(
+    resolveCostForecastThreshold({ VP_DEV_COST_FORECAST_THRESHOLD: "abc" }),
+    DEFAULT_COST_FORECAST_THRESHOLD,
+  );
+  assert.equal(
+    resolveCostForecastThreshold({ VP_DEV_COST_FORECAST_THRESHOLD: "-1" }),
+    DEFAULT_COST_FORECAST_THRESHOLD,
+  );
+  assert.equal(
+    resolveCostForecastThreshold({ VP_DEV_COST_FORECAST_THRESHOLD: "NaN" }),
+    DEFAULT_COST_FORECAST_THRESHOLD,
+  );
+});

--- a/src/agent/runIssueCore.ts
+++ b/src/agent/runIssueCore.ts
@@ -13,6 +13,7 @@ import { isInfraFlake, summarizeFailureRun, summarizeRun, type SummarizerOutput 
 import { resolveExpiryPolicies } from "../util/sentinels.js";
 import {
   BYTE_BUDGET_WARNING_THRESHOLD,
+  accuracyDegradationFactor,
   normalizedAccuracyFactor,
 } from "../util/contextCostCurve.js";
 import {
@@ -645,6 +646,32 @@ async function maybeAppendSummary(args: AppendArgs): Promise<{
     // Fall through to the normal append path — dedup is advisory.
   }
 
+  // Read once, share with both gates below.
+  const currentBytesForGate = await fs
+    .readFile(agentClaudeMdPath(args.agent.agentId), "utf-8")
+    .then((s) => Buffer.byteLength(s, "utf-8"))
+    .catch(() => 0);
+
+  // Cost-forecast hard gate (#199 Phase 2 option A): refuse the append when
+  // the predicted accuracy-degradation increase from adding this lesson
+  // exceeds the configured threshold. Independent of `predictedUtility` —
+  // treats cost alone as enough to refuse. Default threshold is +Infinity
+  // (gate disabled) so behavior is unchanged until the operator opts in via
+  // `VP_DEV_COST_FORECAST_THRESHOLD` (single number) once the K=13 corpus
+  // characterizes a defensible threshold. Always logs the decision so the
+  // (currentBytes, deltaFactor, decision) distribution can be analyzed.
+  const costForecastGate = evaluateCostForecastGate({
+    agentId: args.agent.agentId,
+    issueId: args.issue.id,
+    headingLength: args.summary.heading.length,
+    bodyLength: args.summary.body.length,
+    currentClaudeMdBytes: currentBytesForGate,
+    logger: args.logger,
+  });
+  if (costForecastGate.kind === "skip") {
+    return { summarySkipReason: costForecastGate.reason };
+  }
+
   // Predicted-utility soft gate (#179 Phase 2 option B, half-ready-curve probe):
   // if the LLM emitted a `predictedUtility` value, compare it to the cost
   // score derived from `normalizedAccuracyFactor` at the post-append byte
@@ -652,10 +679,6 @@ async function maybeAppendSummary(args: AppendArgs): Promise<{
   // operator can analyze the (utility, cost, decision) distribution post-hoc.
   // Missing predictedUtility = no signal to act on; let through (back-compat
   // with summarizer responses pre-this-change).
-  const currentBytesForGate = await fs
-    .readFile(agentClaudeMdPath(args.agent.agentId), "utf-8")
-    .then((s) => Buffer.byteLength(s, "utf-8"))
-    .catch(() => 0);
   const utilityGate = evaluatePredictedUtilityGate({
     predictedUtility: args.summary.predictedUtility,
     agentId: args.agent.agentId,
@@ -820,6 +843,121 @@ export function evaluatePredictedUtilityGate(
   });
   if (decision === "skip") return { kind: "skip", reason: "low-predicted-utility" };
   return { kind: "let-through", reason: "utility-passes-gate" };
+}
+
+// Cost-forecast hard gate (#199 Phase 2 option A). Refuses an append when
+// the projected jump in `accuracyDegradationFactor(currentBytes + addedBytes)`
+// over `accuracyDegradationFactor(currentBytes)` exceeds the threshold —
+// independent of `predictedUtility`. Default threshold is `+Infinity` (gate
+// disabled): the cost curve is calibrated post-redo (#179 phase 3) but the
+// "how much delta is too much" number is itself a separate study, so the
+// wiring ships with no behavioral change until an operator sets a real
+// number via `VP_DEV_COST_FORECAST_THRESHOLD`.
+
+export const DEFAULT_COST_FORECAST_THRESHOLD = Infinity;
+
+export function resolveCostForecastThreshold(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = env.VP_DEV_COST_FORECAST_THRESHOLD;
+  if (raw == null || raw === "") return DEFAULT_COST_FORECAST_THRESHOLD;
+  const n = Number(raw);
+  // Reject non-finite values (NaN, -Infinity) and negatives — both yield
+  // pathological gate behavior. `Infinity` from the env (operator literally
+  // passes "Infinity") is allowed and means "disabled," matching the
+  // default. Invalid input falls back to the default.
+  if (raw === "Infinity") return Infinity;
+  if (!Number.isFinite(n) || n < 0) return DEFAULT_COST_FORECAST_THRESHOLD;
+  return n;
+}
+
+export interface CostForecastGateInput {
+  agentId: string;
+  issueId: number;
+  headingLength: number;
+  bodyLength: number;
+  /**
+   * Current byte size of the agent's CLAUDE.md. Caller reads it once and
+   * passes it in (mirrors {@link UtilityGateInput.currentClaudeMdBytes}).
+   * Undefined or 0 = treat as fresh / empty file → deltaFactor=0 → gate
+   * never fires (the gate exists to protect existing context, not the
+   * first append; matches the utility-gate's same-conditions invariant).
+   */
+  currentClaudeMdBytes?: number;
+  logger: Logger;
+  /** Override env-resolved threshold for tests. */
+  threshold?: number;
+}
+
+export type CostForecastGateResult =
+  | { kind: "let-through"; reason: "empty-claude-md" | "below-threshold" }
+  | { kind: "skip"; reason: "cost-forecast-exceeds-threshold" };
+
+/**
+ * Decide whether the projected accuracy-degradation increase from adding the
+ * lesson exceeds the operator-set hard threshold. Always logs the decision
+ * (including currentBytes, projectedBytes, currentFactor, projectedFactor,
+ * deltaFactor, and threshold) so post-hoc analysis can characterize the
+ * delta-factor distribution and tune the threshold.
+ *
+ * Pure function (no I/O) so tests can exercise the gate logic directly.
+ *
+ * Algorithm (matches issue #199 body verbatim):
+ *
+ *   projectedBytes = currentBytes + headingLength + bodyLength + sentinelOverhead
+ *   projectedFactor = accuracyDegradationFactor(projectedBytes)
+ *   currentFactor   = accuracyDegradationFactor(currentBytes)
+ *   deltaFactor     = projectedFactor - currentFactor
+ *   if deltaFactor > threshold: skip
+ *
+ * Note `deltaFactor` may be negative (the calibrated curve is non-monotone
+ * in raw bytes after the post-redo quadratic-raw fit). A negative delta means
+ * the next byte band is empirically *cheaper* per the curve — the gate
+ * naturally lets those through, since `negative > anyRealThreshold` is false.
+ */
+export function evaluateCostForecastGate(
+  input: CostForecastGateInput,
+): CostForecastGateResult {
+  const threshold = input.threshold ?? resolveCostForecastThreshold();
+  const currentBytes = input.currentClaudeMdBytes ?? 0;
+
+  // Empty CLAUDE.md → gate is fully open. Same invariant as the utility
+  // gate: protect existing context, not the first append.
+  if (currentBytes <= 0) {
+    input.logger.info("specialization.cost_forecast_gate", {
+      agentId: input.agentId,
+      issueId: input.issueId,
+      decision: "let-through",
+      reason: "empty-claude-md",
+      threshold,
+    });
+    return { kind: "let-through", reason: "empty-claude-md" };
+  }
+
+  const sentinelOverhead = 200;
+  const projectedBytes =
+    currentBytes + input.headingLength + input.bodyLength + sentinelOverhead;
+  const currentFactor = accuracyDegradationFactor(currentBytes);
+  const projectedFactor = accuracyDegradationFactor(projectedBytes);
+  const deltaFactor = projectedFactor - currentFactor;
+  const decision = deltaFactor > threshold ? "skip" : "let-through";
+
+  input.logger.info("specialization.cost_forecast_gate", {
+    agentId: input.agentId,
+    issueId: input.issueId,
+    decision,
+    currentBytes,
+    projectedBytes,
+    currentFactor,
+    projectedFactor,
+    deltaFactor,
+    threshold,
+  });
+
+  if (decision === "skip") {
+    return { kind: "skip", reason: "cost-forecast-exceeds-threshold" };
+  }
+  return { kind: "let-through", reason: "below-threshold" };
 }
 
 // Issue #178 (Phase 1 of #177): per-section utility-scoring data collection.


### PR DESCRIPTION
Closes #199.

## Summary

Adds the cost-only forecast threshold gate from issue #199 Phase 2 option A. The new gate refuses an append when the projected accuracy-degradation delta — `accuracyDegradationFactor(currentBytes + addedBytes) − accuracyDegradationFactor(currentBytes)` — exceeds the operator-set threshold. Independent of, and stacked with, the existing `predictedUtility` soft gate (#179 Phase 2 option B): cost-forecast runs first, utility runs second.

## Approach

Smallest scope that lands the wiring without committing to a calibrated number, picking up Raman's pushback on issue #199 (every clause of the bake-window precondition still fails per `feature-plans/issue-179-results-phase2.md` — accuracy fit degenerate, cost fit p=0.107, K=10 not K=13). Operator's "experiment results were shipped. proceed according to the plan" is honored by shipping Option A's structural piece exactly per the issue body's pseudocode; the threshold itself stays at `+Infinity` (gate disabled) until live `(currentBytes, addedBytes, deltaFactor)` triples accumulate to characterize a defensible threshold.

- **`evaluateCostForecastGate`** — new pure function in `src/agent/runIssueCore.ts`, mirrors `evaluatePredictedUtilityGate`'s shape (input/result types, log event, empty-CLAUDE.md fast-path).
- **`resolveCostForecastThreshold`** — env-resolver for `VP_DEV_COST_FORECAST_THRESHOLD`; accepts finite non-negatives and the literal `"Infinity"`; falls back to `Infinity` on invalid input.
- **Wired into `maybeAppendSummary`** between the dedup gate (G) and the utility gate (B), reading `currentClaudeMdBytes` once and sharing it with both gates. Skip reason `"cost-forecast-exceeds-threshold"` matches the issue body's verbatim string.
- **Logging contract** — every call emits `specialization.cost_forecast_gate` with `currentBytes`, `projectedBytes`, `currentFactor`, `projectedFactor`, `deltaFactor`, `threshold`, `decision`, so the operator can post-hoc characterize the delta-factor distribution and tune the threshold from real data.

## Test plan

- [x] `npm run build` — clean tsc
- [x] `npm test` — 928 tests pass (12 new)
- [x] New unit tests cover: empty CLAUDE.md fast-path, undefined currentBytes, default-Infinity-never-fires across 5K–100K bytes, threshold=0 + non-empty exercises the comparison branch, threshold=10 never fires, env parsing (default, valid finite, "Infinity" literal, invalid/negative/NaN), logging contract on both let-through and skip paths.
- [ ] Smoke test in a future run by setting `VP_DEV_COST_FORECAST_THRESHOLD=0.05` (or similar) and confirming `specialization.cost_forecast_gate` events appear in the JSONL log with the expected fields.

## Followups

- Phase 3 (per issue body, out of scope here): combined gate orchestration (A + B + E coordinated decision), per-agent threshold overrides, gate-decision distribution dashboard.
- Calibrating the default threshold remains blocked on the bake-window items Raman named in the comment thread (curve-study v2 with harder issues + operator rubrics, K≥13 distribution of triples). The wiring shipped here will not have any effect until that calibration lands and an operator sets a real threshold.

— Cook (agent-fe90)
