### PR TITLE
fix(preflight): untrack node_modules placeholder + actionable error on missing deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Issue #264: keep both forms — `node_modules` (no slash) catches a stray
+# symlink (e.g. `node_modules -> ../../../node_modules` for worktree sharing)
+# that the directory-only pattern below would not match; `node_modules/`
+# (with slash) keeps the explicit directory-form ignore for clarity.
+node_modules
 node_modules/
 dist/
 *.log

--- a/bin/vp-dev.ts
+++ b/bin/vp-dev.ts
@@ -1,5 +1,16 @@
 #!/usr/bin/env node
 import { ensureFreshDist } from "../src/preflight.js";
+import { ensureNodeModules } from "../src/util/preflightNodeModules.js";
+
+// Bug #264: a tracked-empty `node_modules` placeholder could be silently
+// restored by `git checkout` / `git reset --hard`, leaving every subsequent
+// vp-dev invocation crashing with `ERR_MODULE_NOT_FOUND: 'commander'` from
+// the dynamic cli.js import below. Probe a known runtime dep here so the
+// failure mode reduces to a one-line "run npm ci" message + clean exit
+// instead of an opaque module-resolution stack trace. (The structural fix
+// — untracking the placeholder so .gitignore actually applies — ships in
+// the same PR.) Cheap to keep imported (pure stdlib + a require.resolve).
+ensureNodeModules();
 
 // Bug #39: stale dist/ silently runs old code. Rebuild + re-exec before any
 // further imports so the freshly-compiled module graph is what actually

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-../../../node_modules

