### PR TITLE
feat(post-mortem): suppress fanout when failure mode is uniform-harness

### DIFF
--- a/src/orchestrator/failurePostMortem.test.ts
+++ b/src/orchestrator/failurePostMortem.test.ts
@@ -3,7 +3,9 @@ import assert from "node:assert/strict";
 import {
   composeFailurePostMortem,
   detectPendingPostMortem,
+  detectUniformHarnessFailure,
   POST_MORTEM_SENTINEL,
+  type PendingPostMortem,
 } from "./failurePostMortem.js";
 import type { IssueComment } from "../github/gh.js";
 
@@ -187,4 +189,111 @@ test("detectPendingPostMortem: an ambient unrelated comment does NOT lift the ga
     comment("yeah this is annoying, will look later", "2026-05-05T11:00:00Z", "alice"),
   ]);
   assert.equal(result.pending, true);
+});
+
+// ---- detectUniformHarnessFailure (issue #250) ---------------------------
+
+function pending(
+  issueId: number,
+  input: Partial<PendingPostMortem["input"]> & { errorSubtype?: string } = {},
+): PendingPostMortem {
+  return {
+    issueId,
+    input: {
+      runId: "run-2026-05-08T10-01-12-536Z",
+      agentId: `agent-${issueId.toString(16).padStart(4, "0")}`,
+      errorSubtype: input.errorSubtype,
+      errorReason: input.errorReason,
+      costUsd: input.costUsd ?? 0,
+      durationMs: input.durationMs ?? 5_000,
+      partialBranchUrl: input.partialBranchUrl,
+    },
+  };
+}
+
+test("detectUniformHarnessFailure: empty queue → not suppressed", () => {
+  const v = detectUniformHarnessFailure([]);
+  assert.equal(v.suppress, false);
+  assert.equal(v.count, 0);
+});
+
+test("detectUniformHarnessFailure: single failure → not suppressed (no fanout exists)", () => {
+  // The whole point of the suppression is to silence N near-identical
+  // comments across N issues. With one issue there's no fanout — the
+  // operator wants the per-issue gate even for a $0/short-duration crash.
+  const v = detectUniformHarnessFailure([
+    pending(101, { errorSubtype: "error_during_execution" }),
+  ]);
+  assert.equal(v.suppress, false);
+  assert.equal(v.count, 1);
+});
+
+test("detectUniformHarnessFailure: uniform harness pattern (SDK init crash) → suppressed", () => {
+  // Mirrors run-2026-05-08T10-01-12-536Z: 11 SDK-init failures, $0 cost,
+  // sub-30s durations, all sharing the same errorSubtype. The whole
+  // fanout collapses into one run-level diagnostic.
+  const v = detectUniformHarnessFailure([
+    pending(101, { errorSubtype: "error_during_execution", costUsd: 0, durationMs: 8_000 }),
+    pending(102, { errorSubtype: "error_during_execution", costUsd: 0, durationMs: 7_500 }),
+    pending(103, { errorSubtype: "error_during_execution", costUsd: 0, durationMs: 9_200 }),
+  ]);
+  assert.equal(v.suppress, true);
+  assert.equal(v.count, 3);
+  assert.equal(v.sharedSubtype, "error_during_execution");
+  assert.ok(v.reason && /3 dispatched issues/.test(v.reason));
+  assert.ok(v.reason && /error_during_execution/.test(v.reason));
+});
+
+test("detectUniformHarnessFailure: mixed errorSubtypes → not suppressed (issue-side, distinct causes)", () => {
+  // Two separate failures with separate root causes → operators want
+  // both per-issue post-mortems so triage flags each correctly.
+  const v = detectUniformHarnessFailure([
+    pending(201, { errorSubtype: "error_during_execution", costUsd: 0, durationMs: 5_000 }),
+    pending(202, { errorSubtype: "error_max_turns", costUsd: 0, durationMs: 5_000 }),
+  ]);
+  assert.equal(v.suppress, false);
+});
+
+test("detectUniformHarnessFailure: any pending exceeds cost threshold → not suppressed", () => {
+  // One agent reached issue context (cost > threshold) — that's
+  // issue-side work that crashed late, the per-issue gate IS the right
+  // surface even if the other agents died at SDK-init.
+  const v = detectUniformHarnessFailure([
+    pending(301, { errorSubtype: "error_during_execution", costUsd: 0, durationMs: 5_000 }),
+    pending(302, { errorSubtype: "error_during_execution", costUsd: 0.5, durationMs: 5_000 }),
+  ]);
+  assert.equal(v.suppress, false);
+});
+
+test("detectUniformHarnessFailure: any pending exceeds duration threshold → not suppressed", () => {
+  // An agent that ran for 60s likely reached issue context even with
+  // cost not reported — keep the per-issue gate.
+  const v = detectUniformHarnessFailure([
+    pending(401, { errorSubtype: "error_during_execution", costUsd: 0, durationMs: 5_000 }),
+    pending(402, { errorSubtype: "error_during_execution", costUsd: 0, durationMs: 60_000 }),
+  ]);
+  assert.equal(v.suppress, false);
+});
+
+test("detectUniformHarnessFailure: missing errorSubtype on first pending → not suppressed", () => {
+  // No machine-readable cause to share — fall back to per-issue posts so
+  // a human reading each comment can read the free-form reason.
+  const v = detectUniformHarnessFailure([
+    pending(501, { errorReason: "no envelope emitted", costUsd: 0, durationMs: 5_000 }),
+    pending(502, { errorReason: "no envelope emitted", costUsd: 0, durationMs: 5_000 }),
+  ]);
+  assert.equal(v.suppress, false);
+});
+
+test("detectUniformHarnessFailure: error_max_turns on a long-running agent → not suppressed", () => {
+  // Classic issue-side failure: agent burned cost and turns reading the
+  // issue + editing files, then ran out. Per-issue post-mortem IS the
+  // value-add here (Pre-dispatch scope-fit check, salvage with
+  // --resume-incomplete, etc.). Two such failures don't make them
+  // harness-shaped.
+  const v = detectUniformHarnessFailure([
+    pending(601, { errorSubtype: "error_max_turns", costUsd: 4.51, durationMs: 7 * 60_000 }),
+    pending(602, { errorSubtype: "error_max_turns", costUsd: 3.20, durationMs: 6 * 60_000 }),
+  ]);
+  assert.equal(v.suppress, false);
 });

