### PR TITLE
fix(dispatcher): pass --no-registry-mutation in research dispatch

### DIFF
--- a/research/curve-redo-bundle/specialist-redo/dispatch-specialist-redo-parallel.sh
+++ b/research/curve-redo-bundle/specialist-redo/dispatch-specialist-redo-parallel.sh
@@ -10,6 +10,12 @@
 #
 # Behavior matches the serial dispatcher cell-for-cell:
 #   * --dry-run, --no-target-claude-md, --skip-summary, --capture-diff-path
+#   * --no-registry-mutation (research-mode): suppresses every persistent side
+#     effect of the run on the per-agent registry record. Without this flag,
+#     each cell's envelope `memoryUpdate.addTags` mutates the agent's tags
+#     mid-run — for the picker-vs-content naive arm (one agent across 39
+#     cells) that drift contaminated cells 2..N before the fix. Snapshot
+#     state/agents-registry.json before the run anyway as defense in depth.
 #   * --replay-base-sha + --allow-closed-issue + --issue-body-only for closed
 #     leg-2 issues
 #   * --model claude-sonnet-4-6 (override via $MODEL)
@@ -191,6 +197,7 @@ run_cell() {
     --dry-run
     --no-target-claude-md
     --skip-summary
+    --no-registry-mutation
     --model "$MODEL"
     --capture-diff-path "$diff_path")
   if [[ "$state" == "closed" ]]; then


### PR DESCRIPTION
## Summary

- `dispatch-specialist-redo-parallel.sh` now passes `--no-registry-mutation` (research-mode) to every `vp-dev spawn` cell. Without it, each cell's envelope `memoryUpdate.addTags` mutated the agent's registry record mid-run.
- For specialist-redo (one specialist per issue) the drift was bounded — each agent already specialized to its tag cluster. For the [#265](https://github.com/szhygulin/vaultpilot-dev-framework/pull/265) picker-vs-content **naive arm** (one agent across 39 cells), the drift compounded: after the first pushback cell the naive agent had four tags (`general`, `idl-drift`, `marginfi`, `tracking-issue`); cells 2..N no longer measured a fresh general agent.
- `--skip-summary` was already passed — that suppresses summarizer-driven CLAUDE.md writes, but registry-side `addTags` / `issuesHandled` mutations have a separate trigger and slipped through. `--no-registry-mutation` ([#248](https://github.com/szhygulin/vaultpilot-dev-framework/issues/248)) is the right gate.
- The [#265](https://github.com/szhygulin/vaultpilot-dev-framework/pull/265) plan flagged this as risk #1 with snapshot+restore as the recommended mitigation. Snapshot+restore handles persistence after the run; it does not prevent within-run drift on the agent's tags. This change closes that gap.

## Why caught now

Mid-run inspection of the first naive-baseline cells: `agentTags` in the spawn output had grown from `["general"]` to four tags after a single pushback cell. The naive arm's whole point is "agent has zero issue-specific exposure" — a contaminated naive arm doesn't separate picker-bad from content-bad, which was the entire purpose of [#265](https://github.com/szhygulin/vaultpilot-dev-framework/pull/265).

## No retroactive impact

[PR #255](https://github.com/szhygulin/vaultpilot-dev-framework/pull/255)'s specialist-redo data is immutable. Re-running with this flag would not materially change those results — each specialist's per-agent CLAUDE.md is the dominant prompt input, and shared-lessons reads (the only tag-driven prompt path) had no on-disk pools to read from.

## Test plan

- [x] `--dry-print` confirms `--no-registry-mutation` lands in every per-cell `vp-dev spawn` invocation.
- [x] Idempotent skip-if-exists path still works — 9 already-completed naive-baseline cells correctly identified as `skip (exists)`.
- [x] Resumed dispatch (post-fix) produces spawn outputs with `noRegistryMutation: true` and the agent's persisted tags stay at `["general"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)