### PR TITLE
fix(dispatch): two-path fallback for target-repo clone resolution

### DIFF
--- a/research/curve-redo-bundle/specialist-redo/dispatch-specialist-redo.sh
+++ b/research/curve-redo-bundle/specialist-redo/dispatch-specialist-redo.sh
@@ -123,18 +123,23 @@ while IFS=$'\t' read -r issueId agentId rationale score pickedLeg labels; do
 done <"$PICKS"
 
 # Resolve the clone path for a target repo. Mirrors `resolveTargetRepoPath` in
-# src/git/worktree.ts: defaults to $HOME/dev/<repo-name>. The whole loop runs
+# src/git/worktree.ts: defaults to $HOME/dev/<repo-name>, with a two-path
+# fallback to $HOME/dev/vaultpilot/<repo-name> (issue #254) so a grouped
+# layout works without an outer back-compat symlink. The whole loop runs
 # serially (one cell at a time), so a single shared clone per repo is safe —
 # `vp-dev spawn` manages its own worktrees inside the clone.
 clone_path_for_repo() {
   local repo="$1"
   local name="${repo##*/}"
-  local p; p="${HOME:-/home}/dev/$name"
-  if [[ ! -d "$p/.git" ]]; then
-    echo "ERROR: no clone at $p for repo $repo. Clone it (gh repo clone $repo) before dispatching." >&2
-    return 1
-  fi
-  echo "$p"
+  local candidate
+  for candidate in "${HOME:-/home}/dev/$name" "${HOME:-/home}/dev/vaultpilot/$name"; do
+    if [[ -d "$candidate/.git" ]]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  echo "ERROR: no clone at ${HOME:-/home}/dev/$name nor ${HOME:-/home}/dev/vaultpilot/$name for repo $repo. Clone it (gh repo clone $repo) before dispatching." >&2
+  return 1
 }
 
 # Group dispatch by agent so cells on the same clone serialize naturally.

