### PR TITLE
feat(dispatch): replace tag-based routing with full-prose CLAUDE.md analysis

### DIFF
--- a/src/agent/summarizer.test.ts
+++ b/src/agent/summarizer.test.ts
@@ -35,6 +35,7 @@ const stubIssue: IssueSummary = {
   title: "Test issue",
   labels: ["bug"],
   state: "open",
+  body: "",
 };
 
 const stubEnvelope: ResultEnvelope = {

--- a/src/github/gh.test.ts
+++ b/src/github/gh.test.ts
@@ -10,6 +10,7 @@ const FIXTURE_RECORD = {
   title: "fix(curve-study): transient gh issue view 404 should retry",
   state: "OPEN",
   labels: [{ name: "bug" }],
+  body: "",
 };
 
 test("getIssue: first-attempt success returns issue, no retries fired", async () => {

--- a/src/github/gh.ts
+++ b/src/github/gh.ts
@@ -12,10 +12,10 @@ interface GhIssueRecord {
   title: string;
   state: string;
   labels: { name: string }[];
+  body: string;
 }
 
 interface GhIssueDetailRecord extends GhIssueRecord {
-  body: string;
   comments: { author?: { login?: string }; body: string; createdAt: string }[];
 }
 
@@ -26,7 +26,6 @@ export interface IssueComment {
 }
 
 export interface IssueDetail extends IssueSummary {
-  body: string;
   comments: IssueComment[];
 }
 
@@ -43,7 +42,7 @@ export async function listOpenIssues(targetRepo: string): Promise<IssueSummary[]
       "--limit",
       "1000",
       "--json",
-      "number,title,state,labels",
+      "number,title,state,labels,body",
     ],
     { maxBuffer: 50 * 1024 * 1024 },
   );
@@ -101,9 +100,9 @@ async function fetchIssueRecord(targetRepo: string, number: number): Promise<GhI
       "--repo",
       targetRepo,
       "--json",
-      "number,title,state,labels",
+      "number,title,state,labels,body",
     ],
-    { maxBuffer: 5 * 1024 * 1024 },
+    { maxBuffer: 50 * 1024 * 1024 },
   );
   return JSON.parse(stdout) as GhIssueRecord;
 }
@@ -144,6 +143,7 @@ function toSummary(rec: GhIssueRecord): IssueSummary {
     title: rec.title,
     labels: rec.labels.map((l) => l.name),
     state,
+    body: rec.body ?? "",
   };
 }
 