--- a/src/orchestrator/failurePostMortem.ts
+++ b/src/orchestrator/failurePostMortem.ts
@@ -184,3 +184,95 @@ function extractRunId(body: string): string | undefined {
   const m = /\(\s*(run-[^,)\s]+)/i.exec(body);
   return m ? m[1] : undefined;
 }
+
+// ---- Uniform-harness-failure suppression (issue #250) -------------------
+
+/**
+ * A post-mortem queued during the run, deferred until the run finishes so
+ * the orchestrator can decide whether to fan out (post N comments) or
+ * suppress (uniform-harness pattern; see `detectUniformHarnessFailure`).
+ */
+export interface PendingPostMortem {
+  /** GitHub issue number. */
+  issueId: number;
+  /** Inputs forwarded to `composeFailurePostMortem` at flush time. */
+  input: FailurePostMortemInput;
+}
+
+/**
+ * Cost threshold (USD) below which an agent run is treated as NOT having
+ * reached the issue-content read step. SDK-init failures cost $0; a single
+ * tool call typically costs ~$0.005–$0.01. Conservative: an agent that
+ * read the issue body and emitted even one tool call clears this.
+ */
+export const UNIFORM_HARNESS_COST_USD_THRESHOLD = 0.01;
+
+/**
+ * Duration threshold (ms) below which a non-clean exit is treated as
+ * "did not reach issue context". SDK-init failures land in <10s; genuine
+ * issue work takes 60–180s+. 30s is conservative on both sides.
+ */
+export const UNIFORM_HARNESS_DURATION_MS_THRESHOLD = 30_000;
+
+export interface UniformHarnessVerdict {
+  /** True when the post-mortem fanout should be suppressed. */
+  suppress: boolean;
+  /** Operator-facing reason; populated when suppress=true. */
+  reason?: string;
+  /** Shared error subtype across all dispatched issues; populated when suppress=true. */
+  sharedSubtype?: string;
+  /** Number of pending post-mortems considered. */
+  count: number;
+}
+
+/**
+ * Detect the uniform-harness-failure pattern (issue #250).
+ *
+ * Returns `suppress: true` when ALL of:
+ *   1. ≥2 dispatched issues failed (no fanout to suppress when count<2).
+ *   2. All share the same `errorSubtype` at the SDK / orchestrator boundary.
+ *   3. No agent reached issue-content read — proxy: per-pending
+ *      `costUsd < UNIFORM_HARNESS_COST_USD_THRESHOLD` AND
+ *      `durationMs < UNIFORM_HARNESS_DURATION_MS_THRESHOLD`.
+ *
+ * When the verdict is `suppress: true`, the orchestrator skips the
+ * per-issue post-mortem comment fanout and logs a single
+ * `orchestrator.post_mortem_fanout_suppressed` event so the run-state JSON
+ * surfaces the harness-side cause without flooding N issues with
+ * environmental-hiccup comments.
+ *
+ * Issue-side failure shapes (mixed subtypes, `error_max_turns` after the
+ * agent burned real cost reading + editing, partial completes) all return
+ * `suppress: false` — those genuinely benefit from the per-issue gate.
+ */
+export function detectUniformHarnessFailure(
+  pendings: ReadonlyArray<PendingPostMortem>,
+): UniformHarnessVerdict {
+  const count = pendings.length;
+  if (count < 2) return { suppress: false, count };
+
+  const sharedSubtype = pendings[0].input.errorSubtype;
+  if (!sharedSubtype) return { suppress: false, count };
+
+  const allSameSubtype = pendings.every(
+    (p) => p.input.errorSubtype === sharedSubtype,
+  );
+  if (!allSameSubtype) return { suppress: false, count };
+
+  const allUnreached = pendings.every((p) => {
+    const cost = p.input.costUsd ?? 0;
+    const dur = p.input.durationMs ?? 0;
+    return (
+      cost < UNIFORM_HARNESS_COST_USD_THRESHOLD &&
+      dur < UNIFORM_HARNESS_DURATION_MS_THRESHOLD
+    );
+  });
+  if (!allUnreached) return { suppress: false, count };
+
+  return {
+    suppress: true,
+    sharedSubtype,
+    count,
+    reason: `all ${count} dispatched issues failed at the SDK/orchestrator boundary with shared subtype \`${sharedSubtype}\` before reaching issue context — harness-side cause, see run-state JSON`,
+  };
+}

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -14,7 +14,11 @@ import {
   resolveTargetRepoPath,
 } from "../git/worktree.js";
 import { postIssueComment } from "../github/gh.js";
