### PR TITLE
feat(spawn): add --no-registry-mutation / --research-mode flag (#248)

### DIFF
--- a/src/agent/runIssueCore.ts
+++ b/src/agent/runIssueCore.ts
@@ -44,6 +44,22 @@ export interface RunIssueCoreInput {
   dryRun: boolean;
   logger: Logger;
   skipSummary?: boolean;
+  /**
+   * Issue #248: when `true`, suppress ALL registry side effects of the run —
+   * the per-agent counter bumps (`issuesHandled`, `implementCount`,
+   * `pushbackCount`, `errorCount`), `lastActiveAt` refresh, and
+   * `applyTagUpdate(...)` of the envelope's `addTags` / `removeTags`.
+   *
+   * Implies `skipSummary` (no CLAUDE.md append, no utility-scoring record):
+   * any persistent state the orchestrator would write on behalf of the
+   * specialist is gated off so research dispatchers (`vp-dev research
+   * bench-specialists`, curve-redo cells) can fan out across many
+   * specialists without snapshotting / restoring the registry around the
+   * run.
+   *
+   * Off by default — the production path keeps tracking who handled what.
+   */
+  noRegistryMutation?: boolean;
   inspectPaths?: string[];
   /**
    * Per-run cost accumulator threaded down from `cmdRun()`. Phase 1 of
@@ -247,6 +263,13 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
     let appendOutcome: AppendOutcome | undefined;
     let summarySkipReason: string | undefined;
 
+    // Issue #248: research/calibration dispatchers pass `noRegistryMutation`
+    // to suppress every persistent side effect of the run. Treat it as a
+    // strict superset of `skipSummary` for downstream gating — the
+    // summarizer + CLAUDE.md append + utility-scoring writes already match
+    // the "no persistent state on the specialist" intent.
+    const skipSummary = !!input.skipSummary || !!input.noRegistryMutation;
+
     // #86 Phase 2: when the per-run cost ceiling has already been crossed
     // by the time this in-flight issue finished, skip the summarizer.
     // Rationale: the orchestrator is about to mark the run aborted, and
@@ -258,7 +281,7 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
     const budgetExceededAtCompletion =
       input.budgetUsd !== undefined &&
       input.costTracker?.exceedsBudget(input.budgetUsd) === true;
-    if (budgetExceededAtCompletion && !input.skipSummary) {
+    if (budgetExceededAtCompletion && !skipSummary) {
       summarySkipReason =
         "budget exceeded mid-run; summarizer skipped to avoid memory poisoning";
       input.logger.info("specialization.skipped", {
@@ -269,14 +292,22 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
     }
 
     if (envelope) {
-      input.agent.issuesHandled += 1;
-      if (envelope.decision === "implement") input.agent.implementCount += 1;
-      else if (envelope.decision === "pushback") input.agent.pushbackCount += 1;
-      else input.agent.errorCount += 1;
+      // Issue #248: gate the per-agent counter bumps + `applyTagUpdate` on
+      // `noRegistryMutation`. Production callers leave the flag undefined
+      // and the registry tracks decisions as before; research dispatchers
+      // pass the flag and the in-memory `AgentRecord` stays at the values
+      // it was loaded with (the persist-side `mutateRegistry` call below
+      // is similarly gated so nothing reaches `state/agents-registry.json`).
+      if (!input.noRegistryMutation) {
+        input.agent.issuesHandled += 1;
+        if (envelope.decision === "implement") input.agent.implementCount += 1;
+        else if (envelope.decision === "pushback") input.agent.pushbackCount += 1;
+        else input.agent.errorCount += 1;
 
-      applyTagUpdate(input.agent, envelope);
+        applyTagUpdate(input.agent, envelope);
+      }
 
-      if (!input.skipSummary && !budgetExceededAtCompletion) {
+      if (!skipSummary && !budgetExceededAtCompletion) {
         // Read current CLAUDE.md size for the marginal-cost transparency line
         // injected into the summarizer prompt (#179 Phase 1, option F). Surfaces
         // the empirical accuracy-degradation cost so the LLM can choose to skip
@@ -384,13 +415,19 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
         }
       }
     } else {
-      input.agent.errorCount += 1;
+      // Issue #248: same registry-mutation gate as the envelope branch
+      // above. A no-envelope run still bumps `errorCount` in production,
+      // but research dispatchers want the in-memory `AgentRecord`
+      // untouched.
+      if (!input.noRegistryMutation) {
+        input.agent.errorCount += 1;
+      }
 
       // No envelope — the SDK or the agent crashed before emitting one. Fire
       // the failure summarizer unless the cause is an infra flake (transport
       // error, GitHub 5xx, worktree creation fail) where there's no lesson,
       // or the run is being torn down for budget reasons (#86).
-      if (!input.skipSummary && !budgetExceededAtCompletion) {
+      if (!skipSummary && !budgetExceededAtCompletion) {
         if (isInfraFlake(result.errorReason)) {
           summarySkipReason = `infra flake skipped: ${result.errorReason}`;
           input.logger.info("specialization.skipped", {
@@ -450,7 +487,7 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
     // whose heading + tags overlap the agent's pushback reasoning. Runs
     // regardless of whether maybeAppendSummary appended — the signal is
     // about which prior rule the agent applied, not the new lesson.
-    if (envelope?.decision === "pushback" && !input.skipSummary) {
+    if (envelope?.decision === "pushback" && !skipSummary) {
       await recordUtilityForPushback({
         agentId: input.agent.agentId,
         runId: input.runId,
@@ -462,17 +499,25 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
       });
     }
 
-    await mutateRegistry((reg) => {
-      const persisted = ensureAgent(reg, input.agent.agentId);
-      Object.assign(persisted, {
-        tags: input.agent.tags,
-        issuesHandled: input.agent.issuesHandled,
-        implementCount: input.agent.implementCount,
-        pushbackCount: input.agent.pushbackCount,
-        errorCount: input.agent.errorCount,
-        lastActiveAt: new Date().toISOString(),
+    // Issue #248: research/calibration dispatchers pass `noRegistryMutation`
+    // so the persisted registry — `state/agents-registry.json` — stays
+    // exactly as the run started. Skipping `mutateRegistry` here is the
+    // step that closes the loop with the in-memory `AgentRecord` gate
+    // above; without it the on-disk registry would still pick up
+    // `lastActiveAt` from `new Date().toISOString()`.
+    if (!input.noRegistryMutation) {
+      await mutateRegistry((reg) => {
+        const persisted = ensureAgent(reg, input.agent.agentId);
+        Object.assign(persisted, {
+          tags: input.agent.tags,
+          issuesHandled: input.agent.issuesHandled,
+          implementCount: input.agent.implementCount,
+          pushbackCount: input.agent.pushbackCount,
+          errorCount: input.agent.errorCount,
+          lastActiveAt: new Date().toISOString(),
+        });
       });
-    });
+    }
 
     // Orchestrator-level safety net: when the run ended in a non-clean
     // exit (per `shouldPushPartial`) AND the agent did not finish with a

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -277,6 +277,14 @@ export function buildCli(): Command {
     .option("--dry-run", "Intercept comment / PR / push tools with synthetic responses")
     .option("--verbose", "Mirror a colorized event subset to stderr")
     .option("--skip-summary", "Skip summarizer + CLAUDE.md append")
+    .option(
+      "--no-registry-mutation",
+      "Issue #248: suppress every persistent side effect of the run on the per-agent record. No `issuesHandled` / `implementCount` / `pushbackCount` / `errorCount` bump, no `lastActiveAt` refresh, no `applyTagUpdate` of envelope `addTags` / `removeTags`. Implies `--skip-summary` (no CLAUDE.md append, no utility-scoring write). Used by research / calibration dispatchers (curve-redo, specialist bench) so fan-outs across many specialists don't drift the registry. Default: production-mode mutations on.",
+    )
+    .option(
+      "--research-mode",
+      "Alias for `--no-registry-mutation`. Either flag suppresses every persistent registry side effect of the run. Both flags coexist for callers that prefer the descriptive `--research-mode` over the inverted `--no-…` form.",
+    )
     .option("--inspect-paths <csv>", "Comma-separated absolute paths the agent may inspect read-only (e.g. prior worktrees)")
     .option(
       "--allow-closed-issue",
@@ -3239,6 +3247,18 @@ interface SpawnOpts {
   dryRun?: boolean;
   verbose?: boolean;
   skipSummary?: boolean;
+  /**
+   * Issue #248: commander's `--no-registry-mutation` sets
+   * `registryMutation: false`. Default is `true` (production callers mutate
+   * the registry as before). Research dispatchers pass the flag and we
+   * derive the noRegistryMutation intent below.
+   */
+  registryMutation?: boolean;
+  /**
+   * Issue #248: descriptive alias for `--no-registry-mutation`. Either flag
+   * suppresses every persistent registry side effect of the run.
+   */
+  researchMode?: boolean;
   inspectPaths?: string;
   allowClosedIssue?: boolean;
   issueBodyOnly?: boolean;
@@ -3290,6 +3310,12 @@ async function cmdSpawn(opts: SpawnOpts): Promise<void> {
   // ceiling is crossed mid-run.
   const budgetUsd = resolveBudgetUsd({ flag: opts.maxCostUsd, env: process.env });
   const costTracker = new RunCostTracker({ budgetUsd });
+  // Issue #248: derive `noRegistryMutation` from either flag. Commander
+  // emits `registryMutation: false` for `--no-registry-mutation`; the
+  // descriptive `--research-mode` lands as `researchMode: true`. Either
+  // form suppresses every persistent registry side effect of the run.
+  const noRegistryMutation =
+    opts.registryMutation === false || !!opts.researchMode;
   logger.info("spawn.started", {
     runId,
     agentId: agent.agentId,
@@ -3298,6 +3324,7 @@ async function cmdSpawn(opts: SpawnOpts): Promise<void> {
     targetRepoPath: repoPath,
     dryRun: !!opts.dryRun,
     skipSummary: !!opts.skipSummary,
+    noRegistryMutation,
     maxCostUsd: budgetUsd ?? null,
   });
 
@@ -3343,6 +3370,11 @@ async function cmdSpawn(opts: SpawnOpts): Promise<void> {
       dryRun: !!opts.dryRun,
       logger,
       skipSummary: !!opts.skipSummary,
+      // Issue #248: forward the suppress-all-mutations intent. runIssueCore
+      // gates the per-agent counter bumps, applyTagUpdate, persisted
+      // mutateRegistry call, and (via implication) the summarizer/utility
+      // writes. Production callers leave it false and tracking is unchanged.
+      noRegistryMutation,
       inspectPaths,
       issueBodyOnly: !!opts.issueBodyOnly,
       suppressTargetClaudeMd: opts.targetClaudeMd === false,
@@ -3370,6 +3402,10 @@ async function cmdSpawn(opts: SpawnOpts): Promise<void> {
       // #235: surface the resolved per-spawn budget so dispatch loops
       // can confirm the ceiling actually applied (vs. silently undefined).
       maxCostUsd: budgetUsd ?? null,
+      // Issue #248: surface the registry-mutation gate so dispatch loops
+      // can confirm research-mode actually suppressed the per-run drift.
+      // True = registry untouched by this run; false = production tracking.
+      noRegistryMutation,
       appendOutcome: result.appendOutcome ?? null,
       summarySkipReason: result.summarySkipReason ?? null,
     };

--- a/src/research/curveStudy/dispatch.test.ts
+++ b/src/research/curveStudy/dispatch.test.ts
@@ -1,0 +1,55 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildCurveStudySpawnArgs,
+  type CellSpec,
+  type DispatchOptions,
+} from "./dispatch.js";
+
+const CELL: CellSpec = {
+  devAgentId: "agent-2a3d",
+  issueId: 156,
+  clonePath: "/tmp/fake-clone",
+};
+
+const BASE_OPTS: DispatchOptions = {
+  cells: [CELL],
+  targetRepo: "szhygulin/vaultpilot-mcp",
+  logsDir: "/tmp/fake-logs",
+  logPrefix: "curve-",
+  cwd: process.cwd(),
+};
+
+test("buildCurveStudySpawnArgs: includes --research-mode by default (#248)", () => {
+  // Curve-study cells fan out across the specialist roster; without
+  // --research-mode every cell would mutate the registry (issuesHandled,
+  // counters, lastActiveAt, applied tags), forcing an operator-level
+  // snapshot+restore around the experiment. Both --skip-summary AND
+  // --research-mode should appear — the former is the long-standing
+  // documented contract; the latter (#248) is the new registry-mutation
+  // gate.
+  const args = buildCurveStudySpawnArgs(CELL, BASE_OPTS);
+  assert.ok(args.includes("--research-mode"), `expected --research-mode in: ${args.join(" ")}`);
+  assert.ok(args.includes("--skip-summary"), `expected --skip-summary in: ${args.join(" ")}`);
+  assert.equal(args[0], "run");
+  assert.equal(args[1], "vp-dev");
+  assert.equal(args[3], "spawn");
+});
+
+test("buildCurveStudySpawnArgs: optional flags push onto the end without dropping --research-mode", () => {
+  const args = buildCurveStudySpawnArgs(CELL, {
+    ...BASE_OPTS,
+    dryRun: true,
+    allowClosedIssue: true,
+    issueBodyOnly: true,
+    suppressTargetClaudeMd: true,
+  });
+  // The static head still carries the research-mode block.
+  assert.ok(args.includes("--research-mode"));
+  assert.ok(args.includes("--skip-summary"));
+  // And every optional flag was appended.
+  assert.ok(args.includes("--dry-run"));
+  assert.ok(args.includes("--allow-closed-issue"));
+  assert.ok(args.includes("--issue-body-only"));
+  assert.ok(args.includes("--no-target-claude-md"));
+});

--- a/src/research/curveStudy/dispatch.ts
+++ b/src/research/curveStudy/dispatch.ts
@@ -136,9 +136,16 @@ export async function dispatchCells(opts: DispatchOptions): Promise<DispatchResu
   });
 }
 
-async function runCell(cell: CellSpec, opts: DispatchOptions): Promise<DispatchResult> {
-  opts.onEvent?.({ kind: "start", cell, t: new Date() });
-  const logPath = path.join(opts.logsDir, `${opts.logPrefix}${cell.devAgentId}-${cell.issueId}.log`);
+/**
+ * Build the `npm run vp-dev -- spawn` argv for a single curve-study cell.
+ * Exported so unit tests can verify the per-cell flag set without spawning a
+ * real subprocess. Includes the static `--skip-summary` + `--research-mode`
+ * pair (#248) up front; optional flags (`--dry-run`, etc.) push onto the end.
+ */
+export function buildCurveStudySpawnArgs(
+  cell: CellSpec,
+  opts: DispatchOptions,
+): string[] {
   const args = [
     "run",
     "vp-dev",
@@ -153,11 +160,25 @@ async function runCell(cell: CellSpec, opts: DispatchOptions): Promise<DispatchR
     "--target-repo-path",
     cell.clonePath,
     "--skip-summary",
+    // Issue #248: curve-study cells fan out across the specialist roster
+    // (per-cell devAgentId varies). Without this flag every cell mutates
+    // the registry (`issuesHandled`, counters, lastActiveAt, applied tags),
+    // forcing the operator to snapshot+restore around the experiment.
+    // `--research-mode` suppresses every persistent registry side effect of
+    // the run; pass it alongside `--skip-summary` for a full block.
+    "--research-mode",
   ];
   if (opts.dryRun) args.push("--dry-run");
   if (opts.allowClosedIssue) args.push("--allow-closed-issue");
   if (opts.issueBodyOnly) args.push("--issue-body-only");
   if (opts.suppressTargetClaudeMd) args.push("--no-target-claude-md");
+  return args;
+}
+
+async function runCell(cell: CellSpec, opts: DispatchOptions): Promise<DispatchResult> {
+  opts.onEvent?.({ kind: "start", cell, t: new Date() });
+  const logPath = path.join(opts.logsDir, `${opts.logPrefix}${cell.devAgentId}-${cell.issueId}.log`);
+  const args = buildCurveStudySpawnArgs(cell, opts);
 
   const out = await fs.open(logPath, "w");
   const rc = await new Promise<number>((res, rej) => {

--- a/src/research/specialistBench/dispatch.test.ts
+++ b/src/research/specialistBench/dispatch.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { runBenchDispatch, type BenchCellSpec } from "./dispatch.js";
+import { buildBenchSpawnArgs, runBenchDispatch, type BenchCellSpec } from "./dispatch.js";
 import type { AgentRegistryFile } from "../../types.js";
 
 const FIXTURE_REGISTRY: AgentRegistryFile = {
@@ -153,6 +153,32 @@ test("runBenchDispatch: emits onEvent for pick / start / done in order", async (
   } finally {
     await fs.rm(dir, { recursive: true, force: true });
   }
+});
+
+test("buildBenchSpawnArgs: includes --research-mode by default (#248)", () => {
+  // Bench dispatch fans out across specialists to score them; every cell
+  // must NOT mutate the registry. The new `--research-mode` flag (#248) is
+  // a strict superset of `--skip-summary` — it also gates the per-agent
+  // counter bumps + applyTagUpdate. Both flags should be emitted; if a
+  // future refactor drops `--research-mode` the registry would silently
+  // drift across the bench again, which is what the snapshot+restore
+  // workaround was avoiding before this issue.
+  const spec: BenchCellSpec = {
+    pickedAgentId: "agent-2a3d",
+    issueId: 156,
+    replicate: 1,
+    targetRepo: "szhygulin/vaultpilot-mcp",
+    clonePath: "/tmp/fake-clone",
+  };
+  const args = buildBenchSpawnArgs(spec);
+  assert.ok(args.includes("--research-mode"), `expected --research-mode in: ${args.join(" ")}`);
+  assert.ok(args.includes("--skip-summary"), `expected --skip-summary in: ${args.join(" ")}`);
+  assert.ok(args.includes("--dry-run"), `expected --dry-run in: ${args.join(" ")}`);
+  // The two flags coexist intentionally — --skip-summary is the long-standing
+  // documented contract; --research-mode adds the registry-mutation gate.
+  assert.equal(args[0], "run");
+  assert.equal(args[1], "vp-dev");
+  assert.equal(args[3], "spawn");
 });
 
 test("runBenchDispatch: replicates default to 3 when not specified", async () => {

--- a/src/research/specialistBench/dispatch.ts
+++ b/src/research/specialistBench/dispatch.ts
@@ -185,11 +185,13 @@ async function defaultFetchIssueLabels(
   return parsed.labels.map((l) => l.name);
 }
 
-async function defaultSpawnCell(
-  spec: BenchCellSpec,
-  logPath: string,
-): Promise<{ rc: number }> {
-  const args = [
+/**
+ * Build the `npm run vp-dev -- spawn` argv for a single bench cell. Exported
+ * so unit tests can verify the per-cell flag set (especially `--research-mode`,
+ * #248) without spawning a real subprocess.
+ */
+export function buildBenchSpawnArgs(spec: BenchCellSpec): string[] {
+  return [
     "run",
     "vp-dev",
     "--",
@@ -203,10 +205,24 @@ async function defaultSpawnCell(
     "--target-repo-path",
     spec.clonePath,
     "--skip-summary",
+    // Issue #248: bench dispatch fans out across specialists to score them
+    // against held-out issues — every cell would otherwise drift the
+    // registry (`issuesHandled`, counters, lastActiveAt, applied tags).
+    // `--research-mode` suppresses every persistent registry side effect of
+    // the run. Keeps `--skip-summary` explicit too because the alias
+    // implication is internal to runIssueCore.
+    "--research-mode",
     "--dry-run",
     "--no-target-claude-md",
     "--issue-body-only",
   ];
+}
+
+async function defaultSpawnCell(
+  spec: BenchCellSpec,
+  logPath: string,
+): Promise<{ rc: number }> {
+  const args = buildBenchSpawnArgs(spec);
   const out = await fs.open(logPath, "w");
   return new Promise<{ rc: number }>((resolve, reject) => {
     const child = spawn("npm", args, {


### PR DESCRIPTION
Closes #248.

## Summary

`vp-dev spawn` gains `--no-registry-mutation` (descriptive alias `--research-mode`) that suppresses every persistent registry side effect of the run:

- no `issuesHandled` / `implementCount` / `pushbackCount` / `errorCount` bump,
- no `lastActiveAt` refresh,
- no `applyTagUpdate` of the envelope's `addTags` / `removeTags`,
- implies `--skip-summary` (no CLAUDE.md append, no utility-scoring write),
- skips the persisted `mutateRegistry` write that closes the loop on the in-memory `AgentRecord` gate above.

Production callers (`vp-dev run`, normal `vp-dev spawn`) leave the flag undefined and the registry tracks decisions exactly as before. Research / calibration dispatchers can now fan out across many specialists without snapshotting + restoring `state/agents-registry.json` around the experiment.

## Plumbing

Mirrors `--skip-summary`:

- **`src/cli.ts`** — `vp-dev spawn` exposes `--no-registry-mutation` (commander's `--no-X` form sets `registryMutation: false` with default `true`) and the alias `--research-mode` (sets `researchMode: true`). `cmdSpawn` derives `noRegistryMutation = opts.registryMutation === false || !!opts.researchMode` and threads it into `runIssueCore`. The gate appears in `spawn.started` log line + the spawn-output JSON so dispatch loops can confirm research-mode actually applied (vs. silently undefined).
- **`src/agent/runIssueCore.ts`** — new `noRegistryMutation?: boolean` field on `RunIssueCoreInput`. Gates the per-agent counter bumps + `applyTagUpdate(...)` (lines 271-277), the no-envelope `errorCount` bump (line 387), and the persisted `mutateRegistry` write (lines 465-475). Local `skipSummary = !!input.skipSummary || !!input.noRegistryMutation` is treated as the strict superset for the existing summarizer / utility-scoring gates.
- **`src/research/specialistBench/dispatch.ts`** — `defaultSpawnCell` now passes `--research-mode` alongside `--skip-summary`. The argv builder is hoisted to an exported `buildBenchSpawnArgs(spec)` helper.
- **`src/research/curveStudy/dispatch.ts`** — `runCell` now passes `--research-mode` alongside `--skip-summary`. The argv builder is hoisted to an exported `buildCurveStudySpawnArgs(cell, opts)` helper.

## Why a separate flag (not overload `--skip-summary`)

`--skip-summary`'s documented contract is "Skip summarizer + CLAUDE.md append" (`src/cli.ts:279`). Existing callers — including bench + curve-study dispatchers — may rely on registry tracking still happening when summarization is suppressed (e.g. to count which agents handled which issues during a benchmark). Silently broadening `--skip-summary` to cover registry mutations would be a behavior change for those callers; a separate flag is the cleaner scope. The two flags coexist.

## Tests

`npm run build` + `npm test` pass (919 tests, +3 new).

- `buildBenchSpawnArgs: includes --research-mode by default (#248)` — pins both `--research-mode` and `--skip-summary` on the static head of the bench cell argv.
- `buildCurveStudySpawnArgs: includes --research-mode by default (#248)` — same for the curve-study path.
- `buildCurveStudySpawnArgs: optional flags push onto the end without dropping --research-mode` — guards against a future refactor that reorders the optional-flag append loop and silently drops the static head.

## Out of scope

- The in-flight curve-redo follow-up's `state/agents-registry.snapshot-pre-specialist-redo.json` snapshot stays in place. If/when this lands, the next experiment can drop the snapshot pattern in favor of `--research-mode`. No rerun needed before then (per the issue's "Out of scope" section).
- `vp-dev run` is the production multi-agent path and intentionally does NOT thread `--no-registry-mutation` through the orchestrator's `runOneIssue` — production dispatch tracks who handled what. The flag lives on `vp-dev spawn` where research dispatchers consume it.

— Galois (agent-916a-trim-22000-s24026)