@@ -166,7 +166,6 @@ export async function getIssueDetail(targetRepo: string, number: number): Promis
     const summary = toSummary(rec);
     return {
       ...summary,
-      body: rec.body ?? "",
       comments: (rec.comments ?? []).map((c) => ({
         author: c.author?.login ?? "",
         body: c.body ?? "",

--- a/src/orchestrator/costEstimator.test.ts
+++ b/src/orchestrator/costEstimator.test.ts
@@ -17,7 +17,7 @@ import {
 import type { IssueSummary } from "../types.js";
 
 function issue(id: number, title = `Issue ${id}`): IssueSummary {
-  return { id, title, labels: [], state: "open" };
+  return { id, title, labels: [], state: "open", body: "" };
 }
 
 // Float-tolerant equality for budget arithmetic (3.6 - 1.2 - 2.4 lands on

--- a/src/orchestrator/dependencies.test.ts
+++ b/src/orchestrator/dependencies.test.ts
@@ -16,7 +16,7 @@ import type { IssueSummary } from "../types.js";
 // pure-function checkDependencies tests with stubbed state resolvers.
 
 function makeSummary(id: number, title = `Issue ${id}`): IssueSummary {
-  return { id, title, labels: [], state: "open" };
+  return { id, title, labels: [], state: "open", body: "" };
 }
 
 // ---------- parseDependencyRefs ----------

--- a/src/orchestrator/dispatcher.ts
+++ b/src/orchestrator/dispatcher.ts
@@ -36,6 +36,14 @@ export interface DispatchInput {
    * always picks it first.
    */
   preferAgentId?: string;
+  /**
+   * Path to the target repo's checkout. Threaded into the dispatcher
+   * prompt so each per-agent CLAUDE.md can be deduped against the
+   * project's seed CLAUDE.md (mirrors `buildAgentSystemPrompt`'s
+   * live-load logic). Required: the prompt builder reads files using
+   * this path.
+   */
+  targetRepoPath: string;
 }
 
 export interface DispatchResult {
@@ -58,6 +66,7 @@ export async function dispatch(input: DispatchInput): Promise<DispatchResult> {
     logger: input.logger,
     costTracker: input.costTracker,
     preferAgentId: input.preferAgentId,
+    targetRepoPath: input.targetRepoPath,
   });
   if (firstAttempt.assignments) {
     return { assignments: firstAttempt.assignments, source: "llm" };
@@ -76,6 +85,7 @@ export async function dispatch(input: DispatchInput): Promise<DispatchResult> {
     errorsFromPrior: firstAttempt.errors,
     costTracker: input.costTracker,
     preferAgentId: input.preferAgentId,
+    targetRepoPath: input.targetRepoPath,
   });
   if (retry.assignments) {
     return { assignments: retry.assignments, source: "llm-retry" };
@@ -108,13 +118,16 @@ async function tryProposeWithLLM(opts: {
   errorsFromPrior?: string[];
   costTracker?: RunCostTracker;
   preferAgentId?: string;
+  targetRepoPath: string;
 }): Promise<ProposeOutcome> {
-  const prompt = buildTickPrompt({
+  const prompt = await buildTickPrompt({
     pendingIssues: opts.pendingIssues,
     idleAgents: opts.idleAgents,
     cap: opts.cap,
     errorsFromPrior: opts.errorsFromPrior,
     preferAgentId: opts.preferAgentId,
+    targetRepoPath: opts.targetRepoPath,
+    logger: opts.logger,
   });
 
   let raw = "";

--- a/src/orchestrator/models.ts
+++ b/src/orchestrator/models.ts
@@ -5,8 +5,14 @@
 // Tier rationale:
 //   - triage:      haiku — per-issue scan, often 50+ issues per run; opus at
 //                  ~50× would be uneconomical and the rubric is narrow.
-//   - dispatch:    opus  — cross-issue routing reasoning; mistakes cascade
-//                  into wrong-agent assignments and burn coding-agent budget.
+//   - dispatch:    opus[1m] — cross-issue routing reasoning over the full
+//                  per-agent CLAUDE.md prose for every idle agent (~370K
+//                  tokens at scale). The 1M-context variant is required to
+//                  fit ~45 deduped agent CLAUDE.mds plus pending issue
+//                  bodies; the standard 200K window overflows. Mistakes
+//                  cascade into wrong-agent assignments and burn
+//                  coding-agent budget, so the precision-over-cost tier
+//                  matches the work.
 //   - split:       opus  — clusterer reasoning over the entire CLAUDE.md to
 //                  propose meaningful splits; quality matters more than cost.
 //   - summarizer:  sonnet — per-run, frequency-justifies-cheaper-tier; the
@@ -25,7 +31,7 @@ export const ORCHESTRATOR_MODEL_TRIAGE =
   process.env.VP_DEV_TRIAGE_MODEL ?? "claude-haiku-4-5-20251001";
 
 export const ORCHESTRATOR_MODEL_DISPATCH =
-  process.env.VP_DEV_DISPATCH_MODEL ?? "claude-opus-4-7";
+  process.env.VP_DEV_DISPATCH_MODEL ?? "claude-opus-4-7[1m]";
 
 export const ORCHESTRATOR_MODEL_SPLIT =
   process.env.VP_DEV_SPLIT_MODEL ?? "claude-opus-4-7";

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -158,6 +158,7 @@ export async function runOrchestrator(input: OrchestratorInput): Promise<void> {
         logger: input.logger,
         costTracker: input.costTracker,
         preferAgentId: input.preferAgentId,
+        targetRepoPath: repoPath,
       });
       input.logger.info("tick.proposal", {
         tick: input.state.tickCount,

--- a/src/orchestrator/prompt.test.ts
+++ b/src/orchestrator/prompt.test.ts
@@ -1,0 +1,193 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { buildTickPrompt, PROMPT_BYTE_BUDGET } from "./prompt.js";
+import { agentClaudeMdPath, agentDir } from "../agent/specialization.js";
+import type { AgentRecord, IssueSummary } from "../types.js";
+
+// `buildTickPrompt` reads three files per call: the target repo's
+// CLAUDE.md (seed), each idle agent's `agents/<id>/CLAUDE.md`, and
+// any global CLAUDE.md is NOT consumed here (the dispatcher prompt
+// is a different surface than `buildAgentSystemPrompt`). These
+// helpers stage the first two on disk, then unwind them in `finally`.
+
+async function withTargetRepo<T>(
+  claudeMd: string,
+  fn: (targetRepoPath: string) => Promise<T>,
+): Promise<T> {
+  const targetRepoPath = await fs.mkdtemp(
+    path.join(os.tmpdir(), "vp-tick-prompt-target-"),
+  );
+  await fs.writeFile(path.join(targetRepoPath, "CLAUDE.md"), claudeMd);
+  try {
+    return await fn(targetRepoPath);
+  } finally {
+    await fs.rm(targetRepoPath, { recursive: true, force: true });
+  }
+}
+
+async function withPerAgentMds<T>(
+  byAgentId: Record<string, string>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const dirs: string[] = [];
+  for (const [agentId, content] of Object.entries(byAgentId)) {
+    const dir = agentDir(agentId);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(agentClaudeMdPath(agentId), content);
+    dirs.push(dir);
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const dir of dirs) {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  }
+}
+
+function makeAgent(overrides: Partial<AgentRecord> & Pick<AgentRecord, "agentId">): AgentRecord {
+  return {
+    createdAt: "2026-01-01T00:00:00.000Z",
+    tags: ["general"],
+    issuesHandled: 0,
+    implementCount: 0,
+    pushbackCount: 0,
+    errorCount: 0,
+    lastActiveAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeIssue(overrides: Partial<IssueSummary> & Pick<IssueSummary, "id">): IssueSummary {
+  return {
+    title: `Issue ${overrides.id}`,
+    labels: [],
+    state: "open",
+    body: "",
+    ...overrides,
+  };
+}
+
+test("buildTickPrompt: inlines per-agent CLAUDE.md prose verbatim (deduped against seed)", async () => {
+  const seed = `# Project rules\n\n## Shared rule\nstays in seed.\n`;
+  const perAgent =
+    `## Shared rule\nshould be deduped — appears in seed too.\n\n` +
+    `## Specialty rule\nUNIQUE_PROSE_TOKEN_glibc_musl_loader\n`;
+  const agentId = "agent-test-prompt-prose-a";
+
+  await withTargetRepo(seed, async (targetRepoPath) => {
+    await withPerAgentMds({ [agentId]: perAgent }, async () => {
+      const prompt = await buildTickPrompt({
+        idleAgents: [makeAgent({ agentId, tags: ["sdk-binary"] })],
+        pendingIssues: [
+          makeIssue({ id: 99, title: "preflight", body: "glibc vs musl loader fix" }),
+        ],
+        cap: 1,
+        targetRepoPath,
+      });
+
+      assert.match(prompt, /UNIQUE_PROSE_TOKEN_glibc_musl_loader/);
+      assert.doesNotMatch(prompt, /should be deduped/);
+      assert.match(prompt, /Issue #99/);
+      assert.match(prompt, /glibc vs musl loader fix/);
+      assert.match(prompt, /## Agent agent-test-prompt-prose-a/);
+    });
+  });
+});
+
+test("buildTickPrompt: empty issue body renders as (empty), oversized body truncates", async () => {
+  const seed = `# Project rules\n`;
+  const agentId = "agent-test-prompt-issue-b";
+
+  await withTargetRepo(seed, async (targetRepoPath) => {
+    await withPerAgentMds({ [agentId]: "## solo\nminimal\n" }, async () => {
+      const longBody = "x".repeat(7000);
+      const prompt = await buildTickPrompt({
+        idleAgents: [makeAgent({ agentId })],
+        pendingIssues: [
+          makeIssue({ id: 1, body: "" }),
+          makeIssue({ id: 2, body: longBody }),
+        ],
+        cap: 2,
+        targetRepoPath,
+      });
+
+      assert.match(prompt, /Issue #1[^]*\(empty\)/);
+      // 6000-char cap trims the 7000-char body to 5997 chars + "..."
+      const issue2Match = prompt.match(/Issue #2[^]*?(?=\n\n##|\n\nOutput|$)/);
+      assert.ok(issue2Match, "issue 2 block should render");
+      assert.ok(
+        issue2Match![0].includes("...") && !issue2Match![0].includes("x".repeat(6500)),
+        "long body should be truncated to 6000 chars",
+      );
+    });
+  });
+});
+
+test("buildTickPrompt: byte-budget guard drops oldest agents to tag-only fallback", async () => {
+  // Budget math: each full agent block ≈ 4 KB (4000 A's + heading + meta).
+  // The internal builder reserves ~50 KB for framing prose. Setting the
+  // override to ~55 KB leaves ~5 KB for agent content — fits exactly one
+  // full block, so the second agent has to fall back to tag-only.
+  const seed = `# Project rules\n`;
+  const heavyProse = `## ${"H".repeat(40)}\n${"A".repeat(4000)}\n`;
+  const recent = "agent-test-prompt-recent-c";
+  const stale = "agent-test-prompt-stale-c";
+
+  await withTargetRepo(seed, async (targetRepoPath) => {
+    await withPerAgentMds(
+      { [recent]: heavyProse, [stale]: heavyProse },
+      async () => {
+        const prompt = await buildTickPrompt({
+          idleAgents: [
+            makeAgent({
+              agentId: stale,
+              tags: ["stale-tag"],
+              lastActiveAt: "2025-01-01T00:00:00.000Z",
+            }),
+            makeAgent({
+              agentId: recent,
+              tags: ["recent-tag"],
+              lastActiveAt: "2026-05-01T00:00:00.000Z",
+            }),
+          ],
+          pendingIssues: [makeIssue({ id: 7 })],
+          cap: 1,
+          targetRepoPath,
+          byteBudgetOverride: 55_000,
+        });
+
+        // Recent agent's heavy prose appears in full.
+        assert.match(prompt, new RegExp(`Agent ${recent}[^]*A{3000,}`));
+        // Stale agent gets the tag-only fallback marker.
+        assert.match(
+          prompt,
+          new RegExp(
+            `Agent ${stale}[^]*CLAUDE\\.md prose omitted under prompt-byte-budget`,
+          ),
+        );
+      },
+    );
+  });
+});
+
+test("buildTickPrompt: PROMPT_BYTE_BUDGET is large enough that 1 small agent + 1 small issue fits", async () => {
+  // Sanity check: production default budget is permissive on realistic inputs.
+  const seed = `# Project rules\n`;
+  const agentId = "agent-test-prompt-default-d";
+  await withTargetRepo(seed, async (targetRepoPath) => {
+    await withPerAgentMds({ [agentId]: "## small\nbody\n" }, async () => {
+      const prompt = await buildTickPrompt({
+        idleAgents: [makeAgent({ agentId })],
+        pendingIssues: [makeIssue({ id: 1, body: "small body" })],
+        cap: 1,
+        targetRepoPath,
+      });
+      assert.ok(prompt.length < PROMPT_BYTE_BUDGET);
+      assert.match(prompt, /## small/);
+    });
+  });
+});

--- a/src/orchestrator/prompt.ts
+++ b/src/orchestrator/prompt.ts
@@ -1,5 +1,11 @@
 import { isTwoPhaseRoutingEnabled, SPECIALIST_THRESHOLD } from "./routing.js";
+import {
+  readAgentClaudeMd,
+  readSeedClaudeMd,
+} from "../agent/specialization.js";
+import { stripOverlappingSections } from "../agent/prompt.js";
 import type { AgentRecord, IssueSummary } from "../types.js";
+import type { Logger } from "../log/logger.js";
 
 export interface TickPromptInput {
   pendingIssues: IssueSummary[];
@@ -11,19 +17,88 @@ export interface TickPromptInput {
    *  validator enforces this and the deterministic fallback honors it on
    *  failure. */
   preferAgentId?: string;
+  /**
+   * Path to the target repo's checkout. Used to read the project CLAUDE.md
+   * once and dedupe each per-agent CLAUDE.md against it (same logic
+   * `buildAgentSystemPrompt` uses for live-load). Without this, every
+   * agent block would re-ship the target-repo seed.
+   */
+  targetRepoPath: string;
+  /**
+   * Optional logger. When set, the prompt builder warn-logs which agents
+   * had their CLAUDE.md prose dropped under the byte-budget guard so
+   * post-hoc audits can see what the LLM actually saw.
+   */
+  logger?: Logger;
+  /**
+   * Test-only override of the soft byte budget. Production callers leave
+   * this unset; tests use a small value to exercise the truncation path.
+   */
+  byteBudgetOverride?: number;
 }
 
-export function buildTickPrompt(input: TickPromptInput): string {
-  const pending = input.pendingIssues.map((i) => ({
-    id: i.id,
-    title: i.title,
-    labels: i.labels,
-  }));
-  const idle = input.idleAgents.map((a) => ({
-    agentId: a.agentId,
-    tags: a.tags,
-    issuesHandled: a.issuesHandled,
-  }));
+/**
+ * Soft cap on assembled prompt byte size. ~2.5 MB ≈ 700K tokens at the
+ * ~3.5 chars/token rule of thumb — comfortably under Opus 4.7's 1M-context
+ * window even after orchestrator-side framing overhead. When the assembled
+ * prose exceeds this, agents are dropped (full prose → tags-only fallback)
+ * in least-recently-active order until the rest fits. The dropped agents
+ * remain dispatchable; they just give the LLM less prose to reason from.
+ * The deterministic fallback in `routing.ts` still works against the full
+ * set if the LLM under-dispatches.
+ */
+export const PROMPT_BYTE_BUDGET = 2_500_000;
+
+/**
+ * Per-issue body cap. Mirrors `truncate(detail.body, 6000)` at
+ * `src/orchestrator/triage.ts:280` — that's the load-bearing shape for
+ * issue bodies elsewhere in the orchestrator and the routing signal
+ * almost always lives in the first 6000 characters (issue title + first
+ * paragraph + scope notes).
+ */
+const ISSUE_BODY_MAX_CHARS = 6000;
+
+export async function buildTickPrompt(input: TickPromptInput): Promise<string> {
+  const seed = await readSeedClaudeMd(input.targetRepoPath);
+  const fullProseBlocks = await Promise.all(
+    input.idleAgents.map((agent) => renderAgentBlock(agent, input.targetRepoPath, seed)),
+  );
+
+  const issueBlocks = input.pendingIssues.map((issue) => renderIssueBlock(issue));
+
+  const budget = input.byteBudgetOverride ?? PROMPT_BYTE_BUDGET;
+  const issueBytes = issueBlocks.reduce((n, s) => n + s.length, 0);
+  // Reserve ~50 KB for routing-rule prose, error block, JSON shape, headings.
+  const agentBudget = Math.max(0, budget - issueBytes - 50_000);
+
+  // Most-recently-active agents win full prose; oldest get a tags-only
+  // fallback. Keeps the most-current specialization visible to the LLM
+  // when many agents compete for limited budget.
+  const orderedByActive = input.idleAgents
+    .map((agent, idx) => ({ agent, idx, fullBlock: fullProseBlocks[idx] }))
+    .sort((a, b) => Date.parse(b.agent.lastActiveAt) - Date.parse(a.agent.lastActiveAt));
+
+  let used = 0;
+  const droppedAgentIds: string[] = [];
+  const renderedBlocks: string[] = new Array(input.idleAgents.length);
+  for (const entry of orderedByActive) {
+    if (used + entry.fullBlock.length <= agentBudget) {
+      renderedBlocks[entry.idx] = entry.fullBlock;
+      used += entry.fullBlock.length;
+    } else {
+      const fallback = renderAgentTagFallback(entry.agent);
+      renderedBlocks[entry.idx] = fallback;
+      used += fallback.length;
+      droppedAgentIds.push(entry.agent.agentId);
+    }
+  }
+  if (droppedAgentIds.length > 0) {
+    input.logger?.warn("dispatcher.prompt_budget", {
+      droppedFullProseAgentIds: droppedAgentIds,
+      assembledAgentBytes: used,
+      agentBudget,
+    });
+  }
 
   const errorBlock = input.errorsFromPrior?.length
     ? `\n\nYour PRIOR proposal failed validation. Fix these and re-emit:\n${input.errorsFromPrior.map((e) => `- ${e}`).join("\n")}\n`
@@ -36,28 +111,71 @@ export function buildTickPrompt(input: TickPromptInput): string {
     input.preferAgentId !== undefined &&
     input.idleAgents.some((a) => a.agentId === input.preferAgentId);
   const preferBlock = preferredIsIdle
-    ? `\n\nOVERRIDE: the run was launched with --prefer-agent ${input.preferAgentId}. Assign that agent to one of the pending issues — natural Jaccard fit does not matter. Picking any other assignment for ${input.preferAgentId} when it is idle will fail validation.`
+    ? `\n\nOVERRIDE: the run was launched with --prefer-agent ${input.preferAgentId}. Assign that agent to one of the pending issues — natural fit does not matter. Picking any other assignment for ${input.preferAgentId} when it is idle will fail validation.`
     : "";
 
   const routingRule = isTwoPhaseRoutingEnabled()
-    ? `Routing rule (two-phase):
-- Phase A — specialists first. For each issue, prefer an agent whose tags overlap the issue's labels with Jaccard >= ${SPECIALIST_THRESHOLD}. Pick the highest-scoring agent x issue pair first; don't double-book a specialist if another also fits.
-- Phase B — fall back to a general agent (tags includes "general", <=3 tags total). General agents pick up issues with no specialist match.
+    ? `Routing rule (two-phase, prose-aware):
+- Phase A — specialists first. For each issue, read each agent's CLAUDE.md sections and pick the agent whose past lessons, past-incident citations, and accumulated domain coverage best match the issue body. Tags (Jaccard >= ${SPECIALIST_THRESHOLD}) are a sanity check; PROSE BEATS TAGS — an agent whose CLAUDE.md describes "glibc-vs-musl SDK loader" is a stronger fit for a glibc preflight issue than one merely tagged \`linux\`.
+- Phase B — fall back to a general agent (tags include "general", <=3 tags total, OR whose CLAUDE.md is mostly the seed with little accumulated specialization). Generals pick up issues with no clear specialist match.
 - Each agent gets at most ONE issue per tick. Each issue is assigned to at most ONE agent.
-- Emit AT MOST ${input.cap} assignment${input.cap === 1 ? "" : "s"}. Leaving slots empty is acceptable when no specialist OR general agent fits the remaining issues. If a specialist OR general agent IS available for an unmatched issue, you must assign it.`
-    : `Routing rule:
-- Prefer specialists by Jaccard overlap between agent.tags and issue.labels.
-- Brand-new general agents (tags == ["general"]) should pick up issues with no obvious specialist match.
+- Emit AT MOST ${input.cap} assignment${input.cap === 1 ? "" : "s"}. Leaving slots empty is acceptable when no specialist OR general agent fits. If a specialist OR general agent IS available for an unmatched issue, you must assign it.`
+    : `Routing rule (prose-aware):
+- For each issue, read each agent's CLAUDE.md sections and pick the agent whose past lessons, past-incident citations, and accumulated domain coverage best match the issue body. Tags are a sanity check; PROSE BEATS TAGS.
+- Brand-new general agents (mostly the seed CLAUDE.md, few accumulated sections) should pick up issues with no obvious specialist match.
 - Each agent gets at most ONE issue per tick. Each issue is assigned to at most ONE agent.
-- Emit EXACTLY ${input.cap} assignment${input.cap === 1 ? "" : "s"}. The cap reflects how many idle-agent x pending-issue pairs are available — leaving slots empty wastes parallelism. If the routing fit is weak, still assign — Jaccard overlap of 0 is acceptable when no better match exists.`;
+- Emit EXACTLY ${input.cap} assignment${input.cap === 1 ? "" : "s"}. The cap reflects how many idle-agent x pending-issue pairs are available — leaving slots empty wastes parallelism. If the prose match is weak, still assign — even a weak prose match beats waiting another tick.`;
 
-  return `You are the dispatcher for vp-dev. You assign idle agents to pending issues for ONE scheduling tick.
+  return `You are the dispatcher for vp-dev. You assign idle agents to pending issues for ONE scheduling tick. Decide based on the prose below — each agent's accumulated CLAUDE.md sections reveal real expertise far more accurately than a tag list.
 
 ${routingRule}
 
-Inputs (JSON):
-${JSON.stringify({ pending, idle, cap: input.cap }, null, 2)}${preferBlock}${errorBlock}
+# Idle agents (${input.idleAgents.length})
+
+${renderedBlocks.join("\n\n")}
+
+# Pending issues (${input.pendingIssues.length}, cap=${input.cap})
+
+${issueBlocks.join("\n\n")}${preferBlock}${errorBlock}
 
 Output ONLY valid JSON in this exact shape, no prose, no markdown:
 {"assignments":[{"agentId":"<id>","issueId":<number>}, ...]}`;
+}
+
+async function renderAgentBlock(
+  agent: AgentRecord,
+  targetRepoPath: string,
+  seed: string,
+): Promise<string> {
+  const rawClaudeMd = await readAgentClaudeMd(agent.agentId, targetRepoPath);
+  const deduped = stripOverlappingSections(rawClaudeMd, seed).trim();
+  const label = agent.name ? `${agent.name} [${agent.agentId}]` : agent.agentId;
+  const meta = [
+    `Tags: ${agent.tags.length === 0 ? "(none)" : agent.tags.join(", ")}`,
+    `Issues handled: ${agent.issuesHandled}`,
+    `Last active: ${agent.lastActiveAt}`,
+  ].join("\n");
+  const prose =
+    deduped.length > 0
+      ? deduped
+      : "(no agent-specific sections beyond the target-repo seed — generalist)";
+  return `## Agent ${label}\n${meta}\n\n${prose}`;
+}
+
+function renderAgentTagFallback(agent: AgentRecord): string {
+  const label = agent.name ? `${agent.name} [${agent.agentId}]` : agent.agentId;
+  const tags = agent.tags.length === 0 ? "(none)" : agent.tags.join(", ");
+  return `## Agent ${label}\nTags: ${tags}\nIssues handled: ${agent.issuesHandled}\nLast active: ${agent.lastActiveAt}\n\n(CLAUDE.md prose omitted under prompt-byte-budget — fall back to tag-based judgment for this agent.)`;
+}
+
+function renderIssueBlock(issue: IssueSummary): string {
+  const labels = issue.labels.length === 0 ? "(none)" : issue.labels.join(", ");
+  const body = issue.body.trim();
+  const truncatedBody =
+    body.length === 0
+      ? "(empty)"
+      : body.length <= ISSUE_BODY_MAX_CHARS
+        ? body
+        : body.slice(0, ISSUE_BODY_MAX_CHARS - 3) + "...";
+  return `## Issue #${issue.id}: ${issue.title}\nLabels: ${labels}\n\n${truncatedBody}`;
 }

--- a/src/orchestrator/setup.test.ts
+++ b/src/orchestrator/setup.test.ts
@@ -16,8 +16,8 @@ function basePreview(overrides: Partial<SetupPreview> = {}): SetupPreview {
     targetRepoPath: "/tmp/octocat-repo",
     rangeLabel: "100-110",
     openIssues: [
-      { id: 100, title: "first", state: "open", labels: [] },
-      { id: 110, title: "second", state: "open", labels: [] },
+      { id: 100, title: "first", state: "open", labels: [], body: "" },
+      { id: 110, title: "second", state: "open", labels: [], body: "" },
     ],
     closedSkipped: [],
     parallelism: 2,
@@ -221,7 +221,7 @@ test("formatSetupPreview: empty dependencyDeferred renders no skip block", () =>
 test("formatSetupPreview: non-empty dependencyDeferred renders the skip block + override hint", () => {
   const deferred = [
     {
-      issue: { id: 180, title: "Phase 3 advisory", state: "open" as const, labels: [] },
+      issue: { id: 180, title: "Phase 3 advisory", state: "open" as const, labels: [], body: "" },
       blockingVerdicts: [
         { ref: { issueId: 178 }, state: "open" as const },
       ],
@@ -237,7 +237,7 @@ test("formatSetupPreview: non-empty dependencyDeferred renders the skip block + 
 test("formatSetupPreview: dependencyForceIncluded renders WARNING block (not deferred block)", () => {
   const forceIncluded = [
     {
-      issue: { id: 180, title: "Phase 3 advisory", state: "open" as const, labels: [] },
+      issue: { id: 180, title: "Phase 3 advisory", state: "open" as const, labels: [], body: "" },
       blockingVerdicts: [
         { ref: { issueId: 178 }, state: "open" as const },
       ],
@@ -260,7 +260,7 @@ test("formatSetupPreview: dependency block drift changes the rendered text (prev
     basePreview({
       dependencyDeferred: [
         {
-          issue: { id: 50, title: "x", state: "open", labels: [] },
+          issue: { id: 50, title: "x", state: "open", labels: [], body: "" },
           blockingVerdicts: [{ ref: { issueId: 40 }, state: "open" }],
           reason: "depends on open #40 — re-dispatch after #40 lands",
         },
@@ -274,7 +274,7 @@ test("formatSetupPreview: dependency block drift changes the rendered text (prev
     basePreview({
       dependencyForceIncluded: [
         {
-          issue: { id: 50, title: "x", state: "open", labels: [] },
+          issue: { id: 50, title: "x", state: "open", labels: [], body: "" },
           blockingVerdicts: [{ ref: { issueId: 40 }, state: "open" }],
           reason: "depends on open #40 — re-dispatch after #40 lands",
         },

--- a/src/research/specialistBench/dispatch.ts
+++ b/src/research/specialistBench/dispatch.ts
@@ -102,6 +102,7 @@ export async function runBenchDispatch(
       title: "", // pickAgents doesn't use title — Jaccard is on labels
       labels,
       state: "open",
+      body: "",
     };
     const pickResult = pickAgents({
       reg,

--- a/src/types.ts
+++ b/src/types.ts
@@ -229,6 +229,14 @@ export interface IssueSummary {
   title: string;
   labels: string[];
   state: "open" | "closed";
+  /**
+   * Issue body markdown. Populated by the gh fetchers (`listOpenIssues`,
+   * `getIssue`, `resolveRangeToIssues`) so the dispatcher prompt can route
+   * on prose, not just labels. Empty string when GitHub returns a null body
+   * (issues with no description). Comments are NOT included here — see
+   * `IssueDetail` for that richer shape.
+   */
+  body: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

The orchestrator's per-tick LLM dispatcher already runs through Opus (`src/orchestrator/dispatcher.ts:54`), but the prompt at `src/orchestrator/prompt.ts:22-26` only fed it `{agentId, tags, issuesHandled}` per agent and `{id, title, labels}` per issue. The richest signals — each agent's accumulated `agents/<id>/CLAUDE.md` and the issue body — were dropped before the LLM got a vote. Tags are a lossy projection of CLAUDE.md prose: they collapse `"glibc-vs-musl SDK loader"` and `">5-file scope-fit check"` into the same flat strings, and reproduce the same loss on the issue side via GitHub labels.

This PR enriches the existing LLM dispatch path — no rewrite, no new module:

- **`buildTickPrompt`** now inlines each idle agent's full `CLAUDE.md` (deduped against the target-repo seed via the existing `stripOverlappingSections` helper at `src/agent/prompt.ts:217`) plus each pending issue's body text (truncated to 6000 chars, mirroring `src/orchestrator/triage.ts:280`). The routing rule reframes from "Jaccard ≥ 0.25" to "PROSE BEATS TAGS — read each agent's sections and pick by domain coverage."
- **Default dispatch model** bumps to `claude-opus-4-7[1m]` (1M-context variant). Total agent CLAUDE.md content across ~45 agents is ~370K tokens — overflows the standard 200K window. Env var `VP_DEV_DISPATCH_MODEL` already exists for downshifts.
- **`IssueSummary`** gains a required `body: string` field; `gh.ts` populates it from the same `gh issue list/view --json` calls (just adding `body` to the field list).
- **Token-budget guard** sorts agents by `lastActiveAt` and falls back to tag-only blocks for the oldest when the prompt approaches `PROMPT_BYTE_BUDGET` (2.5 MB / ~700K tokens). Most-recently-active agents win full prose.
- **Deterministic Jaccard scorer** in `routing.ts` stays unchanged as the LLM-failure safety net. Tags remain in the registry for operator UX (`vp-dev agents list`, `prune-tags`); they just no longer drive scoring in the LLM path.

## Cost trade-off (surfaced explicitly)

1M-context Opus pricing is roughly 2× standard Opus; at ~370K input tokens per tick, expect **~\$10–15 per dispatch tick**. A typical 5-issue run with 1–2 ticks ≈ \$15–30 dispatcher overhead, additive to the existing \$5–50 agent cost. This more than doubles dispatcher spend vs. status quo. Prompt caching would slash this on subsequent ticks; this codebase has zero caching today, so it's an obvious follow-up.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `npm test` — 982 tests pass (4 new in `src/orchestrator/prompt.test.ts` covering prose inlining + seed dedup, issue-body truncation, byte-budget guard fallback, default-budget sanity)
- [ ] Live smoke (post-merge or locally): `vp-dev run --plan --issues N..N+1` against 2-3 idle agents and verify `logs/<runId>.jsonl` `tick.llm_io` shows full prose entering the prompt and the LLM's reasoning references CLAUDE.md content the tag scorer couldn't see

🤖 Generated with [Claude Code](https://claude.com/claude-code)