--- a/src/util/preflightNodeModules.test.ts
+++ b/src/util/preflightNodeModules.test.ts
@@ -1,0 +1,79 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  PROBE_PACKAGE,
+  ensureNodeModules,
+  type PreflightNodeModulesDeps,
+} from "./preflightNodeModules.js";
+
+// Issue #264: when node_modules is wiped after a successful run, the bin
+// shim's dynamic import of cli.js fails with a misleading
+// `ERR_MODULE_NOT_FOUND: 'commander'` stack. ensureNodeModules() probes a
+// known runtime dep before that import and surfaces an actionable
+// "run npm ci" message + clean exit. Tests pin the two branches against
+// fully-injected dependencies — no real filesystem, no real exit — so the
+// suite is deterministic across hosts.
+
+interface CapturedExit {
+  code: number | null;
+  writes: string[];
+}
+
+function capturedDeps(
+  overrides: Partial<PreflightNodeModulesDeps> = {},
+): { deps: PreflightNodeModulesDeps; captured: CapturedExit } {
+  const captured: CapturedExit = { code: null, writes: [] };
+  const deps: PreflightNodeModulesDeps = {
+    resolveProbe: () => "/repo/node_modules/commander/package.json",
+    write: (s) => captured.writes.push(s),
+    exit: (c) => {
+      captured.code = c;
+      // Throw a sentinel so test code can assert exit was called without
+      // actually terminating the test runner. The production code's exit
+      // type is `never`, so callers don't observe the throw in practice.
+      throw new Error(`__exit__:${c}`);
+    },
+    ...overrides,
+  };
+  return { deps, captured };
+}
+
+test("ensureNodeModules: probe resolves → ok, no write, no exit", () => {
+  const { deps, captured } = capturedDeps();
+  const r = ensureNodeModules(deps);
+  assert.deepEqual(r, { ok: true });
+  assert.equal(captured.code, null);
+  assert.equal(captured.writes.length, 0);
+});
+
+test("ensureNodeModules: probe fails → write 'npm ci' message and exit(1)", () => {
+  const { deps, captured } = capturedDeps({ resolveProbe: () => null });
+  assert.throws(() => ensureNodeModules(deps), /__exit__:1/);
+  assert.equal(captured.code, 1);
+  assert.equal(captured.writes.length, 1);
+  const msg = captured.writes[0];
+  assert.match(msg, /dependencies missing/);
+  assert.match(msg, /commander/);
+  assert.match(msg, /npm ci/);
+  assert.match(msg, /#264/);
+});
+
+test("PROBE_PACKAGE is commander (bare main entry)", () => {
+  // commander is the first npm dep the CLI imports; the probe must stay
+  // bound to it so the preflight tracks the actual import contract. If the
+  // CLI's first dep ever changes, this assertion forces us to update the
+  // probe in the same PR. Bare name (not "commander/package.json"): commander
+  // doesn't expose `./package.json` via its exports map, so a subpath probe
+  // would always fail with ERR_PACKAGE_PATH_NOT_EXPORTED even when installed.
+  assert.equal(PROBE_PACKAGE, "commander");
+});
+
+test("ensureNodeModules: real default probe resolves commander in this checkout", () => {
+  // Sanity check on the production resolve path — confirms the bare-name
+  // probe actually finds commander on a fresh checkout where this PR's
+  // structural fix (untracked node_modules) is in place. If commander is
+  // missing the test runner itself wouldn't have been able to import this
+  // file, so a passing assertion here means the probe agrees with reality.
+  const r = ensureNodeModules();
+  assert.deepEqual(r, { ok: true });
+});

--- a/src/util/preflightNodeModules.ts
+++ b/src/util/preflightNodeModules.ts
@@ -1,0 +1,69 @@
+/**
+ * Issue #264: detect a missing/empty `node_modules` BEFORE the bin shim
+ * dynamically imports `../src/cli.js` (which immediately imports
+ * `commander`). When `node_modules` has been wiped — most reliably reproduced
+ * after a `git checkout` / `git reset --hard` accidentally restoring a
+ * tracked-empty placeholder — every subsequent `vp-dev <subcommand>` invocation
+ * crashes with a `ERR_MODULE_NOT_FOUND: 'commander' from dist/src/cli.js` stack
+ * trace. The trace is technically accurate but unhelpful: the operator's next
+ * action is `npm ci`, and the stack does not say so.
+ *
+ * Strategy: pick a small, always-imported runtime dependency (`commander`),
+ * try to resolve it from the bin shim's directory, and on miss surface a
+ * one-line "run `npm ci`" message + clean non-zero exit. Keeps the failure
+ * mode self-explanatory without changing the build / dispatch semantics.
+ *
+ * Defense in depth, not a fix for the wipe itself. The structural fix
+ * — untracking `node_modules` so it can no longer be silently restored to
+ * a tracked-empty state — ships in the same PR.
+ */
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+export interface PreflightNodeModulesDeps {
+  resolveProbe?: (spec: string) => string | null;
+  write?: (s: string) => void;
+  exit?: (code: number) => never;
+}
+
+export type PreflightNodeModulesResult = { ok: true } | { ok: false; reason: string };
+
+/** The probe dependency. `commander` is the first npm package the CLI imports
+ * (via `src/cli.ts`), so its presence is a sufficient proxy for "node_modules
+ * is populated enough for vp-dev to start." Use the bare package name (the
+ * main entry) — `commander/package.json` is not in commander's `exports` map
+ * and would always fail with `ERR_PACKAGE_PATH_NOT_EXPORTED` even when
+ * commander is correctly installed. */
+export const PROBE_PACKAGE = "commander";
+
+export function ensureNodeModules(deps: PreflightNodeModulesDeps = {}): PreflightNodeModulesResult {
+  const resolve = deps.resolveProbe ?? defaultResolveProbe;
+  const write = deps.write ?? ((s) => process.stderr.write(s));
+  const exit = deps.exit ?? ((c) => process.exit(c) as never);
+
+  const resolved = resolve(PROBE_PACKAGE);
+  if (resolved !== null) return { ok: true };
+
+  const reason =
+    `vp-dev: dependencies missing — could not resolve '${PROBE_PACKAGE}' from node_modules.\n` +
+    `  Run 'npm ci' from the repo root to install dependencies, then re-run vp-dev.\n` +
+    `  (See issue #264: a tracked-empty node_modules placeholder could be restored by\n` +
+    `   'git checkout' / 'git reset --hard'; this PR also untracks the placeholder.)\n`;
+  write(reason);
+  exit(1);
+  return { ok: false, reason };
+}
+
+function defaultResolveProbe(spec: string): string | null {
+  try {
+    // Anchor resolution at this module's directory so the probe walks the
+    // same node_modules chain that the dynamic `import("../src/cli.js")`
+    // would walk a moment later. createRequire on import.meta.url gives a
+    // local resolver attached to dist/src/util/preflightNodeModules.js.
+    const here = fileURLToPath(import.meta.url);
+    const req = createRequire(here);
+    return req.resolve(spec);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #264

## Summary

`vp-dev status` (and any other subcommand) crashed with a misleading `ERR_MODULE_NOT_FOUND: 'commander' from dist/src/cli.js` after a successful run. Root cause: `node_modules` was tracked as a symlink (mode 120000, `node_modules -> ../../../node_modules`) accidentally introduced by `2594598` ("refactor: relocate experiment data + bundles to research/"). `.gitignore` listed `node_modules/` (trailing slash) which only matches directories — the symlink stayed tracked. A `git checkout` / `git reset --hard` could silently restore the empty placeholder, wiping the populated install; the next `vp-dev` invocation then failed because `import("../src/cli.js")` could no longer resolve `commander`.

## Scope choice

**Option 1 + Option 2** from the issue body — surfaced explicitly because the issue noted "operator's call which scope is right":

1. **Structural (option 1)**: untrack the symlink and extend `.gitignore` to include `node_modules` (no slash) so any future symlink at that path is ignored, not just a directory. Node's standard module resolution walks parent directories, so worktrees that previously relied on the symlink for shared `node_modules` still resolve dependencies via the main worktree's installation — no per-worktree `npm ci` required (verified locally: build + 986 tests pass in this worktree without the symlink).

2. **Defense in depth (option 2)**: new `ensureNodeModules()` preflight in `src/util/preflightNodeModules.ts`, wired into `bin/vp-dev.ts` BEFORE the dynamic `import("../src/cli.js")`. Probes `commander` (the bare main entry — `commander/package.json` is not in commander's `exports` map and would always fail with `ERR_PACKAGE_PATH_NOT_EXPORTED`). On miss, writes a one-line `npm ci` instruction and exits(1) cleanly instead of dumping a node ESM stack trace. Mirrors the dependency-injection pattern already used by `preflightSdkBinary` for testability.

**Option 3** (audit agent workdirs for stray `git clean`/`reset --hard`) deferred until post-merge observation confirms whether option 1 alone stops the wipes — no need to harden agent isolation if the structural fix removes the restorable placeholder.

## Files

- `.gitignore` — added `node_modules` (no slash) above the existing `node_modules/` directory pattern, with a comment explaining the symlink case.
- `node_modules` (deleted) — symlink untracked.
- `src/util/preflightNodeModules.ts` — new module, dependency-injectable `ensureNodeModules()`.
- `src/util/preflightNodeModules.test.ts` — 4 tests: probe-OK path, probe-fail write+exit path, `PROBE_PACKAGE` constant, real default-probe sanity.
- `bin/vp-dev.ts` — calls `ensureNodeModules()` before `ensureFreshDist()`.

## Test plan

- [x] `npm run build` — passes.
- [x] `npm test` — 986/986 pass (was 982; +3 new test cases + 1 sanity test).
- [x] `node dist/bin/vp-dev.js --help` — preflight runs silently, CLI starts as before.
- [ ] After merge, run a full `vp-dev run --plan` + `--confirm` cycle and verify subsequent `vp-dev status` keeps working without an `npm ci` between them.

## Operator note

While preparing this fix I accidentally Edit/Write'd into the main worktree first (using absolute paths under `vaultpilot-dev-framework/` instead of `vaultpilot-dev-framework/.claude/worktrees/agent-92ff-issue-264/`). I reverted the main-worktree `.gitignore` and `bin/vp-dev.ts` edits in place, but `rm` on absolute paths outside the agent cwd is gate-blocked, so two stray files remain in the main worktree:

- `<repo-root>/src/preflightNodeModules.ts`
- `<repo-root>/src/preflightNodeModules.test.ts`

They are untracked (not in any commit, not in this PR), don't match the `npm test` patterns, and only consume disk in the main worktree. Cleanup: `rm <repo-root>/src/preflightNodeModules.ts <repo-root>/src/preflightNodeModules.test.ts`.

— Alonzo (agent-92ff)
