### PR TITLE
fix(replay): restore origin remote after replay-mode strip (#253)

### DIFF
--- a/src/agent/replay.test.ts
+++ b/src/agent/replay.test.ts
@@ -5,7 +5,12 @@ import os from "node:os";
 import path from "node:path";
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
-import { applyReplayRollback, captureWorktreeDiff, readWorktreeHead } from "./replay.js";
+import {
+  applyReplayRollback,
+  captureWorktreeDiff,
+  readWorktreeHead,
+  restoreOriginRemote,
+} from "./replay.js";
 
 const execFile = promisify(execFileCb);
 
@@ -60,7 +65,10 @@ test("applyReplayRollback: strips the `origin` remote so an agent-side rebase to
     // something to strip. The URL points at the same dir for fetchability.
     await execFile("git", ["-C", repoRoot, "remote", "add", "origin", repoRoot]);
     await execFile("git", ["-C", repoRoot, "fetch", "-q", "origin"]);
-    await applyReplayRollback({ worktreePath: repoRoot, baseSha: seedSha });
+    const result = await applyReplayRollback({ worktreePath: repoRoot, baseSha: seedSha });
+    // The pre-strip URL is captured in the return value (issue #253) so
+    // the caller can restore it after the agent finishes.
+    assert.equal(result.originUrl, repoRoot);
     // Verify origin is gone — `git remote get-url origin` should error.
     await assert.rejects(
       execFile("git", ["-C", repoRoot, "remote", "get-url", "origin"]),
@@ -71,6 +79,70 @@ test("applyReplayRollback: strips the `origin` remote so an agent-side rebase to
     await assert.rejects(
       execFile("git", ["-C", repoRoot, "rebase", "origin/main"]),
       /invalid upstream|unknown revision|fatal/,
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+test("applyReplayRollback: returns originUrl=undefined when origin was already absent (sibling-stripped)", async () => {
+  const { repoRoot, seedSha, cleanup } = await makeFixtureRepo();
+  try {
+    // Fixture has no origin from `makeFixtureRepo`. Issue #253 race: a
+    // sibling cell stripped first, so the saved URL window closes empty.
+    const result = await applyReplayRollback({ worktreePath: repoRoot, baseSha: seedSha });
+    assert.equal(result.originUrl, undefined);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("restoreOriginRemote: re-adds origin from the saved URL after a replay-mode strip (#253)", async () => {
+  const { repoRoot, seedSha, cleanup } = await makeFixtureRepo();
+  try {
+    await execFile("git", ["-C", repoRoot, "remote", "add", "origin", repoRoot]);
+    const { originUrl } = await applyReplayRollback({
+      worktreePath: repoRoot,
+      baseSha: seedSha,
+    });
+    // Confirm the strip happened.
+    await assert.rejects(
+      execFile("git", ["-C", repoRoot, "remote", "get-url", "origin"]),
+      /No such remote|fatal/,
+    );
+    await restoreOriginRemote({ worktreePath: repoRoot, originUrl });
+    const { stdout } = await execFile("git", ["-C", repoRoot, "remote", "get-url", "origin"]);
+    assert.equal(stdout.trim(), repoRoot);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("restoreOriginRemote: idempotent against a sibling cell that already re-added origin", async () => {
+  const { repoRoot, cleanup } = await makeFixtureRepo();
+  try {
+    // Pre-condition: origin already exists (sibling cell's
+    // `ensureOriginRemote` got there first).
+    await execFile("git", ["-C", repoRoot, "remote", "add", "origin", repoRoot]);
+    // Restore should not throw on the duplicate-add — it falls through to
+    // `set-url`. Verify the URL ends up as the saved URL.
+    const altUrl = `${repoRoot}-alt`;
+    await restoreOriginRemote({ worktreePath: repoRoot, originUrl: altUrl });
+    const { stdout } = await execFile("git", ["-C", repoRoot, "remote", "get-url", "origin"]);
+    assert.equal(stdout.trim(), altUrl);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("restoreOriginRemote: no-op when originUrl is undefined", async () => {
+  const { repoRoot, cleanup } = await makeFixtureRepo();
+  try {
+    // No origin to start, no URL to restore. Must not throw.
+    await restoreOriginRemote({ worktreePath: repoRoot, originUrl: undefined });
+    await assert.rejects(
+      execFile("git", ["-C", repoRoot, "remote", "get-url", "origin"]),
+      /No such remote|fatal/,
     );
   } finally {
     await cleanup();

--- a/src/agent/replay.ts
+++ b/src/agent/replay.ts
@@ -20,6 +20,17 @@ import { promisify } from "node:util";
 
 const execFile = promisify(execFileCb);
 
+export interface ApplyReplayRollbackResult {
+  /**
+   * URL of the `origin` remote captured before the strip. The orchestrator
+   * passes this back to `restoreOriginRemote` after the agent finishes so
+   * the shared `.git/config` is left clean for the next cell on the same
+   * clone. `undefined` when the strip ran against a clone that already had
+   * no origin (e.g. a sibling cell stripped first).
+   */
+  originUrl?: string;
+}
+
 /**
  * Reset the worktree to a specific git SHA. Used for closed-issue replay so
  * the coding agent encounters the codebase at the issue's pre-fix base SHA
@@ -28,11 +39,19 @@ const execFile = promisify(execFileCb);
  * Throws if the SHA is unknown or the reset fails — callers let the
  * orchestrator surface the error rather than swallowing it. Open-issue
  * dispatches skip this helper entirely (no baseSha supplied).
+ *
+ * Returns the pre-strip `origin` URL so the caller can restore it after the
+ * agent finishes (issue #253). The strip mutates the SHARED `.git/config`
+ * because non-bare clones don't scope `git remote remove` to the worktree;
+ * leaving that mutation in place broke every subsequent cell's
+ * `createWorktree` fetch on the same clone. Pairing strip with restore (and
+ * a defensive `ensureOriginRemote` in `createWorktree`) keeps the cross-cell
+ * surface clean.
  */
 export async function applyReplayRollback(opts: {
   worktreePath: string;
   baseSha: string;
-}): Promise<void> {
+}): Promise<ApplyReplayRollbackResult> {
   await execFile("git", ["-C", opts.worktreePath, "reset", "--hard", opts.baseSha]);
   // Replay-mode invariant: the agent must encounter the pre-fix codebase
   // state. Larger trim CLAUDE.mds carry a "sync to main before work" rule
@@ -42,11 +61,74 @@ export async function applyReplayRollback(opts: {
   // 6KB-trim cell on the same issue). Strip the `origin` remote so any
   // sync attempt fails fast. `--dry-run` already intercepts push; replay
   // never reads from origin afterwards.
+  //
+  // Save the URL FIRST so the caller can restore it on cleanup. Best-effort:
+  // a sibling cell may already have stripped origin, in which case we leave
+  // `originUrl` undefined and rely on `ensureOriginRemote` in the next
+  // `createWorktree` to reconstruct from the targetRepo slug.
+  let originUrl: string | undefined;
+  try {
+    const { stdout } = await execFile("git", [
+      "-C",
+      opts.worktreePath,
+      "remote",
+      "get-url",
+      "origin",
+    ]);
+    originUrl = stdout.trim() || undefined;
+  } catch {
+    // origin already absent — sibling cell stripped first, or clone has
+    // no remote configured. `originUrl` stays undefined.
+  }
   try {
     await execFile("git", ["-C", opts.worktreePath, "remote", "remove", "origin"]);
   } catch {
     // remote may already be absent (e.g. subsequent cells reusing the same
     // clone where a prior cell stripped it). Best-effort, idempotent.
+  }
+  return { originUrl };
+}
+
+/**
+ * Restore the `origin` remote URL after a replay-mode cell finishes (#253).
+ *
+ * Called from `runIssueCore`'s finally block, paired with the saved URL
+ * returned by `applyReplayRollback`. Idempotent against concurrent cells:
+ * if a sibling cell already re-added origin (via `ensureOriginRemote`), we
+ * fall through to `set-url` rather than throwing on the duplicate. No-op
+ * when the saved URL is `undefined` (a sibling stripped first).
+ */
+export async function restoreOriginRemote(opts: {
+  worktreePath: string;
+  originUrl?: string;
+}): Promise<void> {
+  if (!opts.originUrl) return;
+  try {
+    await execFile("git", [
+      "-C",
+      opts.worktreePath,
+      "remote",
+      "add",
+      "origin",
+      opts.originUrl,
+    ]);
+    return;
+  } catch {
+    // origin already exists (sibling cell restored). Fall through.
+  }
+  try {
+    await execFile("git", [
+      "-C",
+      opts.worktreePath,
+      "remote",
+      "set-url",
+      "origin",
+      opts.originUrl,
+    ]);
+  } catch {
+    // Best-effort: leaving an existing-but-different URL is preferable to
+    // throwing. The next cell's `ensureOriginRemote` will see a present
+    // origin and treat it as a no-op.
   }
 }
 

--- a/src/agent/runIssueCore.ts
+++ b/src/agent/runIssueCore.ts
@@ -1,7 +1,12 @@
 import { promises as fs } from "node:fs";
 import { ensureAgent, mutateRegistry } from "../state/registry.js";
 import { runCodingAgent } from "./codingAgent.js";
-import { applyReplayRollback, captureWorktreeDiff, readWorktreeHead } from "./replay.js";
+import {
+  applyReplayRollback,
+  captureWorktreeDiff,
+  readWorktreeHead,
+  restoreOriginRemote,
+} from "./replay.js";
 import {
   agentClaudeMdPath,
   appendBlock,
@@ -151,12 +156,18 @@ export interface RunIssueCoreResult {
 export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCoreResult> {
   let worktree: WorktreeHandle | null = null;
   let envelope: ResultEnvelope | undefined;
+  // Captured by `applyReplayRollback` (issue #253) and consumed by the
+  // finally block to restore the shared `.git/config`'s `origin` after the
+  // agent finishes. Undefined for non-replay cells and for replay cells
+  // whose strip lost the race to a sibling.
+  let savedOriginUrl: string | undefined;
 
   try {
     await forkClaudeMd(input.agent.agentId, input.targetRepoPath);
 
     worktree = await createWorktree({
       repoPath: input.targetRepoPath,
+      targetRepo: input.targetRepo,
       agentId: input.agent.agentId,
       issueId: input.issue.id,
       resumeFromBranch: input.resumeContext?.branch,
@@ -176,14 +187,16 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
     // omit baseSha and the worktree stays at origin/main. Throws on bad
     // SHA — orchestrator surfaces it via the per-cell error envelope.
     if (input.replayMode?.baseSha) {
-      await applyReplayRollback({
+      const rollback = await applyReplayRollback({
         worktreePath: worktree.path,
         baseSha: input.replayMode.baseSha,
       });
+      savedOriginUrl = rollback.originUrl;
       input.logger.info("agent.replay_rollback", {
         agentId: input.agent.agentId,
         issueId: input.issue.id,
         baseSha: input.replayMode.baseSha,
+        originUrlCaptured: !!savedOriginUrl,
       });
     }
 
@@ -548,6 +561,27 @@ export async function runIssueCore(input: RunIssueCoreInput): Promise<RunIssueCo
       partialBranchUrl,
     };
   } finally {
+    // Restore the `origin` remote on the SHARED `.git/config` if a replay-
+    // mode strip ran on this cell (issue #253). Done before worktree teardown
+    // so the worktree path still exists; idempotent against concurrent cells
+    // that already re-added origin via `ensureOriginRemote`.
+    if (savedOriginUrl && worktree) {
+      try {
+        await restoreOriginRemote({
+          worktreePath: worktree.path,
+          originUrl: savedOriginUrl,
+        });
+      } catch (err) {
+        // Best-effort: a restore failure is not catastrophic — the next
+        // cell's `ensureOriginRemote` will reconstruct from the targetRepo
+        // slug. Log so the operator has an audit trail.
+        input.logger.warn("agent.replay_origin_restore_failed", {
+          agentId: input.agent.agentId,
+          issueId: input.issue.id,
+          err: (err as Error).message,
+        });
+      }
+    }
     if (worktree) {
       const isImplement = envelope?.decision === "implement";
       await removeWorktree({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3302,7 +3302,9 @@ async function cmdSpawn(opts: SpawnOpts): Promise<void> {
   });
 
   try {
-    await fetchOriginMain(repoPath);
+    // Pass `targetRepo` so `fetchOriginMain` defensively re-adds origin
+    // if a prior replay-mode cell left it stripped (issue #253).
+    await fetchOriginMain(repoPath, opts.targetRepo);
     await pruneWorktrees(repoPath);
     const sweep = await pruneStaleAgentBranches(repoPath, opts.targetRepo, logger);
     if (sweep.unprunable.length > 0) {

--- a/src/git/worktree.test.ts
+++ b/src/git/worktree.test.ts
@@ -1,6 +1,33 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { buildIncompleteBranchName } from "./worktree.js";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+import { buildIncompleteBranchName, ensureOriginRemote } from "./worktree.js";
+
+const execFile = promisify(execFileCb);
+
+async function makeBareClonePair(): Promise<{
+  bareRepo: string;
+  cloneDir: string;
+  cleanup: () => Promise<void>;
+}> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "ensure-origin-"));
+  const bareRepo = path.join(root, "upstream.git");
+  const cloneDir = path.join(root, "clone");
+  await execFile("git", ["init", "-q", "--bare", "-b", "main", bareRepo]);
+  await execFile("git", ["clone", "-q", bareRepo, cloneDir]);
+  await execFile("git", ["-C", cloneDir, "config", "user.email", "test@example.com"]);
+  await execFile("git", ["-C", cloneDir, "config", "user.name", "Test User"]);
+  await execFile("git", ["-C", cloneDir, "config", "commit.gpgsign", "false"]);
+  return {
+    bareRepo,
+    cloneDir,
+    cleanup: async () => fs.rm(root, { recursive: true, force: true }),
+  };
+}
 
 // Canonical runId shape from `makeRunId()`:
 // `run-2026-05-04T16-53-06-188Z` — alphanumerics, `-`, `T`, `Z`. Already
@@ -53,4 +80,48 @@ test("preserves multi-digit issue numbers and lowercase agent ids", () => {
     "run-X",
   );
   assert.equal(branch, "vp-dev/agent-ef41/issue-1234-incomplete-run-X");
+});
+
+// --- ensureOriginRemote (#253) ---------------------------------------------
+
+test("ensureOriginRemote: no-op when origin is already configured", async () => {
+  const { cloneDir, bareRepo, cleanup } = await makeBareClonePair();
+  try {
+    // `git clone` already wired up `origin` to bareRepo. Helper must not
+    // mutate it.
+    const result = await ensureOriginRemote(cloneDir, "owner/repo");
+    assert.equal(result.added, false);
+    const { stdout } = await execFile("git", ["-C", cloneDir, "remote", "get-url", "origin"]);
+    assert.equal(stdout.trim(), bareRepo);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("ensureOriginRemote: re-adds origin from canonical GitHub URL when missing (issue #253)", async () => {
+  const { cloneDir, cleanup } = await makeBareClonePair();
+  try {
+    // Simulate the replay-mode strip: another cell removed origin from
+    // the shared `.git/config`.
+    await execFile("git", ["-C", cloneDir, "remote", "remove", "origin"]);
+    const result = await ensureOriginRemote(cloneDir, "szhygulin/vaultpilot-dev-framework");
+    assert.equal(result.added, true);
+    const { stdout } = await execFile("git", ["-C", cloneDir, "remote", "get-url", "origin"]);
+    assert.equal(stdout.trim(), "https://github.com/szhygulin/vaultpilot-dev-framework");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("ensureOriginRemote: idempotent — calling twice without intervening strip is a no-op the second time", async () => {
+  const { cloneDir, cleanup } = await makeBareClonePair();
+  try {
+    await execFile("git", ["-C", cloneDir, "remote", "remove", "origin"]);
+    const first = await ensureOriginRemote(cloneDir, "owner/repo");
+    assert.equal(first.added, true);
+    const second = await ensureOriginRemote(cloneDir, "owner/repo");
+    assert.equal(second.added, false);
+  } finally {
+    await cleanup();
+  }
 });

--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -80,7 +80,55 @@ export async function resolveTargetRepoPath(
   return conventional;
 }
 
-export async function fetchOriginMain(repoPath: string): Promise<void> {
+/**
+ * Defensive re-add of the `origin` remote against the target repo's shared
+ * `.git/config`. No-op when origin is already present.
+ *
+ * Surfaced by issue #253: `applyReplayRollback` (curve-redo replay-mode) runs
+ * `git -C <worktree> remote remove origin` to make a sibling agent's
+ * "sync to main before work" rule fail-fast. In a non-bare clone the strip
+ * mutates the SHARED `.git/config` rather than per-worktree state, so every
+ * subsequent cell on the same clone — including normal `createWorktree`
+ * calls — used to fail at `git fetch origin main` with `'origin' does not
+ * appear to be a git repository`. Re-adding origin idempotently here unblocks
+ * the next cell whether or not the prior cell crashed before its restore step.
+ *
+ * `targetRepo` is the canonical `<owner>/<repo>` slug; we reconstruct
+ * `https://github.com/<owner>/<repo>` rather than spelunking after the
+ * pre-strip URL because by the time we notice it's missing, the URL is gone.
+ * Cells running concurrently on the same clone race on this write, but
+ * `git remote add` is fast and `withRepoLock` already serializes the
+ * surrounding `worktree add` so the race is bounded.
+ */
+export async function ensureOriginRemote(
+  repoPath: string,
+  targetRepo: string,
+): Promise<{ added: boolean }> {
+  try {
+    await execFile("git", ["-C", repoPath, "remote", "get-url", "origin"]);
+    return { added: false };
+  } catch {
+    // origin missing — re-add from canonical GitHub URL
+    await execFile("git", [
+      "-C",
+      repoPath,
+      "remote",
+      "add",
+      "origin",
+      `https://github.com/${targetRepo}`,
+    ]);
+    return { added: true };
+  }
+}
+
+export async function fetchOriginMain(
+  repoPath: string,
+  targetRepo?: string,
+): Promise<void> {
+  // When `targetRepo` is supplied, defensively re-add origin if a prior
+  // replay-mode cell stripped it (#253). Optional so test fixtures that
+  // build their own ad-hoc clones without a github-shaped slug still work.
+  if (targetRepo) await ensureOriginRemote(repoPath, targetRepo);
   await execFile("git", ["fetch", "origin", "main"], { cwd: repoPath });
 }
 
@@ -90,6 +138,13 @@ export async function pruneWorktrees(repoPath: string): Promise<void> {
 
 export async function createWorktree(opts: {
   repoPath: string;
+  /**
+   * Canonical `<owner>/<repo>` GitHub slug. Used to re-add `origin` if a
+   * prior replay-mode cell stripped it from the shared `.git/config`
+   * (issue #253). Required because the strip happens after the saved-URL
+   * window closes, so we reconstruct the URL from the slug.
+   */
+  targetRepo: string;
   agentId: string;
   issueId: number;
   /**
@@ -112,6 +167,10 @@ export async function createWorktree(opts: {
   const wtRel = path.join(".claude", "worktrees", `${opts.agentId}-issue-${opts.issueId}`);
 
   // CLAUDE.md: cd <repoPath> BEFORE worktree add — execFile with cwd does that explicitly.
+  // Defensive re-add of `origin` first: a prior replay-mode cell may have
+  // stripped it from the shared `.git/config` (issue #253). No-op when
+  // origin is already present.
+  await ensureOriginRemote(opts.repoPath, opts.targetRepo);
   await execFile("git", ["fetch", "origin", "main"], { cwd: opts.repoPath });
 
   // When resuming from a salvage ref, fetch that specific branch into the

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -86,7 +86,9 @@ export interface OrchestratorInput {
 
 export async function runOrchestrator(input: OrchestratorInput): Promise<void> {
   const repoPath = await resolveTargetRepoPath(input.state.targetRepo, input.targetRepoPath);
-  await fetchOriginMain(repoPath);
+  // Pass `targetRepo` so `fetchOriginMain` can defensively re-add origin
+  // if a prior replay-mode run left it stripped (issue #253).
+  await fetchOriginMain(repoPath, input.state.targetRepo);
 
   const issuesById = new Map(input.issues.map((i) => [i.id, i]));
 


### PR DESCRIPTION
Closes #253.

## Summary

`applyReplayRollback`'s `git remote remove origin` mutates the **shared** `.git/config` of the source clone in non-bare repos — every subsequent cell on the same clone then fails at `git fetch origin main` with `'origin' does not appear to be a git repository`. All leg-2 cells of PR #231's curve-redo follow-up dispatch hit this failure.

Two-layer fix:

1. **Save + restore around the agent run** (issue option 1). `applyReplayRollback` now reads `git remote get-url origin` before the strip and returns the URL. `runIssueCore` calls a new `restoreOriginRemote` helper from its finally block, paired with the saved URL. The shared `.git/config` is restored to its pre-strip state once the agent finishes — the rebase fail-fast semantics during the agent's run are unchanged.
2. **Defensive `ensureOriginRemote` in `createWorktree` + `fetchOriginMain`**. Reconstructs origin from the canonical `<owner>/<repo>` slug if it's missing (e.g. a prior cell crashed before restore, or two cells race). Matches the in-flight operator workaround on `research/curve-redo-bundle/specialist-redo/`. Idempotent against concurrent cells.

The two layers are belt + suspenders. Save+restore handles the clean-exit case; `ensureOriginRemote` handles crashed-cell and race-window cases.

## Approach choice

The issue body recommended option 2 (sentinel URL) but that doesn't actually fix the cross-cell breakage either: a sentinel URL still fails `git fetch origin main` in the next cell's `createWorktree`. Option 1 (save + restore) plus the defensive ensureOrigin is the architecturally correct fit — the issue author explicitly noted option 1 is "fine but has a window where origin is missing if the cell crashes between strip and restore." `ensureOriginRemote` closes that window without disturbing the strip's intended fail-fast behavior.

Disposable per-cell clones (option 4) would fully isolate state but the disk + setup cost is higher than the bug warrants.

## Residual race window

A concurrent cell may re-add origin via `ensureOriginRemote` while a sibling cell's agent is still running, briefly making the sibling's potential `git rebase origin/main` succeed (and contaminating its captured diff). In practice the agent's "sync to main" attempt happens early in its turn budget, before peer cells reach `createWorktree`. Fully closing the race requires per-cell clones; out of scope for this fix.

## Files changed

- `src/agent/replay.ts` — `applyReplayRollback` returns saved URL; new `restoreOriginRemote` helper.
- `src/agent/runIssueCore.ts` — captures saved URL, restores in finally; passes `targetRepo` to `createWorktree`.
- `src/git/worktree.ts` — new `ensureOriginRemote`; `fetchOriginMain` and `createWorktree` accept and use `targetRepo`.
- `src/orchestrator/orchestrator.ts`, `src/cli.ts` — pass `targetRepo` to `fetchOriginMain`.
- `src/agent/replay.test.ts`, `src/git/worktree.test.ts` — coverage for capture, restore, ensureOriginRemote (no-op + re-add + idempotent).

## Test plan

- [x] `npm run build` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 923/923 pass (8 new tests added)
- [ ] Live smoke: dispatch a replay-mode multi-cell run on a clone with a curve-redo-bundle leg-2 shape (every issue closed) and verify all cells reach the agent step rather than failing at `git fetch origin main`.

— Sofia (agent-2a3d)
