### PR TITLE
feat(dispatcher): enable Anthropic prompt caching via SDK system-prompt boundary

### DIFF
--- a/src/orchestrator/dispatcher.ts
+++ b/src/orchestrator/dispatcher.ts
@@ -1,4 +1,7 @@
-import { query } from "@anthropic-ai/claude-agent-sdk";
+import {
+  query,
+  SYSTEM_PROMPT_DYNAMIC_BOUNDARY,
+} from "@anthropic-ai/claude-agent-sdk";
 import { buildTickPrompt } from "./prompt.js";
 import { claudeBinPath } from "../agent/sdkBinary.js";
 import { parseJsonEnvelope } from "../util/parseJsonEnvelope.js";
@@ -120,7 +123,7 @@ async function tryProposeWithLLM(opts: {
   preferAgentId?: string;
   targetRepoPath: string;
 }): Promise<ProposeOutcome> {
-  const prompt = await buildTickPrompt({
+  const { cacheStablePrefix, volatileSuffix } = await buildTickPrompt({
     pendingIssues: opts.pendingIssues,
     idleAgents: opts.idleAgents,
     cap: opts.cap,
@@ -131,11 +134,29 @@ async function tryProposeWithLLM(opts: {
   });
 
   let raw = "";
+  // Issue #268: capture cache hit/miss telemetry from the SDK usage block.
+  // `cache_creation_input_tokens` is the cost of *writing* the cache prefix
+  // (full input price); `cache_read_input_tokens` is the *cached read*
+  // (~10% of input price). Logging both lets post-hoc audits see when the
+  // dispatcher prefix is paying off.
+  let cacheCreationInputTokens = 0;
+  let cacheReadInputTokens = 0;
+  let inputTokens = 0;
+  let outputTokens = 0;
   try {
     const stream = query({
-      prompt,
+      // Issue #268: split into a cacheable system-prompt prefix and a
+      // volatile user-message suffix. The Agent SDK's `string[]`
+      // `systemPrompt` mode applies prompt-cache breakpoints at
+      // `SYSTEM_PROMPT_DYNAMIC_BOUNDARY`; blocks before the marker are
+      // eligible for cross-call cache hits, blocks after are not.
+      // Within the same dispatch call's validation-retry round-trip the
+      // cacheable prefix is byte-identical (only `errorsFromPrior` in
+      // the suffix changes), so attempt 2 reads the prefix from cache.
+      prompt: volatileSuffix,
       options: {
         model: ORCHESTRATOR_MODEL,
+        systemPrompt: [cacheStablePrefix, SYSTEM_PROMPT_DYNAMIC_BOUNDARY],
         tools: [],
         permissionMode: "default",
         env: process.env,
@@ -148,8 +169,18 @@ async function tryProposeWithLLM(opts: {
     for await (const msg of stream) {
       if (msg.type === "result") {
         // Forward whether success or error subtype — the SDK reports cost
-        // for both, and a failed dispatch still consumed tokens.
+        // for both, and a failed dispatch still consumed tokens. The
+        // `total_cost_usd` already reflects cached vs. uncached pricing
+        // (cache reads bill at ~10% of input rate, writes at ~125%), so
+        // the run-level cost line stays accurate without manual math.
         opts.costTracker?.add(msg.total_cost_usd);
+        const usage = msg.usage;
+        if (usage) {
+          cacheCreationInputTokens = usage.cache_creation_input_tokens ?? 0;
+          cacheReadInputTokens = usage.cache_read_input_tokens ?? 0;
+          inputTokens = usage.input_tokens ?? 0;
+          outputTokens = usage.output_tokens ?? 0;
+        }
         if (msg.subtype === "success") raw = msg.result;
         else return { errors: [`Orchestrator query failed: ${msg.subtype}`] };
       }
@@ -159,8 +190,14 @@ async function tryProposeWithLLM(opts: {
   }
 
   opts.logger.info("tick.llm_io", {
-    promptBytes: prompt.length,
+    promptBytes: cacheStablePrefix.length + volatileSuffix.length,
+    cacheStablePrefixBytes: cacheStablePrefix.length,
+    volatileSuffixBytes: volatileSuffix.length,
     responseBytes: raw.length,
+    inputTokens,
+    outputTokens,
+    cacheCreationInputTokens,
+    cacheReadInputTokens,
     response: raw.length > 4000 ? raw.slice(0, 4000) + "..." : raw,
   });
 

--- a/src/orchestrator/prompt.test.ts
+++ b/src/orchestrator/prompt.test.ts
@@ -80,7 +80,7 @@ test("buildTickPrompt: inlines per-agent CLAUDE.md prose verbatim (deduped again
 
   await withTargetRepo(seed, async (targetRepoPath) => {
     await withPerAgentMds({ [agentId]: perAgent }, async () => {
-      const prompt = await buildTickPrompt({
+      const { cacheStablePrefix, volatileSuffix } = await buildTickPrompt({
         idleAgents: [makeAgent({ agentId, tags: ["sdk-binary"] })],
         pendingIssues: [
           makeIssue({ id: 99, title: "preflight", body: "glibc vs musl loader fix" }),
@@ -89,11 +89,81 @@ test("buildTickPrompt: inlines per-agent CLAUDE.md prose verbatim (deduped again
         targetRepoPath,
       });
 
-      assert.match(prompt, /UNIQUE_PROSE_TOKEN_glibc_musl_loader/);
-      assert.doesNotMatch(prompt, /should be deduped/);
-      assert.match(prompt, /Issue #99/);
-      assert.match(prompt, /glibc vs musl loader fix/);
-      assert.match(prompt, /## Agent agent-test-prompt-prose-a/);
+      // Agent prose is in the cache-stable prefix.
+      assert.match(cacheStablePrefix, /UNIQUE_PROSE_TOKEN_glibc_musl_loader/);
+      assert.doesNotMatch(cacheStablePrefix, /should be deduped/);
+      assert.match(cacheStablePrefix, /## Agent agent-test-prompt-prose-a/);
+      // Issue list is in the volatile suffix.
+      assert.match(volatileSuffix, /Issue #99/);
+      assert.match(volatileSuffix, /glibc vs musl loader fix/);
+    });
+  });
+});
+
+test("buildTickPrompt: cache-stable prefix is byte-identical across validation-retry round-trips", async () => {
+  // Issue #268: the prefix MUST be byte-identical between attempt 1 and
+  // attempt 2 within a single dispatch call, otherwise the prompt-cache
+  // hit on retry — the highest-value win — is lost. The only delta
+  // between calls is `errorsFromPrior`; that lives in the volatile
+  // suffix and must NOT appear in the prefix.
+  const seed = `# Project rules\n`;
+  const agentId = "agent-test-prompt-cache-stable";
+  await withTargetRepo(seed, async (targetRepoPath) => {
+    await withPerAgentMds({ [agentId]: "## solo\nminimal\n" }, async () => {
+      const baseInput = {
+        idleAgents: [makeAgent({ agentId })],
+        pendingIssues: [makeIssue({ id: 5, body: "body" })],
+        cap: 1,
+        targetRepoPath,
+      };
+      const attempt1 = await buildTickPrompt(baseInput);
+      const attempt2 = await buildTickPrompt({
+        ...baseInput,
+        errorsFromPrior: ["agentId X is not idle / unknown."],
+      });
+
+      assert.equal(
+        attempt1.cacheStablePrefix,
+        attempt2.cacheStablePrefix,
+        "prefix must be byte-identical between retries",
+      );
+      // Suffix differs: attempt 2 carries the prior-error block.
+      assert.notEqual(attempt1.volatileSuffix, attempt2.volatileSuffix);
+      assert.match(attempt2.volatileSuffix, /PRIOR proposal failed validation/);
+      assert.doesNotMatch(attempt1.volatileSuffix, /PRIOR proposal failed validation/);
+      // Prefix never carries the error block.
+      assert.doesNotMatch(attempt2.cacheStablePrefix, /PRIOR proposal failed validation/);
+    });
+  });
+});
+
+test("buildTickPrompt: cap and pending issues live only in the volatile suffix, not the prefix", async () => {
+  // Issue #268: the cap text is part of the cap-directive line that
+  // moved into the suffix to keep the prefix cap-agnostic, so a tick
+  // where one agent goes busy (cap shrinks) still hits the cache.
+  const seed = `# Project rules\n`;
+  const agentId = "agent-test-prompt-cap-suffix";
+  await withTargetRepo(seed, async (targetRepoPath) => {
+    await withPerAgentMds({ [agentId]: "## solo\nminimal\n" }, async () => {
+      const cap1 = await buildTickPrompt({
+        idleAgents: [makeAgent({ agentId })],
+        pendingIssues: [makeIssue({ id: 1 }), makeIssue({ id: 2 })],
+        cap: 1,
+        targetRepoPath,
+      });
+      const cap2 = await buildTickPrompt({
+        idleAgents: [makeAgent({ agentId })],
+        pendingIssues: [makeIssue({ id: 1 }), makeIssue({ id: 2 })],
+        cap: 2,
+        targetRepoPath,
+      });
+      assert.equal(
+        cap1.cacheStablePrefix,
+        cap2.cacheStablePrefix,
+        "prefix must be cap-agnostic so cross-tick cap shrinkage still hits cache",
+      );
+      assert.match(cap1.volatileSuffix, /cap=1/);
+      assert.match(cap2.volatileSuffix, /cap=2/);
     });
   });
 });
@@ -105,7 +175,7 @@ test("buildTickPrompt: empty issue body renders as (empty), oversized body trunc
   await withTargetRepo(seed, async (targetRepoPath) => {
     await withPerAgentMds({ [agentId]: "## solo\nminimal\n" }, async () => {
       const longBody = "x".repeat(7000);
-      const prompt = await buildTickPrompt({
+      const { volatileSuffix } = await buildTickPrompt({
         idleAgents: [makeAgent({ agentId })],
         pendingIssues: [
           makeIssue({ id: 1, body: "" }),
@@ -115,9 +185,9 @@ test("buildTickPrompt: empty issue body renders as (empty), oversized body trunc
         targetRepoPath,
       });
 
-      assert.match(prompt, /Issue #1[^]*\(empty\)/);
+      assert.match(volatileSuffix, /Issue #1[^]*\(empty\)/);
       // 6000-char cap trims the 7000-char body to 5997 chars + "..."
-      const issue2Match = prompt.match(/Issue #2[^]*?(?=\n\n##|\n\nOutput|$)/);
+      const issue2Match = volatileSuffix.match(/Issue #2[^]*?(?=\n\n##|\n\nEmit|\n\nOutput|$)/);
       assert.ok(issue2Match, "issue 2 block should render");
       assert.ok(
         issue2Match![0].includes("...") && !issue2Match![0].includes("x".repeat(6500)),
@@ -141,7 +211,7 @@ test("buildTickPrompt: byte-budget guard drops oldest agents to tag-only fallbac
     await withPerAgentMds(
       { [recent]: heavyProse, [stale]: heavyProse },
       async () => {
-        const prompt = await buildTickPrompt({
+        const { cacheStablePrefix } = await buildTickPrompt({
           idleAgents: [
             makeAgent({
               agentId: stale,
@@ -161,10 +231,10 @@ test("buildTickPrompt: byte-budget guard drops oldest agents to tag-only fallbac
         });
 
         // Recent agent's heavy prose appears in full.
-        assert.match(prompt, new RegExp(`Agent ${recent}[^]*A{3000,}`));
+        assert.match(cacheStablePrefix, new RegExp(`Agent ${recent}[^]*A{3000,}`));
         // Stale agent gets the tag-only fallback marker.
         assert.match(
-          prompt,
+          cacheStablePrefix,
           new RegExp(
             `Agent ${stale}[^]*CLAUDE\\.md prose omitted under prompt-byte-budget`,
           ),
@@ -180,14 +250,14 @@ test("buildTickPrompt: PROMPT_BYTE_BUDGET is large enough that 1 small agent + 1
   const agentId = "agent-test-prompt-default-d";
   await withTargetRepo(seed, async (targetRepoPath) => {
     await withPerAgentMds({ [agentId]: "## small\nbody\n" }, async () => {
-      const prompt = await buildTickPrompt({
+      const { cacheStablePrefix, volatileSuffix } = await buildTickPrompt({
         idleAgents: [makeAgent({ agentId })],
         pendingIssues: [makeIssue({ id: 1, body: "small body" })],
         cap: 1,
         targetRepoPath,
       });
-      assert.ok(prompt.length < PROMPT_BYTE_BUDGET);
-      assert.match(prompt, /## small/);
+      assert.ok(cacheStablePrefix.length + volatileSuffix.length < PROMPT_BYTE_BUDGET);
+      assert.match(cacheStablePrefix, /## small/);
     });
   });
 });

--- a/src/orchestrator/prompt.ts
+++ b/src/orchestrator/prompt.ts
@@ -38,6 +38,36 @@ export interface TickPromptInput {
 }
 
 /**
+ * Issue #268: split prompt into a cache-stable prefix and a volatile
+ * suffix. The prefix carries the routing rule + per-agent CLAUDE.md prose
+ * (changes only when the summarizer fires after a successful run); the
+ * suffix carries pending issues, cap, prior-attempt errors, and the
+ * --prefer-agent override. Wiring this through `query({ systemPrompt:
+ * [prefix, SYSTEM_PROMPT_DYNAMIC_BOUNDARY], prompt: suffix, ... })` makes
+ * the prefix eligible for Anthropic prompt-cache hits across:
+ *
+ *  - Validation-retry within a single dispatch (errors-only delta).
+ *  - Cross-tick within a run when the idle agent set is unchanged.
+ *
+ * The 5-min cache TTL means the typical sub-minute tick spacing wins
+ * back ~90% of cache-stable input cost on hit.
+ */
+export interface TickPromptParts {
+  /**
+   * The cache-stable prefix. Identical between consecutive calls when
+   * idle agents and cap are stable, even if pending issues / errors /
+   * prefer-agent change.
+   */
+  cacheStablePrefix: string;
+  /**
+   * The volatile suffix. Always rebuilt; carries pending-issue list,
+   * --prefer-agent override, prior-attempt error block, and the
+   * JSON-shape directive.
+   */
+  volatileSuffix: string;
+}
+
+/**
  * Soft cap on assembled prompt byte size. ~2.5 MB ≈ 700K tokens at the
  * ~3.5 chars/token rule of thumb — comfortably under Opus 4.7's 1M-context
  * window even after orchestrator-side framing overhead. When the assembled
@@ -58,7 +88,7 @@ export const PROMPT_BYTE_BUDGET = 2_500_000;
  */
 const ISSUE_BODY_MAX_CHARS = 6000;
 
-export async function buildTickPrompt(input: TickPromptInput): Promise<string> {
+export async function buildTickPrompt(input: TickPromptInput): Promise<TickPromptParts> {
   const seed = await readSeedClaudeMd(input.targetRepoPath);
   const fullProseBlocks = await Promise.all(
     input.idleAgents.map((agent) => renderAgentBlock(agent, input.targetRepoPath, seed)),
@@ -114,32 +144,49 @@ export async function buildTickPrompt(input: TickPromptInput): Promise<string> {
     ? `\n\nOVERRIDE: the run was launched with --prefer-agent ${input.preferAgentId}. Assign that agent to one of the pending issues — natural fit does not matter. Picking any other assignment for ${input.preferAgentId} when it is idle will fail validation.`
     : "";
 
+  // Issue #268: routing rule rewritten to be cap-agnostic (cap appears
+  // only in the volatile suffix). Cap text moved to the suffix means the
+  // prefix stays byte-identical across ticks even when cap shrinks (e.g.
+  // an agent goes busy mid-run), which preserves cross-tick cache hits.
   const routingRule = isTwoPhaseRoutingEnabled()
     ? `Routing rule (two-phase, prose-aware):
 - Phase A — specialists first. For each issue, read each agent's CLAUDE.md sections and pick the agent whose past lessons, past-incident citations, and accumulated domain coverage best match the issue body. Tags (Jaccard >= ${SPECIALIST_THRESHOLD}) are a sanity check; PROSE BEATS TAGS — an agent whose CLAUDE.md describes "glibc-vs-musl SDK loader" is a stronger fit for a glibc preflight issue than one merely tagged \`linux\`.
 - Phase B — fall back to a general agent (tags include "general", <=3 tags total, OR whose CLAUDE.md is mostly the seed with little accumulated specialization). Generals pick up issues with no clear specialist match.
 - Each agent gets at most ONE issue per tick. Each issue is assigned to at most ONE agent.
-- Emit AT MOST ${input.cap} assignment${input.cap === 1 ? "" : "s"}. Leaving slots empty is acceptable when no specialist OR general agent fits. If a specialist OR general agent IS available for an unmatched issue, you must assign it.`
+- The cap on assignments per tick is provided in the pending-issues block below. Leaving slots empty is acceptable when no specialist OR general agent fits. If a specialist OR general agent IS available for an unmatched issue, you must assign it.`
     : `Routing rule (prose-aware):
 - For each issue, read each agent's CLAUDE.md sections and pick the agent whose past lessons, past-incident citations, and accumulated domain coverage best match the issue body. Tags are a sanity check; PROSE BEATS TAGS.
 - Brand-new general agents (mostly the seed CLAUDE.md, few accumulated sections) should pick up issues with no obvious specialist match.
 - Each agent gets at most ONE issue per tick. Each issue is assigned to at most ONE agent.
-- Emit EXACTLY ${input.cap} assignment${input.cap === 1 ? "" : "s"}. The cap reflects how many idle-agent x pending-issue pairs are available — leaving slots empty wastes parallelism. If the prose match is weak, still assign — even a weak prose match beats waiting another tick.`;
+- The cap on assignments per tick is provided in the pending-issues block below. Aim to fill the cap — empty slots waste parallelism. If the prose match is weak, still assign — even a weak prose match beats waiting another tick.`;
 
-  return `You are the dispatcher for vp-dev. You assign idle agents to pending issues for ONE scheduling tick. Decide based on the prose below — each agent's accumulated CLAUDE.md sections reveal real expertise far more accurately than a tag list.
+  // Cache-stable prefix: preamble + routing rule + idle-agent prose.
+  // Identical across the validation-retry round-trip and across ticks
+  // when the idle agent set is unchanged.
+  const cacheStablePrefix = `You are the dispatcher for vp-dev. You assign idle agents to pending issues for ONE scheduling tick. Decide based on the prose below — each agent's accumulated CLAUDE.md sections reveal real expertise far more accurately than a tag list.
 
 ${routingRule}
 
 # Idle agents (${input.idleAgents.length})
 
-${renderedBlocks.join("\n\n")}
+${renderedBlocks.join("\n\n")}`;
 
-# Pending issues (${input.pendingIssues.length}, cap=${input.cap})
+  // Volatile suffix: pending issues, cap, prefer-agent override, prior
+  // errors, output format directive. Rebuilt every call.
+  const capDirective = isTwoPhaseRoutingEnabled()
+    ? `Emit AT MOST ${input.cap} assignment${input.cap === 1 ? "" : "s"}.`
+    : `Emit EXACTLY ${input.cap} assignment${input.cap === 1 ? "" : "s"}.`;
 
-${issueBlocks.join("\n\n")}${preferBlock}${errorBlock}
+  const volatileSuffix = `# Pending issues (${input.pendingIssues.length}, cap=${input.cap})
+
+${issueBlocks.join("\n\n")}
+
+${capDirective}${preferBlock}${errorBlock}
 
 Output ONLY valid JSON in this exact shape, no prose, no markdown:
 {"assignments":[{"agentId":"<id>","issueId":<number>}, ...]}`;
+
+  return { cacheStablePrefix, volatileSuffix };
 }
 
 async function renderAgentBlock(


### PR DESCRIPTION
Closes #268.

## Summary

Enables Anthropic prompt caching on the dispatcher's per-tick `query()` calls by splitting the assembled prompt into a cache-stable prefix and a volatile suffix, and wiring them through the Agent SDK's `systemPrompt: string[]` + `SYSTEM_PROMPT_DYNAMIC_BOUNDARY` contract.

## SDK probe verdict (per Agent SDK Scope-Probing rule)

- SDK: `@anthropic-ai/claude-agent-sdk` (already installed).
- API surface: `systemPrompt?: string | string[] | { type: 'preset', ... }` accepts a `string[]` where the literal `SYSTEM_PROMPT_DYNAMIC_BOUNDARY` (re-exported from the package) marks the split between cacheable prefix and dynamic suffix. `node_modules/@anthropic-ai/claude-agent-sdk/sdk.d.ts:1687-1748` documents the contract; the constant ships at line 5302.
- Telemetry: `SDKResultMessage.usage` is `NonNullableUsage` (BetaUsage with `NonNullable<>` applied), so `cache_creation_input_tokens` and `cache_read_input_tokens` are exposed as `number` on every result.
- Decision: **adopt** — no need to switch to `@anthropic-ai/sdk` directly. None of the SDK conveniences (`claudeBinPath`, `msg.total_cost_usd`, error-subtype handling) need to change.

## Restructure

`buildTickPrompt` now returns `{ cacheStablePrefix, volatileSuffix }`:

| Section                                  | Where                  | Why                                                                 |
|------------------------------------------|------------------------|---------------------------------------------------------------------|
| "You are the dispatcher…" preamble       | cache-stable prefix    | constant per-build                                                  |
| Routing rule (two-phase / single-phase)  | cache-stable prefix    | rewritten to be cap-agnostic (cap text moved to suffix)             |
| `# Idle agents (N)` + per-agent prose    | cache-stable prefix    | per-agent CLAUDE.md changes only when the summarizer fires          |
| `# Pending issues (M, cap=K)` + bodies   | volatile suffix        | issue list shrinks per tick                                         |
| `Emit AT MOST/EXACTLY K assignment(s)`   | volatile suffix        | cap-dependent; suffix change means a cap shrink still hits cache    |
| `OVERRIDE: --prefer-agent …`             | volatile suffix        | per-run override, only for early ticks                              |
| `Your PRIOR proposal failed validation…` | volatile suffix        | retry-only; suffix-only delta means attempt 2 hits the prefix cache |
| `Output ONLY valid JSON…`                | volatile suffix        | tail of the user message                                            |

The dispatcher passes:

```ts
query({
  prompt: volatileSuffix,
  options: {
    model: ORCHESTRATOR_MODEL,
    systemPrompt: [cacheStablePrefix, SYSTEM_PROMPT_DYNAMIC_BOUNDARY],
    // …
  },
});
```

## Cache-hit windows

1. **Validation-retry within a single dispatch call** — guaranteed hit. The two `tryProposeWithLLM` calls inside `dispatch()` differ ONLY in `errorsFromPrior` (which lives in the suffix). Two new tests assert the prefix is byte-identical between attempt 1 and attempt 2.
2. **Cross-tick within a run** — hits when the idle agent set is unchanged. Cap-shrinkage no longer breaks the cache (cap moved to suffix). Per the issue's TTL caveat, sub-5min tick spacing keeps the cache warm.
3. **Cross-run** — cold by design (different `runId`s, agents may have been rewritten by the summarizer between runs).

## Telemetry

`tick.llm_io` now emits the cache breakdown so post-hoc audits can read hit-rate without re-running:

```jsonc
{
  "promptBytes": 412345,            // total = prefix + suffix
  "cacheStablePrefixBytes": 398721,
  "volatileSuffixBytes": 13624,
  "responseBytes": 142,
  "inputTokens": 23,                // non-cached input on this call
  "outputTokens": 81,
  "cacheCreationInputTokens": 0,    // > 0 on first miss; writes the prefix
  "cacheReadInputTokens": 100892,   // > 0 on hit; cached prefix tokens read
  "response": "…"
}
```

The cost tracker still reads `msg.total_cost_usd` directly — the SDK already applies cache pricing (reads at ~10% of input rate, writes at ~125%), so `state/<runId>.json` stays accurate with no manual math.

## Files

- `src/orchestrator/prompt.ts` — split return into `{ cacheStablePrefix, volatileSuffix }`; rewrite routing rule to be cap-agnostic; move cap directive into the suffix.
- `src/orchestrator/dispatcher.ts` — import `SYSTEM_PROMPT_DYNAMIC_BOUNDARY`; pass prefix as `systemPrompt`, suffix as `prompt`; capture `usage.cache_*_input_tokens` and emit in `tick.llm_io`.
- `src/orchestrator/prompt.test.ts` — update existing assertions to read the new return shape; add two new tests asserting prefix byte-identity across retry-round-trip and across cap-shrinkage.

## Test plan

- [x] `npm run build` passes.
- [x] `npm test` — all 984 tests pass, including the two new prefix-stability assertions.
- [ ] Smoke-test on a real `vp-dev run` to observe `cacheReadInputTokens > 0` on the second-and-later tick of the same run (acceptance criterion 4 — leaving as an operator follow-up since it requires live API spend).

— Cook (agent-fe90)