--- a/research/curve-redo-bundle/specialist-redo/score-specialist-redo.sh
+++ b/research/curve-redo-bundle/specialist-redo/score-specialist-redo.sh
@@ -84,14 +84,24 @@ done < <(node -e '
 # Resolve a fresh clone at the issue's baseSha (or origin/main for open
 # issues). Clones are reused per-issue across cells. testRunner copies the
 # diff in and resets between cells, so a single clone per issue is safe.
-# Source defaults to the conventional clone at $HOME/dev/<repo-name>.
+# Source defaults to the conventional clone at $HOME/dev/<repo-name>, with
+# a two-path fallback to $HOME/dev/vaultpilot/<repo-name> (issue #254) so a
+# grouped layout works without an outer back-compat symlink. Falls through
+# to a fresh `gh repo clone` if neither candidate exists.
 ensure_score_clone() {
   local issueId="$1" repo="$2" sha="$3"
   local name="${repo##*/}"
   local cdir="$SCORE_CLONES_DIR/${name}-${issueId}"
   if [[ ! -d "$cdir/.git" ]]; then
-    local src="${HOME:-/home}/dev/$name"
-    if [[ -d "$src/.git" ]]; then
+    local src=""
+    local candidate
+    for candidate in "${HOME:-/home}/dev/$name" "${HOME:-/home}/dev/vaultpilot/$name"; do
+      if [[ -d "$candidate/.git" ]]; then
+        src="$candidate"
+        break
+      fi
+    done
+    if [[ -n "$src" ]]; then
       git clone --quiet "$src" "$cdir" >&2
     else
       gh repo clone "$repo" "$cdir" -- --quiet >&2

--- a/src/git/worktree.test.ts
+++ b/src/git/worktree.test.ts
@@ -5,7 +5,11 @@ import os from "node:os";
 import path from "node:path";
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
-import { buildIncompleteBranchName, ensureOriginRemote } from "./worktree.js";
+import {
+  buildIncompleteBranchName,
+  ensureOriginRemote,
+  resolveTargetRepoPath,
+} from "./worktree.js";
 
 const execFile = promisify(execFileCb);
 
@@ -124,4 +128,100 @@ test("ensureOriginRemote: idempotent — calling twice without intervening strip
   } finally {
     await cleanup();
   }
+});
+
+// ---------------------------------------------------------------------------
+// resolveTargetRepoPath — issue #254 two-path fallback.
+//
+// Convention: $HOME/dev/<repo-name>. Fallback: $HOME/dev/vaultpilot/<repo-name>
+// (the grouped layout used by this repo's operator after the
+// vaultpilot-dev-framework rename, when the outer back-compat symlink may
+// be missing). Tests run with a tmpdir HOME so they don't depend on the
+// caller's actual layout.
+// ---------------------------------------------------------------------------
+
+async function withTmpHome<T>(
+  fn: (homeDir: string) => Promise<T>,
+): Promise<T> {
+  const homeDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "vp-resolve-target-"),
+  );
+  const prevHome = process.env.HOME;
+  process.env.HOME = homeDir;
+  try {
+    return await fn(homeDir);
+  } finally {
+    if (prevHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    await fs.rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+async function makeFakeClone(parent: string, name: string): Promise<string> {
+  const repoDir = path.join(parent, name);
+  await fs.mkdir(path.join(repoDir, ".git"), { recursive: true });
+  return repoDir;
+}
+
+test("resolveTargetRepoPath: prefers conventional $HOME/dev/<name> when present", async () => {
+  await withTmpHome(async (home) => {
+    const expected = await makeFakeClone(path.join(home, "dev"), "demo-repo");
+    // Also make the grouped fallback exist — flat must still win.
+    await makeFakeClone(path.join(home, "dev", "vaultpilot"), "demo-repo");
+    const got = await resolveTargetRepoPath("octo/demo-repo");
+    assert.equal(got, expected);
+  });
+});
+
+test("resolveTargetRepoPath: falls back to $HOME/dev/vaultpilot/<name> when flat path is missing", async () => {
+  await withTmpHome(async (home) => {
+    const expected = await makeFakeClone(
+      path.join(home, "dev", "vaultpilot"),
+      "vaultpilot-dev-framework",
+    );
+    const got = await resolveTargetRepoPath(
+      "szhygulin/vaultpilot-dev-framework",
+    );
+    assert.equal(got, expected);
+  });
+});
+
+test("resolveTargetRepoPath: throws ENOENT naming both candidates when neither exists", async () => {
+  await withTmpHome(async (home) => {
+    await assert.rejects(
+      () => resolveTargetRepoPath("octo/missing-repo"),
+      (err: NodeJS.ErrnoException) => {
+        assert.equal(err.code, "ENOENT");
+        assert.match(err.message, /missing-repo/);
+        assert.match(err.message, /dev\/missing-repo/);
+        assert.match(err.message, /dev\/vaultpilot\/missing-repo/);
+        // Sanity: home is what we expect (tmp).
+        assert.match(err.message, new RegExp(home.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+        return true;
+      },
+    );
+  });
+});
+
+test("resolveTargetRepoPath: explicit path wins regardless of convention layout", async () => {
+  await withTmpHome(async (home) => {
+    // Conventional path also exists — explicit must still win.
+    await makeFakeClone(path.join(home, "dev"), "explicit-repo");
+    const customParent = await fs.mkdtemp(
+      path.join(os.tmpdir(), "vp-explicit-"),
+    );
+    try {
+      const explicit = await makeFakeClone(customParent, "explicit-repo");
+      const got = await resolveTargetRepoPath(
+        "octo/explicit-repo",
+        explicit,
+      );
+      assert.equal(got, explicit);
+    } finally {
+      await fs.rm(customParent, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -75,9 +75,37 @@ export async function resolveTargetRepoPath(
   }
   const name = targetRepo.split("/").pop() ?? targetRepo;
   const home = process.env.HOME ?? "/home";
-  const conventional = path.resolve(home, "dev", name);
-  await fs.access(conventional);
-  return conventional;
+  // Two-path fallback (issue #254): the documented convention is
+  // `$HOME/dev/<repo-name>`, but this repo (and any operator using a
+  // grouped `$HOME/dev/<group>/<repo-name>` layout with back-compat
+  // symlinks) may have only the grouped path on disk. After the
+  // 2026-05-08 vaultpilot-development-agents → vaultpilot-dev-framework
+  // rename, the outer convention symlink for the new name was missing,
+  // so dispatch failed at ENOENT until the operator created it manually.
+  // Try the flat path first (preserves the documented default for
+  // external clones following the simpler convention) then fall back
+  // to the grouped path; the first that exists wins.
+  const candidates = [
+    path.resolve(home, "dev", name),
+    path.resolve(home, "dev", "vaultpilot", name),
+  ];
+  for (const candidate of candidates) {
+    try {
+      await fs.access(candidate);
+      return candidate;
+    } catch {
+      // try next candidate
+    }
+  }
+  // Surface the same ENOENT shape callers have always handled, but with
+  // both probed paths in the message so the fix is obvious.
+  const err = new Error(
+    `ENOENT: no clone for ${targetRepo} at ${candidates.join(" nor ")}. ` +
+      `Clone it (gh repo clone ${targetRepo}) before dispatching, or pass ` +
+      `--target-repo-path explicitly.`,
+  ) as NodeJS.ErrnoException;
+  err.code = "ENOENT";
+  throw err;
 }
 
 /**


### PR DESCRIPTION
Closes #254.

## Summary

`resolveTargetRepoPath` and the bash mirrors in `research/curve-redo-bundle/specialist-redo/{dispatch,score}-specialist-redo.sh` now probe **both** `$HOME/dev/<repo-name>` and `$HOME/dev/vaultpilot/<repo-name>` before failing. The flat path stays primary so external clones following the documented default still resolve; the grouped path is the fallback for operators using a `$HOME/dev/<group>/<repo-name>` layout, where an outer back-compat symlink may be absent.

This unblocks dispatch on the operator's actual layout after the 2026-05-08 `vaultpilot-development-agents → vaultpilot-dev-framework` rename, where the new outer symlink at `$HOME/dev/vaultpilot-dev-framework` was never created and `clone_path_for_repo` returned ENOENT.

## Files

- `src/git/worktree.ts` — `resolveTargetRepoPath` walks `[flat, grouped]` candidates; throws a single `ENOENT` naming both probed paths if neither exists. The `explicit` argument continues to short-circuit before any candidate probing.
- `research/curve-redo-bundle/specialist-redo/dispatch-specialist-redo.sh` — `clone_path_for_repo` walks both candidates with the same primary/fallback ordering.
- `research/curve-redo-bundle/specialist-redo/score-specialist-redo.sh` — `ensure_score_clone` walks both candidates; falls through to `gh repo clone` if neither exists (preserved behavior).
- `src/git/worktree.test.ts` — four new tests exercising every resolver branch (flat-wins-when-both-present, grouped-fallback, ENOENT-naming-both-paths, explicit-overrides-everything).

## Scope note

The issue body cites "similar shaped resolvers in `src/research/specialistBench/dispatch.ts`, `src/research/curveStudy/dispatch.ts`" but those files don't actually contain HOME-based resolution — they consume `clonePath` as input. The single TS resolver lives in `src/git/worktree.ts:resolveTargetRepoPath`, used by every CLI command (`run`, `spawn`, `failure-postmortem-poll`, `research curve-study`, `research specialist-bench`, etc.) via the orchestrator and CLI. Fixing it there propagates the fallback transparently to all TS callers, including the curve-study and specialist-bench dispatchers the issue body called out. The two `.sh` files needed direct edits because they re-implement the resolver in bash.

## Lower-priority companion (not addressed here)

The issue suggests a one-liner to add to a setup-readme creating the outer back-compat symlink. With this PR's two-path fallback in place, that step becomes optional — operators can still create the symlink for muscle-memory `cd $HOME/dev/<name>` ergonomics, but dispatch no longer requires it.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm run build` — clean.
- [x] `npm test` — 920 tests pass (was 916; +4 new resolver tests).
- [x] `node --test dist/src/git/worktree.test.js` — 8/8 pass (4 existing branch-name tests + 4 new resolver tests).

— Euler (agent-916a-trim-6000-s2008032)
