### PR TITLE
feat(preflight): detect libc/SDK-binary mismatch before dispatch (#245)

### DIFF
--- a/src/agent/sdkBinary.test.ts
+++ b/src/agent/sdkBinary.test.ts
@@ -1,0 +1,70 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  MUSL_LOADER_PATH,
+  preflightSdkBinary,
+  type PreflightSdkDeps,
+} from "./sdkBinary.js";
+
+// Issue #245: pre-dispatch libc preflight in `vp-dev run`. These tests pin
+// the four detection branches against fully-injected dependencies — no real
+// filesystem, platform, or `require.resolve` work touches the host — so the
+// suite passes identically on macOS dev boxes, Linux CI, and Windows. The
+// branches mirror the issue body's "Fix one of" enumeration: env override
+// already set / non-Linux / musl SDK not installed / musl loader present /
+// musl loader absent (the actual mismatch we want to catch).
+
+function deps(overrides: Partial<PreflightSdkDeps>): PreflightSdkDeps {
+  return {
+    envClaudeBinPath: () => undefined,
+    platform: () => "linux",
+    resolveMuslBin: () => "/repo/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl/claude",
+    resolveGlibcBin: () => "/repo/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude",
+    fileExists: () => false,
+    ...overrides,
+  };
+}
+
+test("preflightSdkBinary: VP_DEV_CLAUDE_BIN override → ok (operator owns the choice)", () => {
+  const r = preflightSdkBinary(
+    deps({ envClaudeBinPath: () => "/custom/claude" }),
+  );
+  assert.deepEqual(r, { ok: true });
+});
+
+test("preflightSdkBinary: non-Linux platform → ok (no musl probe applies)", () => {
+  const r = preflightSdkBinary(deps({ platform: () => "darwin" }));
+  assert.deepEqual(r, { ok: true });
+});
+
+test("preflightSdkBinary: musl SDK not installed → ok (SDK won't pick it either)", () => {
+  const r = preflightSdkBinary(deps({ resolveMuslBin: () => null }));
+  assert.deepEqual(r, { ok: true });
+});
+
+test("preflightSdkBinary: musl loader present (musl host) → ok", () => {
+  const r = preflightSdkBinary(
+    deps({ fileExists: (p) => p === MUSL_LOADER_PATH }),
+  );
+  assert.deepEqual(r, { ok: true });
+});
+
+test("preflightSdkBinary: musl SDK present + loader absent → mismatch with glibc hint", () => {
+  const r = preflightSdkBinary(deps({ fileExists: () => false }));
+  assert.equal(r.ok, false);
+  if (r.ok) return;
+  assert.match(r.reason, /musl-linked binary/);
+  assert.match(r.reason, /\/lib\/ld-musl-x86_64\.so\.1/);
+  assert.match(r.hint, /VP_DEV_CLAUDE_BIN=\/repo\/node_modules\/@anthropic-ai\/claude-agent-sdk-linux-x64\/claude/);
+  assert.match(r.hint, /musl-disabled/);
+  assert.match(r.hint, /Aborting before dispatch/);
+});
+
+test("preflightSdkBinary: musl SDK present + loader absent + glibc unresolved → mismatch with generic hint", () => {
+  const r = preflightSdkBinary(
+    deps({ fileExists: () => false, resolveGlibcBin: () => null }),
+  );
+  assert.equal(r.ok, false);
+  if (r.ok) return;
+  assert.match(r.hint, /VP_DEV_CLAUDE_BIN=<path to glibc claude binary/);
+});