-import { composeFailurePostMortem } from "./failurePostMortem.js";
+import {
+  composeFailurePostMortem,
+  detectUniformHarnessFailure,
+  type PendingPostMortem,
+} from "./failurePostMortem.js";
 import type { Logger } from "../log/logger.js";
 import type {
   AgentRecord,
@@ -91,6 +95,14 @@ export async function runOrchestrator(input: OrchestratorInput): Promise<void> {
   const issuesById = new Map(input.issues.map((i) => [i.id, i]));
 
   const inFlight = new Map<string, Promise<void>>();
+
+  // Issue #250: post-mortem comments are deferred until the run completes
+  // so we can detect the uniform-harness-failure pattern (every dispatched
+  // agent dying at the same SDK/orchestrator-boundary step before reaching
+  // issue content) and suppress the fanout. Issue-side failures (mixed
+  // subtypes, `error_max_turns` after real work, etc.) still get per-issue
+  // comments via `flushPendingPostMortems` below.
+  const pendingPostMortems: PendingPostMortem[] = [];
 
   // Persist the running USD total into RunState before each save so
   // `vp-dev status` (issue #131) can render the live cost-burn signal
@@ -172,6 +184,7 @@ export async function runOrchestrator(input: OrchestratorInput): Promise<void> {
           budgetUsd: input.budgetUsd,
           resumeContext: input.resumeContextByIssue?.get(issue.id),
           autoPhaseFollowup: input.autoPhaseFollowup,
+          pendingPostMortems,
         }).catch(async (err) => {
           input.logger.error("agent.uncaught", {
             agentId: agent.agentId,
@@ -228,6 +241,75 @@ export async function runOrchestrator(input: OrchestratorInput): Promise<void> {
   await Promise.allSettled(inFlight.values());
   persistCost();
   await saveRunState(input.state);
+
+  // Issue #250: post-mortem fanout decision made AFTER every dispatched
+  // issue has settled. Run in dry-run mode is a no-op (matches the
+  // pre-#250 inline-post behavior — gh calls are intercepted in dry-run).
+  if (!input.dryRun) {
+    await flushPendingPostMortems({
+      pendings: pendingPostMortems,
+      targetRepo: input.state.targetRepo,
+      runId: input.state.runId,
+      logger: input.logger,
+    });
+  }
+}
+
+/**
+ * Issue #250: drain the deferred post-mortem queue at end-of-run.
+ *
+ * If `detectUniformHarnessFailure` returns `suppress: true` (every
+ * dispatched issue failed with the same SDK/orchestrator-boundary cause
+ * before reaching issue content), log a single
+ * `orchestrator.post_mortem_fanout_suppressed` event and skip every
+ * per-issue comment — operators read the run-state JSON / `vp-dev status`
+ * block to diagnose harness-side causes, not N near-identical comments
+ * fanned out across N unrelated issues.
+ *
+ * Otherwise post each pending comment in queue order. Individual post
+ * failures log `orchestrator.post_mortem_failed` and never abort the
+ * flush — matches the pre-#250 best-effort inline post.
+ */
+async function flushPendingPostMortems(opts: {
+  pendings: ReadonlyArray<PendingPostMortem>;
+  targetRepo: string;
+  runId: string;
+  logger: Logger;
+}): Promise<void> {
+  if (opts.pendings.length === 0) return;
+  const verdict = detectUniformHarnessFailure(opts.pendings);
+  if (verdict.suppress) {
+    opts.logger.warn("orchestrator.post_mortem_fanout_suppressed", {
+      runId: opts.runId,
+      count: verdict.count,
+      sharedSubtype: verdict.sharedSubtype,
+      reason: verdict.reason,
+      issueIds: opts.pendings.map((p) => p.issueId),
+    });
+    process.stderr.write(
+      `Skipped post-mortem fanout: ${verdict.count} issues failed with shared subtype \`${verdict.sharedSubtype}\` ` +
+        `before reaching issue context — see logs/${opts.runId}.jsonl for the harness-side cause.\n`,
+    );
+    return;
+  }
+  for (const p of opts.pendings) {
+    const body = composeFailurePostMortem(p.input);
+    try {
+      await postIssueComment(opts.targetRepo, p.issueId, body);
+      opts.logger.info("orchestrator.post_mortem_posted", {
+        agentId: p.input.agentId,
+        issueId: p.issueId,
+        runId: opts.runId,
+      });
+    } catch (err) {
+      opts.logger.warn("orchestrator.post_mortem_failed", {
+        agentId: p.input.agentId,
+        issueId: p.issueId,
+        runId: opts.runId,
+        err: (err as Error).message,
+      });
+    }
+  }
 }
 
 export interface PickAgentsInput {
@@ -531,6 +613,12 @@ async function runOneIssue(opts: {
   budgetUsd?: number;
   resumeContext?: ResumeContext;
   autoPhaseFollowup?: boolean;
+  /**
+   * Issue #250: per-run accumulator of post-mortem inputs. The orchestrator
+   * decides at end-of-run whether to fan out (post N comments) or suppress
+   * (uniform-harness pattern). `runOneIssue` only pushes; never reads.
+   */
+  pendingPostMortems: PendingPostMortem[];
 }): Promise<void> {
   const result = await runIssueCore({
     agent: opts.agent,
@@ -593,36 +681,29 @@ async function runOneIssue(opts: {
   if (stateAgent) stateAgent.status = "idle";
   await saveRunState(opts.state);
 
-  // Issue #100: post a fail-fast post-mortem comment on the GitHub issue
-  // after a non-clean exit. The triage gate on the next `vp-dev run` reads
-  // this comment and skips re-dispatch until a human resolves the blocker
-  // (or `--include-non-ready` overrides). Skipped in dry-run because gh
-  // calls in dry-run runs are intercepted into echoes; failing to post
-  // logs a warning but never aborts the run.
-  if (nonCleanExit && !opts.dryRun) {
-    const body = composeFailurePostMortem({
-      runId: opts.state.runId,
-      agentId: opts.agent.agentId,
-      errorSubtype: result.errorSubtype,
-      errorReason: result.errorReason,
-      costUsd: result.costUsd,
-      durationMs: result.durationMs,
-      partialBranchUrl: result.partialBranchUrl,
+  // Issue #100: a fail-fast post-mortem comment is queued on every
+  // non-clean exit so the triage gate on the next `vp-dev run` skips
+  // re-dispatch until a human resolves the blocker (or
+  // `--include-non-ready` overrides).
+  //
+  // Issue #250: the queue is drained at end-of-run by
+  // `flushPendingPostMortems`. If every dispatched issue failed at the
+  // same SDK/orchestrator-boundary step before reaching issue content
+  // (uniform-harness pattern), the entire fanout is suppressed and the
+  // operator reads the run-state JSON / `vp-dev status` block instead of
+  // having N issues spammed with environmental-hiccup comments.
+  if (nonCleanExit) {
+    opts.pendingPostMortems.push({
+      issueId: opts.issue.id,
+      input: {
+        runId: opts.state.runId,
+        agentId: opts.agent.agentId,
+        errorSubtype: result.errorSubtype,
+        errorReason: result.errorReason,
+        costUsd: result.costUsd,
+        durationMs: result.durationMs,
+        partialBranchUrl: result.partialBranchUrl,
+      },
     });
-    try {
-      await postIssueComment(opts.state.targetRepo, opts.issue.id, body);
-      opts.logger.info("orchestrator.post_mortem_posted", {
-        agentId: opts.agent.agentId,
-        issueId: opts.issue.id,
-        runId: opts.state.runId,
-      });
-    } catch (err) {
-      opts.logger.warn("orchestrator.post_mortem_failed", {
-        agentId: opts.agent.agentId,
-        issueId: opts.issue.id,
-        runId: opts.state.runId,
-        err: (err as Error).message,
-      });
-    }
   }
 }


### PR DESCRIPTION
Closes #250.

## Summary

When every dispatched issue in a `vp-dev run` fails at the same SDK / orchestrator boundary step before reaching issue content (uniform-harness pattern — e.g. SDK selecting the wrong libc artifact in `run-2026-05-08T10-01-12-536Z`, all 11 agents dying at SDK-init with `$0` API cost), the prior behavior posted 11 near-identical `## vp-dev failure post-mortem` comments across 11 unrelated issues. The operator then either spammed 11 resolution keywords or used `--include-non-ready` to silently bypass triage. Both outcomes leave permanent comment noise on each issue about an environmental hiccup that had nothing to do with the issue itself.

## Approach

- **Defer per-issue post-mortems to end-of-run.** `runOneIssue` now pushes failure inputs onto a `pendingPostMortems: PendingPostMortem[]` accumulator instead of calling `postIssueComment` inline.
- **Decide at flush.** After `Promise.allSettled(inFlight)` drains, `runOrchestrator` calls a new `flushPendingPostMortems()` helper. The helper runs `detectUniformHarnessFailure(pendings)` first; if `suppress: true`, it logs a single `orchestrator.post_mortem_fanout_suppressed` event + writes a stderr notice pointing the operator at `logs/<runId>.jsonl`, and skips every per-issue post. Otherwise it posts each pending in queue order with the same best-effort error handling as the pre-`#250` inline path.
- **Suppression predicate** (in `failurePostMortem.ts`) returns `suppress: true` when ALL of:
  1. ≥2 pending failures (no fanout to suppress when count<2).
  2. All share the same `errorSubtype` at the SDK / orchestrator boundary.
  3. No agent reached issue context — proxy: per-pending `costUsd < $0.01` AND `durationMs < 30s`. SDK-init failures cost $0 and finish in <10s; even one tool call from a real run clears both thresholds.

The triage gate's resolution-keyword path (`detectPendingPostMortem`) is unchanged — when the suppression predicate doesn't fire (issue-side failures: mixed subtypes, `error_max_turns` after real cost burned, etc.), per-issue post-mortems still post and still gate re-dispatch. The behavior change is narrowly scoped to the harness-uniform shape.

## Files

- `src/orchestrator/failurePostMortem.ts` — `PendingPostMortem`, `detectUniformHarnessFailure`, `UNIFORM_HARNESS_COST_USD_THRESHOLD = 0.01`, `UNIFORM_HARNESS_DURATION_MS_THRESHOLD = 30_000`.
- `src/orchestrator/orchestrator.ts` — defer queue + `flushPendingPostMortems` helper; `runOneIssue` now pushes instead of posting.
- `src/orchestrator/failurePostMortem.test.ts` — 8 new unit tests for the predicate.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` — 924 / 924 pass (8 new `detectUniformHarnessFailure` tests cover empty queue, single failure, canonical uniform pattern, mixed subtypes, cost-threshold breach, duration-threshold breach, missing subtype on first pending, and long-running `error_max_turns` issue-side failure).

— Copernicus (agent-916a-trim-6000-s1008029)