--- a/src/agent/sdkBinary.ts
+++ b/src/agent/sdkBinary.ts
@@ -1,5 +1,5 @@
 /**
- * Claude Agent SDK binary override.
+ * Claude Agent SDK binary override + libc preflight.
  *
  * Background: `npm install` pulls both
  * `@anthropic-ai/claude-agent-sdk-linux-x64-musl` and
@@ -18,7 +18,101 @@
  * Lookup is centralized here so any future `query()` call site picks it up
  * automatically by passing `pathToClaudeCodeExecutable: claudeBinPath()`.
  */
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+
 export function claudeBinPath(): string | undefined {
   const v = process.env.VP_DEV_CLAUDE_BIN;
   return v && v.length > 0 ? v : undefined;
+}
+
+/**
+ * Issue #245: detect the libc/SDK-binary mismatch BEFORE the orchestrator
+ * dispatches N agents. The SDK's exec-time failure surfaces as a misleading
+ * "Claude Code native binary not found" error and triage's post-mortem gate
+ * then refuses to re-dispatch the affected issues without
+ * `--include-non-ready`. One detectable host condition cascades into N
+ * identical agent crashes plus a triage gate; preflight catches it once.
+ *
+ * Detection (cheap, no exec required):
+ *   1. If the operator already overrode via `VP_DEV_CLAUDE_BIN`, trust them.
+ *   2. Outside Linux (macOS / Windows), the musl probe doesn't apply.
+ *   3. Resolve the musl SDK binary path (the one the SDK will pick first).
+ *      If the package isn't installed, no probe is possible — return ok.
+ *   4. The musl binary's ELF interpreter is hardcoded to
+ *      `/lib/ld-musl-x86_64.so.1`. Existence of that loader on the host is
+ *      a sufficient proxy: present → musl host (binary launches), absent →
+ *      glibc host (binary fails at execve with the misleading error).
+ *
+ * Becomes obsolete once `claudeBinPath()` learns to auto-fall-back to the
+ * glibc binary on libc mismatch (issue #251 follow-up).
+ */
+export interface PreflightSdkDeps {
+  envClaudeBinPath?: () => string | undefined;
+  platform?: () => NodeJS.Platform;
+  resolveMuslBin?: () => string | null;
+  resolveGlibcBin?: () => string | null;
+  fileExists?: (p: string) => boolean;
+}
+
+export type PreflightSdkResult =
+  | { ok: true }
+  | { ok: false; reason: string; hint: string };
+
+export const MUSL_LOADER_PATH = "/lib/ld-musl-x86_64.so.1";
+
+export function preflightSdkBinary(
+  deps: PreflightSdkDeps = {},
+): PreflightSdkResult {
+  const envBin = deps.envClaudeBinPath ?? claudeBinPath;
+  const platformOf = deps.platform ?? (() => process.platform);
+  const fileExists = deps.fileExists ?? existsSync;
+  const resolveMusl = deps.resolveMuslBin ?? defaultResolveMuslBin;
+  const resolveGlibc = deps.resolveGlibcBin ?? defaultResolveGlibcBin;
+
+  if (envBin()) return { ok: true };
+  if (platformOf() !== "linux") return { ok: true };
+
+  const muslBin = resolveMusl();
+  if (!muslBin) return { ok: true };
+  if (fileExists(MUSL_LOADER_PATH)) return { ok: true };
+
+  const glibcBin = resolveGlibc();
+  const fix1 = glibcBin
+    ? `  1. export VP_DEV_CLAUDE_BIN=${glibcBin}`
+    : `  1. export VP_DEV_CLAUDE_BIN=<path to glibc claude binary, e.g. node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude>`;
+  const hint =
+    `Fix one of:\n${fix1}\n` +
+    `  2. mv ${muslBin} ${muslBin}.musl-disabled  (re-apply after every npm ci)\n` +
+    `  3. (future) auto-fallback in src/agent/sdkBinary.ts — see #29 / #251 follow-up\n\n` +
+    `Aborting before dispatch to avoid N identical agent crashes + triage post-mortem gate.`;
+
+  return {
+    ok: false,
+    reason:
+      `Claude Agent SDK will pick the musl-linked binary at\n  ${muslBin}\n` +
+      `on this host, but the musl loader (${MUSL_LOADER_PATH}) is not present. ` +
+      `The exec will fail with the misleading "Claude Code native binary not found" error.`,
+    hint,
+  };
+}
+
+function defaultResolveMuslBin(): string | null {
+  return tryResolve("@anthropic-ai/claude-agent-sdk-linux-x64-musl/claude");
+}
+
+function defaultResolveGlibcBin(): string | null {
+  return tryResolve("@anthropic-ai/claude-agent-sdk-linux-x64/claude");
+}
+
+function tryResolve(spec: string): string | null {
+  try {
+    // Anchor resolution at cwd so a globally-installed vp-dev still finds
+    // the SDK in the user's project node_modules. Mirrors how the SDK
+    // itself resolves its companion binaries at query() time.
+    const req = createRequire(`${process.cwd()}/`);
+    return req.resolve(spec);
+  } catch {
+    return null;
+  }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -72,6 +72,7 @@ import {
   type IncompleteBranchInfo,
 } from "./git/incompleteBranches.js";
 import { agentClaudeMdPath, forkClaudeMd } from "./agent/specialization.js";
+import { preflightSdkBinary } from "./agent/sdkBinary.js";
 import { promises as fs } from "node:fs";
 import { runIssueCore } from "./agent/runIssueCore.js";
 import {
@@ -958,6 +959,19 @@ async function cmdRun(opts: RunOpts): Promise<void> {
     process.stderr.write(
       "INFO: ANTHROPIC_API_KEY is not set; falling back to Claude Code OAuth credentials at ~/.claude/credentials.json.\n",
     );
+  }
+
+  // Issue #245: detect a libc/SDK-binary mismatch BEFORE the approval gate
+  // (and before runResume's dispatch path). On a glibc host without
+  // VP_DEV_CLAUDE_BIN set, the SDK picks the musl-linked binary and every
+  // dispatched agent crashes in <2s with the misleading "native binary not
+  // found" error; triage's post-mortem gate then refuses to re-dispatch the
+  // affected issues without --include-non-ready. Catching the mismatch once
+  // here trades a fast fail for N agent failures + a triage gate.
+  const sdkPreflight = preflightSdkBinary();
+  if (!sdkPreflight.ok) {
+    console.error(`ERROR: ${sdkPreflight.reason}\n\n${sdkPreflight.hint}`);
+    process.exit(2);
   }
 
   if (opts.resume) {


### PR DESCRIPTION
Closes #245.

## Summary

`vp-dev run` now runs a libc/SDK-binary preflight before consuming the approval gate (and before the `runResume` dispatch path). On a glibc Linux host with no `VP_DEV_CLAUDE_BIN` set, the Claude Agent SDK probes the musl-linked binary first — its ELF interpreter is hardcoded to `/lib/ld-musl-x86_64.so.1`, missing on glibc — every dispatched agent crashes in <2s with the misleading "Claude Code native binary not found" error, and triage's post-mortem gate then refuses to re-dispatch the affected issues without `--include-non-ready`. One detectable host condition cascading into N agent crashes + a triage gate is the failure mode catalogued in the local `CLAUDE.md` "Pre-dispatch SDK binary preflight" rule (run-2026-05-08T10-01-12-536Z burned $0 in API but generated 11 post-mortem comments and required a full re-plan).

## Changes

- **`src/agent/sdkBinary.ts`**: new `preflightSdkBinary({ ... })` next to `claudeBinPath()`. Detection is exec-free and walks five branches: env override set → ok; non-Linux → ok; musl SDK package not resolvable → ok; `/lib/ld-musl-x86_64.so.1` exists → ok (musl host, binary launches); otherwise → mismatch with a hint that names the resolved glibc binary path. Dependencies are fully injectable for test isolation.
- **`src/cli.ts`**: hook `preflightSdkBinary()` into `cmdRun` immediately after the `ANTHROPIC_API_KEY` notice so both fresh and `--resume` runs benefit. On mismatch, `console.error` the `reason + hint` block and `process.exit(2)` before any dispatch / triage / dedup / plan-mint work.
- **`src/agent/sdkBinary.test.ts`**: six unit tests covering all five detection branches plus the "glibc unresolved → generic hint" fallback. No real filesystem, platform, or `require.resolve` work touches the host — passes identically on macOS dev boxes, Linux CI, and Windows.

## Acceptance (per issue body)

- ✅ glibc host without `VP_DEV_CLAUDE_BIN` → `vp-dev run` exits non-zero before reaching the approval gate, with hint pointing at the glibc binary, the `mv …musl-disabled` workaround, and the future-#251 auto-fallback.
- ✅ glibc host with `VP_DEV_CLAUDE_BIN` set → preflight returns `{ ok: true }` and the run proceeds normally.
- ✅ macOS / Windows hosts → preflight short-circuits at the platform check; no-op.
- ✅ No agents are dispatched and no triage post-mortem entries are recorded when preflight fails (the `process.exit(2)` fires before triage opens its logger).

## Out of scope (per issue body)

Auto-fallback inside `claudeBinPath()` and a `postinstall` hook are deliberately deferred — the local `CLAUDE.md` rule already names #251 as the auto-fallback follow-up that obsoletes this preflight.

## Test plan

- [x] `npm run build` (clean).
- [x] `npm test` — 922/922 pass; six new sdkBinary tests cover env-override / non-Linux / musl-SDK-absent / musl-host / glibc-mismatch / glibc-unresolved branches.
- [ ] On a glibc host without `VP_DEV_CLAUDE_BIN` set: `node dist/bin/vp-dev.js run --plan ...` exits 2 with the hint text before any triage spend.
- [ ] On a glibc host with `VP_DEV_CLAUDE_BIN=…/linux-x64/claude` set: same `--plan` invocation reaches the gate normally.
- [ ] On macOS: preflight is silent; existing flows unchanged.

— Brahmagupta (agent-916a-trim-6000-s8026)
