### PR TITLE
study(super-agent-curve): prep scripts for Phase A-E

### DIFF
--- a/research/curve-redo-bundle/super-agent/build-super-agent.cjs
+++ b/research/curve-redo-bundle/super-agent/build-super-agent.cjs
@@ -56,6 +56,14 @@ const TARGET_AGENT_NAME = "Super";
 const TARGET_AGENT_TAGS = ["super-agent"];
 const MIN_CLUSTER_SIZE = Number(process.env.MIN_CLUSTER_SIZE || 3);
 const DRY_RUN = process.env.DRY_RUN === "1";
+// SKIP_MERGE=1 bypasses the Opus dedup step entirely and writes the pooled
+// sentinel-tagged sections verbatim. Use when the pool is small enough that
+// the deduper underclusters anyway (cross-agent prose has more semantic
+// divergence than within-agent near-duplicates) and the experiment wants a
+// larger S for grid resolution. Trade-off: any genuine cross-agent
+// duplication (e.g. seed-derived summarizer outputs that happen to land
+// identical) carries through to the super-agent's CLAUDE.md.
+const SKIP_MERGE = process.env.SKIP_MERGE === "1";
 
 function requireDist(rel) {
   const p = path.join(DIST, rel);
@@ -75,7 +83,16 @@ function readClaudeMdForAgent(agentId) {
 }
 
 function isEligible(a) {
-  if (a.agentId.startsWith("agent-916a-trim-")) return false;
+  // Exclude every trim-suffix family — `agent-916a-trim-*` is from #179 leg-2,
+  // `agent-super-trim-*` is what build-super-trims.cjs mints AFTER this script
+  // runs once. Re-running Phase A without the broader filter pulls a previous
+  // run's trims back into the pool (their CLAUDE.mds are subsets of the
+  // existing super-agent), producing a near-doubled output dominated by
+  // duplicate sections. Sister exclusion: the previously-minted `agent-super`
+  // itself — its CLAUDE.md is already a deduped union, re-pooling it is the
+  // same self-feed problem.
+  if (/-trim-/.test(a.agentId)) return false;
+  if (a.agentId === "agent-super") return false;
   if (a.agentId === "agent-8274") return false;
   if (a.archived) return false;
   if (a.mergedInto) return false;
@@ -140,7 +157,7 @@ async function main() {
   process.stderr.write(`[build-super-agent] sentinel-tagged sections: ${pooledParsed.length} (sum across contributors: ${totalParsedSections})\n`);
   process.stderr.write(`[build-super-agent] minClusterSize: ${MIN_CLUSTER_SIZE}\n`);
 
-  if (pooledParsed.length < MIN_CLUSTER_SIZE) {
+  if (pooledParsed.length < MIN_CLUSTER_SIZE && !SKIP_MERGE) {
     process.stderr.write(`ERROR: pooled MD has ${pooledParsed.length} attributable sections — below minClusterSize=${MIN_CLUSTER_SIZE}. Compaction would no-op.\n`);
     process.exit(3);
   }
@@ -162,15 +179,28 @@ async function main() {
   };
 
   process.stderr.write(`[build-super-agent] tag union: ${tagsUnion.length} tags\n`);
-  process.stderr.write(`[build-super-agent] dispatching proposeCompaction (model=${process.env.VP_DEV_ORCHESTRATOR_MODEL_SPLIT || "<default opus>"})...\n`);
 
-  const t0 = Date.now();
-  const proposal = await compactMod.proposeCompaction({
-    agent: synthetic,
-    claudeMd: pooled,
-    minClusterSize: MIN_CLUSTER_SIZE,
-  });
-  const elapsedMs = Date.now() - t0;
+  let proposal;
+  let elapsedMs = 0;
+  if (SKIP_MERGE) {
+    process.stderr.write("[build-super-agent] SKIP_MERGE=1 — skipping Opus dedup; pooling raw sentinel sections.\n");
+    proposal = {
+      clusters: [],
+      unclusteredSectionIds: pooledParsed.map((s) => s.sectionId),
+      estimatedBytesSaved: 0,
+      warnings: [],
+      notes: "SKIP_MERGE=1: raw pool (no Opus dedup).",
+    };
+  } else {
+    process.stderr.write(`[build-super-agent] dispatching proposeCompaction (model=${process.env.VP_DEV_ORCHESTRATOR_MODEL_SPLIT || "<default opus>"})...\n`);
+    const t0 = Date.now();
+    proposal = await compactMod.proposeCompaction({
+      agent: synthetic,
+      claudeMd: pooled,
+      minClusterSize: MIN_CLUSTER_SIZE,
+    });
+    elapsedMs = Date.now() - t0;
+  }
 
   process.stderr.write(`[build-super-agent] proposeCompaction returned in ${(elapsedMs/1000).toFixed(1)}s\n`);
   process.stderr.write(`[build-super-agent]   clusters proposed:     ${proposal.clusters.length}\n`);
@@ -251,7 +281,7 @@ Compaction model output: ${proposal.clusters.length} merged clusters, ${proposal
   process.stderr.write(`[build-super-agent] rendered super-agent CLAUDE.md: ${renderedBytes} bytes (${(renderedBytes/1024).toFixed(1)} KB)\n`);
   process.stderr.write(`[build-super-agent] retention vs pooled input: ${retentionPct.toFixed(1)}%\n`);
 
-  if (retentionPct < 25 || retentionPct > 50) {
+  if (!SKIP_MERGE && (retentionPct < 25 || retentionPct > 50)) {
     process.stderr.write(`WARN: retention ${retentionPct.toFixed(1)}% outside acceptance range [25%, 50%]. Plan suggests rerun with MIN_CLUSTER_SIZE=${retentionPct < 25 ? 4 : 2}.\n`);
   }
 

--- a/research/curve-redo-bundle/super-agent/build-super-agent.cjs
+++ b/research/curve-redo-bundle/super-agent/build-super-agent.cjs
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+// Super-agent build (Phase A of feature-plans/super-agent-curve-experiment-plan.md):
+// pool every eligible agent's CLAUDE.md into a single `agent-super` CLAUDE.md
+// via Opus-driven cross-agent dedup.
+//
+// Eligibility: drop `agent-916a-trim-*`, `archived: true`, `mergedInto != null`,
+// the naive `agent-8274`. (The plan estimated ~47 agents / ~1.3 MB; the actual
+// machine state may have fewer materialized CLAUDE.mds — the eligibility filter
+// returns only those with a real file present, falling back to the snapshot
+// under `.claude/agents-snapshot/agents/<id>/CLAUDE.md` when the live file is
+// missing. The retention gate below decides whether the result is usable.)
+//
+// Steps:
+//   1. Filter the registry to eligible agents and read each agent's CLAUDE.md.
+//   2. Concatenate into a synthetic super-pool MD with provenance-prefixed
+//      sectionIds (`<agentId>:s<n>`) so the post-merge cluster output traces
+//      back to a contributor.
+//   3. Call `proposeCompaction()` with the pooled MD and a synthetic
+//      `agent-super-pool` AgentRecord. The compaction system prompt at
+//      compactClaudeMd.ts:438-462 mandates preservation of past-incident dates,
+//      mechanisms, "Tells" / "How to apply" — exactly the union semantics needed.
+//   4. Hard-gate on `findDroppedIncidentDates` and `findClampedBodies`: if any
+//      cluster has warnings, abort without minting. The proposal is
+//      authoritative; we don't apply a half-merged file.
+//   5. Render the super-agent file: walk pooled sections in source order;
+//      replace clustered members with `renderMergedBlock` at the canonical
+//      (earliest) position, drop the rest; emit unclustered sections verbatim.
+//   6. Mint `agent-super` via `ensureAgent` (explicit ID, set name + tags
+//      directly on the record) and write the rendered file to
+//      `agents/agent-super/CLAUDE.md`.
+//
+// Acceptance: retention % ∈ [25%, 50%] of input AND zero validator warnings.
+// Outside that range, rerun with `MIN_CLUSTER_SIZE=2` (more aggressive) or
+// `MIN_CLUSTER_SIZE=4` (less aggressive).
+//
+// Usage:
+//   npm run build && node research/curve-redo-bundle/super-agent/build-super-agent.cjs
+//
+// Env overrides:
+//   MIN_CLUSTER_SIZE   override proposeCompaction's minClusterSize (default 3)
+//   AGENT_ID           override the minted ID (default "agent-super")
+//   DRY_RUN            "1" → run dedup + render but skip mint + write
+
+"use strict";
+
+const path = require("node:path");
+const fs = require("node:fs");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const DIST = path.join(REPO_ROOT, "dist", "src");
+const SNAPSHOT_AGENTS = path.join(REPO_ROOT, ".claude", "agents-snapshot", "agents");
+const AGENTS_DIR = path.join(REPO_ROOT, "agents");
+const REGISTRY_FILE = path.join(REPO_ROOT, "state", "agents-registry.json");
+const TARGET_AGENT_ID = process.env.AGENT_ID || "agent-super";
+const TARGET_AGENT_NAME = "Super";
+const TARGET_AGENT_TAGS = ["super-agent"];
+const MIN_CLUSTER_SIZE = Number(process.env.MIN_CLUSTER_SIZE || 3);
+const DRY_RUN = process.env.DRY_RUN === "1";
+
+function requireDist(rel) {
+  const p = path.join(DIST, rel);
+  if (!fs.existsSync(p)) {
+    process.stderr.write(`ERROR: ${p} missing — run \`npm run build\` first.\n`);
+    process.exit(1);
+  }
+  return require(p);
+}
+
+function readClaudeMdForAgent(agentId) {
+  const live = path.join(AGENTS_DIR, agentId, "CLAUDE.md");
+  if (fs.existsSync(live)) return { source: "live", text: fs.readFileSync(live, "utf-8") };
+  const snap = path.join(SNAPSHOT_AGENTS, agentId, "CLAUDE.md");
+  if (fs.existsSync(snap)) return { source: "snap", text: fs.readFileSync(snap, "utf-8") };
+  return null;
+}
+
+function isEligible(a) {
+  if (a.agentId.startsWith("agent-916a-trim-")) return false;
+  if (a.agentId === "agent-8274") return false;
+  if (a.archived) return false;
+  if (a.mergedInto) return false;
+  return true;
+}
+
+async function main() {
+  const compactMod = requireDist(path.join("agent", "compactClaudeMd.js"));
+  const splitMod = requireDist(path.join("agent", "split.js"));
+  const registryMod = requireDist(path.join("state", "registry.js"));
+  const specMod = requireDist(path.join("agent", "specialization.js"));
+
+  if (!fs.existsSync(REGISTRY_FILE)) {
+    process.stderr.write(`ERROR: ${REGISTRY_FILE} missing.\n`);
+    process.exit(1);
+  }
+  const reg = JSON.parse(fs.readFileSync(REGISTRY_FILE, "utf-8"));
+  const eligible = reg.agents.filter(isEligible);
+  const contributors = [];
+  for (const a of eligible) {
+    const md = readClaudeMdForAgent(a.agentId);
+    if (!md) continue;
+    contributors.push({ agentId: a.agentId, source: md.source, text: md.text, tags: a.tags || [] });
+  }
+  if (contributors.length === 0) {
+    process.stderr.write("ERROR: no eligible contributors with a CLAUDE.md.\n");
+    process.exit(2);
+  }
+
+  // Build a pooled CLAUDE.md by concatenating each contributor's parsed
+  // sections. We re-emit the original sentinel header verbatim — that's what
+  // `parseClaudeMdSections` (compactClaudeMd's input) already keys on, so the
+  // run/issue provenance carries into the proposal. Per-contributor preambles
+  // (everything before the first sentinel) are dropped since they're seed
+  // boilerplate that would otherwise dominate the input bytes.
+  let pooled = "";
+  let totalInputBytes = 0;
+  let totalParsedSections = 0;
+  const perAgentSections = [];
+  for (const c of contributors) {
+    totalInputBytes += Buffer.byteLength(c.text, "utf-8");
+    const sections = splitMod.parseClaudeMdSections(c.text);
+    totalParsedSections += sections.length;
+    perAgentSections.push({ agentId: c.agentId, count: sections.length });
+    if (sections.length === 0) continue;
+    // Slice the contributor's CLAUDE.md from the first sentinel onward — that
+    // preserves the verbatim sentinels for the parser. The first sentinel's
+    // index isn't surfaced by parseClaudeMdSections, so locate it via the
+    // same regex shape the parser uses.
+    const firstSentinel = c.text.search(/<!--\s*run:\S+\s+issue:#\d+/);
+    if (firstSentinel < 0) continue;
+    pooled += c.text.slice(firstSentinel);
+    if (!pooled.endsWith("\n")) pooled += "\n";
+  }
+  const pooledBytes = Buffer.byteLength(pooled, "utf-8");
+  const pooledParsed = splitMod.parseClaudeMdSections(pooled);
+
+  process.stderr.write(`[build-super-agent] eligible agents: ${eligible.length}\n`);
+  process.stderr.write(`[build-super-agent] contributors with CLAUDE.md: ${contributors.length}\n`);
+  process.stderr.write(`[build-super-agent] input bytes (raw): ${totalInputBytes} (${(totalInputBytes/1024).toFixed(1)} KB)\n`);
+  process.stderr.write(`[build-super-agent] pooled bytes (post-preamble-strip): ${pooledBytes} (${(pooledBytes/1024).toFixed(1)} KB)\n`);
+  process.stderr.write(`[build-super-agent] sentinel-tagged sections: ${pooledParsed.length} (sum across contributors: ${totalParsedSections})\n`);
+  process.stderr.write(`[build-super-agent] minClusterSize: ${MIN_CLUSTER_SIZE}\n`);
+
+  if (pooledParsed.length < MIN_CLUSTER_SIZE) {
+    process.stderr.write(`ERROR: pooled MD has ${pooledParsed.length} attributable sections — below minClusterSize=${MIN_CLUSTER_SIZE}. Compaction would no-op.\n`);
+    process.exit(3);
+  }
+
+  // Synthetic AgentRecord shape that proposeCompaction expects: agentId +
+  // tags. The agentId is informational (lands in the proposal's `agentId`
+  // field); tags are echoed in the user prompt.
+  const tagsUnion = Array.from(new Set(contributors.flatMap((c) => c.tags))).sort();
+  const synthetic = {
+    agentId: "agent-super-pool",
+    name: "SuperPool",
+    createdAt: new Date().toISOString(),
+    tags: tagsUnion,
+    issuesHandled: 0,
+    implementCount: 0,
+    pushbackCount: 0,
+    errorCount: 0,
+    lastActiveAt: new Date().toISOString(),
+  };
+
+  process.stderr.write(`[build-super-agent] tag union: ${tagsUnion.length} tags\n`);
+  process.stderr.write(`[build-super-agent] dispatching proposeCompaction (model=${process.env.VP_DEV_ORCHESTRATOR_MODEL_SPLIT || "<default opus>"})...\n`);
+
+  const t0 = Date.now();
+  const proposal = await compactMod.proposeCompaction({
+    agent: synthetic,
+    claudeMd: pooled,
+    minClusterSize: MIN_CLUSTER_SIZE,
+  });
+  const elapsedMs = Date.now() - t0;
+
+  process.stderr.write(`[build-super-agent] proposeCompaction returned in ${(elapsedMs/1000).toFixed(1)}s\n`);
+  process.stderr.write(`[build-super-agent]   clusters proposed:     ${proposal.clusters.length}\n`);
+  process.stderr.write(`[build-super-agent]   unclustered sections:  ${proposal.unclusteredSectionIds.length}\n`);
+  process.stderr.write(`[build-super-agent]   estimated bytes saved: ${proposal.estimatedBytesSaved}\n`);
+  process.stderr.write(`[build-super-agent]   validator warnings:    ${proposal.warnings.length}\n`);
+  if (proposal.notes) process.stderr.write(`[build-super-agent]   notes: ${proposal.notes}\n`);
+  if (proposal.warnings.length > 0) {
+    for (const w of proposal.warnings) {
+      if (w.kind === "dropped-incident-date") {
+        process.stderr.write(`    ⚠ DROPPED DATES cluster=${w.clusterIndex}: ${w.missingDates.join(", ")} (from ${w.fromSectionIds.join(", ")})\n`);
+      } else {
+        process.stderr.write(`    ⚠ CLAMPED cluster=${w.clusterIndex}: ${w.fields.join(", ")}\n`);
+      }
+    }
+    process.stderr.write("ERROR: validator warnings must be 0 before applying. Rerun (possibly with a different MIN_CLUSTER_SIZE) to get a clean proposal.\n");
+    process.exit(4);
+  }
+
+  // Render the merged file. Walk pooledParsed in source order; for clustered
+  // sections, emit `renderMergedBlock` at the canonical (earliest-position)
+  // member; drop the rest. Unclustered sections render verbatim from the
+  // pooled input via their sentinel + heading + body.
+  const runId = `merge-super-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+  const ts = new Date().toISOString();
+  const sectionIdToIdx = new Map(pooledParsed.map((s, i) => [s.sectionId, i]));
+
+  // Map cluster -> canonical sectionId (earliest position) and skip-set.
+  const clusterByCanonicalId = new Map();
+  const skipIds = new Set();
+  for (const c of proposal.clusters) {
+    let bestIdx = Infinity;
+    let canonicalId = c.sectionIds[0];
+    for (const sid of c.sectionIds) {
+      const idx = sectionIdToIdx.get(sid);
+      if (idx === undefined) continue;
+      if (idx < bestIdx) { bestIdx = idx; canonicalId = sid; }
+    }
+    clusterByCanonicalId.set(canonicalId, c);
+    for (const sid of c.sectionIds) {
+      if (sid !== canonicalId) skipIds.add(sid);
+    }
+  }
+
+  // For each section in pooledParsed: if it's the canonical for a cluster,
+  // emit the merged block; if it's a skipped cluster member, drop; otherwise
+  // emit the verbatim sentinel + heading + body. We re-emit verbatim by
+  // synthesizing a fresh sentinel line + heading + body so the file is
+  // structurally identical to a normal post-summarizer file (every block
+  // begins with a sentinel comment).
+  const blocks = [];
+  for (const s of pooledParsed) {
+    if (skipIds.has(s.sectionId)) continue;
+    const cluster = clusterByCanonicalId.get(s.sectionId);
+    if (cluster) {
+      blocks.push(compactMod.renderMergedBlock(cluster, runId, ts));
+    } else {
+      const issueIdToken = (s.issueIds && s.issueIds.length > 1)
+        ? s.issueIds.map((n) => `#${n}`).join("+")
+        : `#${s.issueId ?? 0}`;
+      const sentinel = `<!-- run:${s.runId ?? runId} issue:${issueIdToken} outcome:${s.outcome ?? "accepted"} ts:${ts} -->`;
+      blocks.push(`${sentinel}\n## ${s.heading}\n\n${s.body}`);
+    }
+  }
+
+  const preamble = `# Super-agent CLAUDE.md (pooled-lessons union)
+
+Built by \`research/curve-redo-bundle/super-agent/build-super-agent.cjs\` on ${ts}.
+Contributors: ${contributors.length} eligible agents (out of ${eligible.length} total registered).
+Input bytes (raw): ${totalInputBytes}. Pooled (post-preamble-strip): ${pooledBytes}.
+Compaction model output: ${proposal.clusters.length} merged clusters, ${proposal.unclusteredSectionIds.length} verbatim sections.
+
+`;
+  const rendered = preamble + blocks.join("\n\n") + "\n";
+  const renderedBytes = Buffer.byteLength(rendered, "utf-8");
+  const retentionPct = pooledBytes > 0 ? (renderedBytes / pooledBytes) * 100 : 0;
+
+  process.stderr.write(`[build-super-agent] rendered super-agent CLAUDE.md: ${renderedBytes} bytes (${(renderedBytes/1024).toFixed(1)} KB)\n`);
+  process.stderr.write(`[build-super-agent] retention vs pooled input: ${retentionPct.toFixed(1)}%\n`);
+
+  if (retentionPct < 25 || retentionPct > 50) {
+    process.stderr.write(`WARN: retention ${retentionPct.toFixed(1)}% outside acceptance range [25%, 50%]. Plan suggests rerun with MIN_CLUSTER_SIZE=${retentionPct < 25 ? 4 : 2}.\n`);
+  }
+
+  if (DRY_RUN) {
+    process.stderr.write("[build-super-agent] DRY_RUN=1 — skipping mint + write.\n");
+    return;
+  }
+
+  // Mint `agent-super` (or env-overridden ID). `ensureAgent` accepts an
+  // explicit agentId; `createAgent` (the random-mint helper) does not.
+  const minted = await registryMod.mutateRegistry((r) => {
+    const rec = registryMod.ensureAgent(r, TARGET_AGENT_ID);
+    rec.name = TARGET_AGENT_NAME;
+    rec.tags = TARGET_AGENT_TAGS;
+    return rec;
+  });
+  const claudeMdPath = specMod.agentClaudeMdPath(minted.agentId);
+  fs.mkdirSync(path.dirname(claudeMdPath), { recursive: true });
+  fs.writeFileSync(claudeMdPath, rendered);
+
+  process.stderr.write(`[build-super-agent] minted ${minted.agentId} (${minted.name})\n`);
+  process.stderr.write(`  CLAUDE.md: ${claudeMdPath} (${renderedBytes} bytes)\n`);
+  process.stdout.write(minted.agentId + "\n");
+
+  // Persist a build manifest next to the CLAUDE.md for downstream phases.
+  const manifest = {
+    agentId: minted.agentId,
+    builtAt: ts,
+    runId,
+    minClusterSize: MIN_CLUSTER_SIZE,
+    contributors: perAgentSections,
+    contributorCount: contributors.length,
+    eligibleCount: eligible.length,
+    inputBytesRaw: totalInputBytes,
+    pooledBytes,
+    pooledSectionCount: pooledParsed.length,
+    proposal: {
+      clusterCount: proposal.clusters.length,
+      unclusteredCount: proposal.unclusteredSectionIds.length,
+      estimatedBytesSaved: proposal.estimatedBytesSaved,
+      warningCount: proposal.warnings.length,
+      notes: proposal.notes,
+    },
+    renderedBytes,
+    retentionPct,
+  };
+  const manifestPath = path.join(path.dirname(claudeMdPath), "super-agent-build-manifest.json");
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+  process.stderr.write(`  manifest: ${manifestPath}\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`${err.stack ?? err}\n`);
+  process.exit(1);
+});

--- a/research/curve-redo-bundle/super-agent/build-super-trims.cjs
+++ b/research/curve-redo-bundle/super-agent/build-super-trims.cjs
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+// Super-agent random-trim sweep (Phase B of feature-plans/super-agent-curve-experiment-plan.md):
+// generate 12 sizes × 3 seeds = 36 trim agents from `agent-super`, mint each
+// in the registry, write the trim CLAUDE.md, group into 6 legs, emit legs.json.
+//
+// Steps:
+//   1. Load `agents/agent-super/CLAUDE.md`. S = its byte size.
+//   2. Build the geometric size grid `[0, S/512, S/256, ..., S/4, S/2, 3S/4, S]`
+//      rounded to whole KB. (Plan size grid; auto-rescales if S diverges from
+//      ~400 KB — Phase A retention can land below that.)
+//   3. Drive `planRandomTrims({ parent, sizes, replicates: 3, seedBase: 19 })`
+//      via dist/src/research/curveStudy/randomTrim.js. The Mulberry32 PRNG
+//      makes seed = seedBase + size + (k * 1000003) deterministic — re-runs
+//      reproduce byte-identical trims (verification path).
+//   4. For each TrimPlan, mint `agent-super-trim-<sizeBytes>-s<seed>` via
+//      `mutateRegistry` + `ensureAgent` (explicit ID), set name + tags
+//      directly on the record, and write the trim text to
+//      `agents/<agentId>/CLAUDE.md`.
+//   5. Pre-create per-agent target-repo clones at
+//      `/tmp/study-clones/<agentId>-<repoBasename>` for each repo present in
+//      the corpus. Skipping clones the dispatch loop would create on its own
+//      eats wall-time × parallelism — pre-creating once amortizes it.
+//   6. Group trims into 6 legs of 6 trims each by sorting on (sizeBytes, seed)
+//      and chunking sequentially. Adjacent-size trims cluster in the same leg
+//      so per-leg quick-look already shows local curve shape. Write
+//      `research/curve-redo-data/super-agent/legs.json`.
+//
+// Idempotency: re-running with the same inputs writes byte-identical trims
+// AND `ensureAgent` no-ops on existing IDs. Re-running with a different
+// SEED_BASE *will* mint additional agents (the agentId encodes the seed).
+//
+// Usage:
+//   npm run build && node research/curve-redo-bundle/super-agent/build-super-trims.cjs
+//
+// Env overrides:
+//   SUPER_AGENT_ID    parent agent (default "agent-super")
+//   SEED_BASE         seedBase for planRandomTrims (default 19)
+//   REPLICATES        replicates per size (default 3)
+//   LEG_COUNT         number of legs (default 6)
+//   SKIP_CLONES       "1" → skip the prepare-scratch-clones step (smoke-test path)
+//   DRY_RUN           "1" → plan + render but skip mint + write
+
+"use strict";
+
+const path = require("node:path");
+const fs = require("node:fs");
+const child_process = require("node:child_process");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const DIST = path.join(REPO_ROOT, "dist", "src");
+const AGENTS_DIR = path.join(REPO_ROOT, "agents");
+const CORPUS_PATH = path.join(REPO_ROOT, "research", "curve-redo-bundle", "corpus.json");
+const OUT_DIR = path.join(REPO_ROOT, "research", "curve-redo-data", "super-agent");
+const LEGS_PATH = path.join(OUT_DIR, "legs.json");
+
+const SUPER_AGENT_ID = process.env.SUPER_AGENT_ID || "agent-super";
+const SEED_BASE = Number(process.env.SEED_BASE || 19);
+const REPLICATES = Number(process.env.REPLICATES || 3);
+const LEG_COUNT = Number(process.env.LEG_COUNT || 6);
+const DRY_RUN = process.env.DRY_RUN === "1";
+const SKIP_CLONES = process.env.SKIP_CLONES === "1";
+
+function requireDist(rel) {
+  const p = path.join(DIST, rel);
+  if (!fs.existsSync(p)) {
+    process.stderr.write(`ERROR: ${p} missing — run \`npm run build\` first.\n`);
+    process.exit(1);
+  }
+  return require(p);
+}
+
+// Geometric grid `[0, S/512, S/256, S/128, S/64, S/32, S/16, S/8, S/4, S/2, 3S/4, S]`,
+// each non-zero entry rounded to the nearest 1 KB. Drops duplicates (small
+// S can collapse the bottom of the grid into 0 or 1 KB).
+function buildSizeGrid(S) {
+  const fractions = [0, 1/512, 1/256, 1/128, 1/64, 1/32, 1/16, 1/8, 1/4, 1/2, 3/4, 1];
+  const sizes = [];
+  for (const f of fractions) {
+    const raw = f * S;
+    const kb = Math.round(raw / 1024);
+    const bytes = kb * 1024;
+    if (!sizes.includes(bytes)) sizes.push(bytes);
+  }
+  return sizes;
+}
+
+function repoBasenames(corpus) {
+  const set = new Set();
+  for (const i of corpus.issues) {
+    set.add(i.repo.split("/")[1]);
+  }
+  return Array.from(set).sort();
+}
+
+function clonePathFor(agentId, repoBasename) {
+  return `/tmp/study-clones/${agentId}-${repoBasename}`;
+}
+
+function clonePathsForRepo(repoBasename) {
+  // Try the operator's local clone first; fall back to gh repo source for the
+  // initial clone. Mirrors `clone_path_for_repo` in dispatch-specialist-redo.sh.
+  const home = process.env.HOME || "/home";
+  for (const c of [`${home}/dev/${repoBasename}`, `${home}/dev/vaultpilot/${repoBasename}`]) {
+    if (fs.existsSync(path.join(c, ".git"))) return c;
+  }
+  return null;
+}
+
+async function prepareScratchClones(agents, repos) {
+  // Pre-create one scratch clone per (agent, repo) under /tmp/study-clones/.
+  // Each clone is a `git clone --no-local <source> <dest>` from the operator's
+  // existing local clone (read-only source — never edited). If any clone
+  // already exists with a `.git/`, leave it alone. Pure plumbing, idempotent.
+  const targetRoot = "/tmp/study-clones";
+  fs.mkdirSync(targetRoot, { recursive: true });
+  let created = 0, existing = 0, failed = 0;
+  for (const repoBase of repos) {
+    const source = clonePathsForRepo(repoBase);
+    if (!source) {
+      process.stderr.write(`WARN: no source clone for ${repoBase} at $HOME/dev/{,vaultpilot/}${repoBase} — skipping.\n`);
+      failed += agents.length;
+      continue;
+    }
+    for (const agentId of agents) {
+      const dest = clonePathFor(agentId, repoBase);
+      if (fs.existsSync(path.join(dest, ".git"))) {
+        existing++;
+        continue;
+      }
+      // Use --no-local because `--local` shares object stores via hardlinks;
+      // each agent worktree will mutate refs / staging which can race across
+      // hardlinked clones. --no-local copies, costing ~5x disk for safety.
+      const rc = child_process.spawnSync(
+        "git",
+        ["clone", "--no-local", "--quiet", source, dest],
+        { stdio: ["ignore", "ignore", "inherit"] },
+      ).status;
+      if (rc !== 0) { failed++; continue; }
+      created++;
+    }
+  }
+  process.stderr.write(`[build-super-trims] clones: created=${created} already=${existing} failed=${failed}\n`);
+  if (failed > 0) {
+    process.stderr.write("WARN: some clones failed; the dispatch loop will fall back to its own clone path.\n");
+  }
+}
+
+async function main() {
+  const registryMod = requireDist(path.join("state", "registry.js"));
+  const specMod = requireDist(path.join("agent", "specialization.js"));
+  const trimMod = requireDist(path.join("research", "curveStudy", "randomTrim.js"));
+
+  const parentPath = specMod.agentClaudeMdPath(SUPER_AGENT_ID);
+  if (!fs.existsSync(parentPath)) {
+    process.stderr.write(`ERROR: parent CLAUDE.md missing at ${parentPath}. Run build-super-agent.cjs first.\n`);
+    process.exit(2);
+  }
+  const parent = fs.readFileSync(parentPath, "utf-8");
+  const S = Buffer.byteLength(parent, "utf-8");
+
+  const sizes = buildSizeGrid(S);
+  process.stderr.write(`[build-super-trims] parent=${SUPER_AGENT_ID} S=${S} bytes (${(S/1024).toFixed(1)} KB)\n`);
+  process.stderr.write(`[build-super-trims] size grid (bytes): ${sizes.join(", ")}\n`);
+  process.stderr.write(`[build-super-trims] replicates=${REPLICATES} seedBase=${SEED_BASE} → ${sizes.length * REPLICATES} trims\n`);
+
+  const plans = trimMod.planRandomTrims({
+    parent,
+    sizes,
+    replicates: REPLICATES,
+    seedBase: SEED_BASE,
+  });
+
+  // Each plan → agentId + clone paths + trim CLAUDE.md content.
+  const corpus = JSON.parse(fs.readFileSync(CORPUS_PATH, "utf-8"));
+  const repos = repoBasenames(corpus);
+
+  const trims = plans.map((plan) => {
+    const agentId = `${SUPER_AGENT_ID}-trim-${plan.size}-s${plan.seed}`;
+    return {
+      agentId,
+      sizeBytes: plan.size,
+      actualBytes: plan.result.actualBytes,
+      seed: plan.seed,
+      selectedIds: plan.result.selectedIds,
+      droppedIds: plan.result.droppedIds,
+      content: plan.result.trimmed,
+      clones: Object.fromEntries(repos.map((r) => [r, clonePathFor(agentId, r)])),
+    };
+  });
+
+  // Sort by (sizeBytes, seed) and chunk sequentially into LEG_COUNT legs.
+  // Cells per leg = ceil(N / LEG_COUNT); the last leg may be smaller if
+  // sizes×replicates doesn't divide evenly.
+  const sorted = [...trims].sort((a, b) => a.sizeBytes - b.sizeBytes || a.seed - b.seed);
+  const perLeg = Math.ceil(sorted.length / LEG_COUNT);
+  const legs = [];
+  for (let i = 0; i < LEG_COUNT; i++) {
+    const slice = sorted.slice(i * perLeg, (i + 1) * perLeg);
+    if (slice.length === 0) continue;
+    legs.push({
+      legNumber: i + 1,
+      trimAgentIds: slice.map((t) => t.agentId),
+    });
+  }
+
+  // Render `legs.json` shape: top-level `parent` + `repos` + `corpus` for
+  // dispatch-super-leg.sh, plus per-trim metadata so the dispatch script can
+  // resolve clone paths without re-deriving them.
+  const legsJson = {
+    builtAt: new Date().toISOString(),
+    parent: SUPER_AGENT_ID,
+    seedBase: SEED_BASE,
+    replicates: REPLICATES,
+    legCount: legs.length,
+    perLeg,
+    repos,
+    parentBytes: S,
+    sizesBytes: sizes,
+    corpusPath: path.relative(REPO_ROOT, CORPUS_PATH),
+    trims: trims.map((t) => ({
+      agentId: t.agentId,
+      sizeBytes: t.sizeBytes,
+      actualBytes: t.actualBytes,
+      seed: t.seed,
+      sectionCounts: { selected: t.selectedIds.length, dropped: t.droppedIds.length },
+      clones: t.clones,
+    })),
+    legs,
+  };
+
+  if (DRY_RUN) {
+    process.stderr.write("[build-super-trims] DRY_RUN=1 — skipping mint, write, clones.\n");
+    process.stdout.write(JSON.stringify(legsJson, null, 2) + "\n");
+    return;
+  }
+
+  // Mint each trim agent and write its CLAUDE.md.
+  let minted = 0, already = 0, written = 0;
+  await registryMod.mutateRegistry((reg) => {
+    for (const t of trims) {
+      const before = reg.agents.find((a) => a.agentId === t.agentId);
+      const rec = registryMod.ensureAgent(reg, t.agentId);
+      rec.tags = ["super-agent-trim", `size-${t.sizeBytes}`, `seed-${t.seed}`];
+      if (before) already++; else minted++;
+    }
+  });
+  for (const t of trims) {
+    const claudeMdPath = specMod.agentClaudeMdPath(t.agentId);
+    fs.mkdirSync(path.dirname(claudeMdPath), { recursive: true });
+    fs.writeFileSync(claudeMdPath, t.content);
+    written++;
+  }
+  process.stderr.write(`[build-super-trims] minted=${minted} already=${already} CLAUDE.md written=${written}\n`);
+
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  fs.writeFileSync(LEGS_PATH, JSON.stringify(legsJson, null, 2));
+  process.stderr.write(`[build-super-trims] wrote ${LEGS_PATH}\n`);
+
+  // Trim summary table.
+  for (const leg of legs) {
+    const agents = leg.trimAgentIds.map((id) => trims.find((t) => t.agentId === id));
+    const sizes = agents.map((t) => t.sizeBytes).sort((a, b) => a - b);
+    process.stderr.write(`  leg ${leg.legNumber}: ${agents.length} trims; sizes=[${sizes.join(", ")}]\n`);
+  }
+
+  if (!SKIP_CLONES) {
+    await prepareScratchClones(trims.map((t) => t.agentId), repos);
+  } else {
+    process.stderr.write("[build-super-trims] SKIP_CLONES=1 — operator must pre-create clones before dispatch.\n");
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`${err.stack ?? err}\n`);
+  process.exit(1);
+});

--- a/research/curve-redo-bundle/super-agent/build-super-trims.cjs
+++ b/research/curve-redo-bundle/super-agent/build-super-trims.cjs
@@ -70,15 +70,17 @@ function requireDist(rel) {
 }
 
 // Geometric grid `[0, S/512, S/256, S/128, S/64, S/32, S/16, S/8, S/4, S/2, 3S/4, S]`,
-// each non-zero entry rounded to the nearest 1 KB. Drops duplicates (small
-// S can collapse the bottom of the grid into 0 or 1 KB).
+// each entry rounded to the nearest BYTE (not KB). Plan rendered the grid in
+// KB for readability, but KB-rounding collapses the bottom octave when S is
+// modest: at S=137 KB the bottom three fractions all rounded to {0, 1, 1} KB,
+// dropping the trim count from 36 to 30 and leaving poly3 with too little
+// resolution at the small-x end. Byte rounding keeps every fraction distinct
+// for any S ≥ 512 (each fraction differs by ≥1 byte).
 function buildSizeGrid(S) {
   const fractions = [0, 1/512, 1/256, 1/128, 1/64, 1/32, 1/16, 1/8, 1/4, 1/2, 3/4, 1];
   const sizes = [];
   for (const f of fractions) {
-    const raw = f * S;
-    const kb = Math.round(raw / 1024);
-    const bytes = kb * 1024;
+    const bytes = Math.round(f * S);
     if (!sizes.includes(bytes)) sizes.push(bytes);
   }
   return sizes;

--- a/research/curve-redo-bundle/super-agent/combine-super-curve.cjs
+++ b/research/curve-redo-bundle/super-agent/combine-super-curve.cjs
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+// Super-agent curve fit + AIC sweep — Phase E of
+// feature-plans/super-agent-curve-experiment-plan.md.
+//
+// Steps:
+//   1. Load per-cell QualityScores from every leg's `scores/` directory under
+//      research/curve-redo-data/super-agent/leg<N>/scores/.
+//   2. Compute per-cell quality via `qualityFromAB` from
+//      dist/src/research/curveStudy/cellScores.js (the same 0..100 formula
+//      curve-redo's combiner uses; see cellScores.ts:143). Decision is parsed
+//      from each cell's spawn log envelope.
+//   3. Project to CurveSample[]: per-agent aggregation, xBytes = trim size,
+//      factor = mean Q across the corpus issues for that trim agent. (Plan
+//      uses raw mean Q — interpretable in 0..100 quality units — rather
+//      than the qmax/meanQuality degradation factor `samplesFromCellScores`
+//      produces.)
+//   4. Fit all 6 candidate forms (degree {1,2,3} × xTransform {identity, log}).
+//      AIC = n·ln(rss/n) + 2·(degree+1); pick min-AIC, report ΔAIC for the
+//      rest.
+//   5. Leave-out-N-outliers refit (N=1, then N=2): rank samples by |residual|
+//      under the winning form, drop top, refit, recompute p. If p drops by
+//      >1 order of magnitude, the dropped seeds are absorbing variance —
+//      surface them in the writeup.
+//   6. Per-leg sanity sub-fit: also fit each leg's slice in isolation.
+//      Wildly-different residuals in one leg flag possibly-defective seeds.
+//
+// Note on size=0: `xTransform="log"` requires xBytes > 0. Samples at size=0
+// (the 0KB trim) are excluded from log-x fits BUT included in identity-x
+// fits — the AIC table notes the n delta per form so the comparison is fair
+// (different n means different rss-scale; AIC-vs-AIC across different n is
+// loose but the comparison is per-form).
+//
+// Usage:
+//   npm run build && node research/curve-redo-bundle/super-agent/combine-super-curve.cjs
+
+"use strict";
+
+const path = require("node:path");
+const fs = require("node:fs");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const DIST = path.join(REPO_ROOT, "dist", "src");
+const OUT_DIR = path.join(REPO_ROOT, "research", "curve-redo-data", "super-agent");
+const LEGS_PATH = path.join(OUT_DIR, "legs.json");
+const RESULT_PATH = path.join(OUT_DIR, "super-agent-curve.json");
+
+function requireDist(rel) {
+  const p = path.join(DIST, rel);
+  if (!fs.existsSync(p)) {
+    process.stderr.write(`ERROR: ${p} missing — run \`npm run build\` first.\n`);
+    process.exit(1);
+  }
+  return require(p);
+}
+
+function extractEnvelope(text) {
+  // Mirrors curveStudy/aggregate.ts:extractEnvelope. Walks `\n{\n` / `{\n`
+  // anchors backwards until a JSON.parse succeeds.
+  for (const anchor of ["\n{\n", "{\n"]) {
+    let idx = text.lastIndexOf(anchor);
+    while (idx >= 0) {
+      const candidate = text.slice(idx).replace(/^\s+/, "");
+      try {
+        return JSON.parse(candidate);
+      } catch (_e) {
+        // try the next-earlier anchor
+      }
+      idx = text.lastIndexOf(anchor, idx - 1);
+    }
+  }
+  return null;
+}
+
+function readDecisionFromLog(logPath) {
+  if (!fs.existsSync(logPath)) return null;
+  const text = fs.readFileSync(logPath, "utf-8");
+  const obj = extractEnvelope(text);
+  if (!obj || !obj.envelope) return null;
+  return obj.envelope.decision || null;
+}
+
+async function main() {
+  if (!fs.existsSync(LEGS_PATH)) {
+    process.stderr.write(`ERROR: legs.json missing at ${LEGS_PATH} — run build-super-trims.cjs first.\n`);
+    process.exit(2);
+  }
+  const legsJson = JSON.parse(fs.readFileSync(LEGS_PATH, "utf-8"));
+  const cellScoresMod = requireDist(path.join("research", "curveStudy", "cellScores.js"));
+  const regressionMod = requireDist(path.join("research", "curveStudy", "regression.js"));
+
+  const trimById = new Map(legsJson.trims.map((t) => [t.agentId, t]));
+
+  // Walk each leg's scores/ dir and rebuild Cells. Each leg's logs/ dir is
+  // the source of truth for `decision`; scores/ holds the test+judge JSONs.
+  const cells = [];
+  let legsRead = 0;
+  for (const leg of legsJson.legs) {
+    const legDir = path.join(OUT_DIR, `leg${leg.legNumber}`);
+    const logsDir = path.join(legDir, "logs");
+    const scoresDir = path.join(legDir, "scores");
+    if (!fs.existsSync(logsDir)) continue;
+    legsRead++;
+    const scoreMap = await cellScoresMod.loadCellScores(scoresDir);
+    const logFiles = fs.readdirSync(logsDir).filter((f) => f.endsWith(".log"));
+    for (const f of logFiles) {
+      const m = /^curveStudy-(agent-[a-z0-9-]+)-(\d+)\.log$/.exec(f);
+      if (!m) continue;
+      const agentId = m[1];
+      const issueId = Number(m[2]);
+      const trim = trimById.get(agentId);
+      if (!trim) continue;
+      const decision = readDecisionFromLog(path.join(logsDir, f));
+      const key = `${agentId}-${issueId}`;
+      const scores = scoreMap.get(key);
+      const quality = cellScoresMod.qualityFromAB({
+        decision,
+        judge: scores?.judge,
+        test: scores?.test,
+      });
+      cells.push({
+        legNumber: leg.legNumber,
+        agentId,
+        issueId,
+        sizeBytes: trim.sizeBytes,
+        decision,
+        quality,
+      });
+    }
+  }
+
+  if (cells.length === 0) {
+    process.stderr.write("ERROR: no cells loaded — dispatch + score must run first.\n");
+    process.exit(3);
+  }
+  process.stderr.write(`[combine-super-curve] cells loaded: ${cells.length} (${legsRead}/${legsJson.legs.length} legs read)\n`);
+
+  // Per-trim aggregation: mean Q across cells of that trim. Plan uses raw
+  // mean Q as the y-axis so coefficients sit in 0..100 quality units.
+  const perAgent = new Map();
+  for (const c of cells) {
+    let bucket = perAgent.get(c.agentId);
+    if (!bucket) {
+      bucket = { sizeBytes: c.sizeBytes, qualities: [], legNumber: c.legNumber };
+      perAgent.set(c.agentId, bucket);
+    }
+    bucket.qualities.push(c.quality);
+  }
+  const samples = [];
+  for (const [agentId, b] of perAgent.entries()) {
+    const meanQ = b.qualities.reduce((s, x) => s + x, 0) / b.qualities.length;
+    samples.push({
+      agentId,
+      legNumber: b.legNumber,
+      xBytes: b.sizeBytes,
+      factor: meanQ,
+      cellCount: b.qualities.length,
+    });
+  }
+  samples.sort((a, b) => a.xBytes - b.xBytes);
+
+  process.stderr.write(`[combine-super-curve] per-trim samples: ${samples.length}\n`);
+
+  // Fit the 6 forms; for log-x exclude xBytes <= 0.
+  const forms = [
+    { degree: 1, xTransform: "identity" },
+    { degree: 1, xTransform: "log" },
+    { degree: 2, xTransform: "identity" },
+    { degree: 2, xTransform: "log" },
+    { degree: 3, xTransform: "identity" },
+    { degree: 3, xTransform: "log" },
+  ];
+
+  function fitOne(form, sampleSet) {
+    const usable = form.xTransform === "log"
+      ? sampleSet.filter((s) => s.xBytes > 0)
+      : sampleSet;
+    if (usable.length <= form.degree + 1) return null;
+    try {
+      const reg = regressionMod.fitPolynomialRegression(usable, form.degree, form.xTransform);
+      const aic = aicFromReg(reg);
+      return { form, n: usable.length, aic, reg };
+    } catch (err) {
+      return { form, n: usable.length, aic: NaN, reg: null, error: String(err.message || err) };
+    }
+  }
+
+  function aicFromReg(reg) {
+    // AIC = n · ln(rss/n) + 2 · (degree+1)
+    if (!(reg.rss > 0)) return Number.NaN;
+    return reg.n * Math.log(reg.rss / reg.n) + 2 * (reg.degree + 1);
+  }
+
+  const fits = forms.map((f) => fitOne(f, samples)).filter((r) => r);
+  // Pick the form with minimum AIC. Ties → fewer parameters wins (lower
+  // degree first; identity before log when degree ties).
+  const valid = fits.filter((r) => Number.isFinite(r.aic));
+  if (valid.length === 0) {
+    process.stderr.write("ERROR: no fits produced finite AIC. Check sample count vs degree budget.\n");
+    process.exit(4);
+  }
+  valid.sort((a, b) => a.aic - b.aic ||
+    a.form.degree - b.form.degree ||
+    (a.form.xTransform === "identity" ? -1 : 1));
+  const winner = valid[0];
+  const aicTable = valid.map((r) => ({
+    form: r.form,
+    n: r.n,
+    aic: r.aic,
+    deltaAic: r.aic - winner.aic,
+    rSquared: r.reg.rSquared,
+    rSquaredAdjusted: r.reg.rSquaredAdjusted,
+    fPValue: r.reg.significance.fPValue,
+  }));
+
+  process.stderr.write(`[combine-super-curve] winning form: degree=${winner.form.degree} x=${winner.form.xTransform} AIC=${winner.aic.toFixed(2)} R²=${winner.reg.rSquared.toFixed(3)} p=${winner.reg.significance.fPValue.toExponential(2)}\n`);
+  for (const row of aicTable) {
+    process.stderr.write(`  d=${row.form.degree} x=${row.form.xTransform.padEnd(8)} n=${row.n} AIC=${row.aic.toFixed(2)} ΔAIC=${row.deltaAic.toFixed(2)} R²=${row.rSquared.toFixed(3)} adjR²=${row.rSquaredAdjusted.toFixed(3)} p=${row.fPValue.toExponential(2)}\n`);
+  }
+
+  // Leave-out-N-outliers refit under the winning form. Rank samples by
+  // |residual|, drop the top N, refit, recompute p.
+  function residualsForReg(reg, sampleSet) {
+    return sampleSet.map((s) => {
+      const yhat = regressionMod.evaluatePolynomial(reg, s.xBytes);
+      return { ...s, yhat, residual: s.factor - yhat };
+    });
+  }
+  const winnerSamples = winner.form.xTransform === "log"
+    ? samples.filter((s) => s.xBytes > 0)
+    : samples;
+  const winnerResid = residualsForReg(winner.reg, winnerSamples);
+  const sortedByAbsResid = [...winnerResid].sort((a, b) => Math.abs(b.residual) - Math.abs(a.residual));
+  const leaveOuts = [1, 2];
+  const refits = [];
+  for (const N of leaveOuts) {
+    const dropAgents = new Set(sortedByAbsResid.slice(0, N).map((s) => s.agentId));
+    const remaining = winnerSamples.filter((s) => !dropAgents.has(s.agentId));
+    const fit = fitOne(winner.form, remaining);
+    if (!fit) continue;
+    refits.push({
+      n: N,
+      droppedAgents: Array.from(dropAgents),
+      droppedResiduals: sortedByAbsResid.slice(0, N).map((s) => ({ agentId: s.agentId, residual: s.residual, factor: s.factor, xBytes: s.xBytes })),
+      reg: fit.reg,
+      aic: fit.aic,
+      pValue: fit.reg.significance.fPValue,
+    });
+    process.stderr.write(`[combine-super-curve] leave-out-${N}: dropped=${Array.from(dropAgents).join(", ")} new p=${fit.reg.significance.fPValue.toExponential(2)} R²=${fit.reg.rSquared.toFixed(3)}\n`);
+  }
+  const winnerP = winner.reg.significance.fPValue;
+  for (const rf of refits) {
+    if (Number.isFinite(winnerP) && Number.isFinite(rf.pValue)) {
+      const ratio = winnerP / rf.pValue;
+      if (ratio > 10) {
+        process.stderr.write(`  ⚠ leave-out-${rf.n}: p dropped by ${ratio.toFixed(0)}× — outliers absorbing variance, name them in writeup.\n`);
+      }
+    }
+  }
+
+  // Per-leg sanity sub-fit: fit each leg's samples in isolation under the
+  // winning form. Surface any leg whose residual SE is wildly different
+  // from the global fit — that leg's seeds may be defective.
+  const perLegFits = [];
+  for (const leg of legsJson.legs) {
+    const legSamples = samples.filter((s) => s.legNumber === leg.legNumber);
+    const fit = fitOne(winner.form, legSamples);
+    if (!fit) {
+      perLegFits.push({ legNumber: leg.legNumber, n: legSamples.length, error: "insufficient samples" });
+      continue;
+    }
+    perLegFits.push({
+      legNumber: leg.legNumber,
+      n: fit.n,
+      aic: fit.aic,
+      rSquared: fit.reg.rSquared,
+      residualStdError: fit.reg.significance.residualStdError,
+      pValue: fit.reg.significance.fPValue,
+    });
+  }
+
+  const result = {
+    builtAt: new Date().toISOString(),
+    cellsLoaded: cells.length,
+    legsRead,
+    perAgentSamples: samples,
+    aicTable,
+    winningForm: winner.form,
+    winningRegression: winner.reg,
+    leaveOutRefits: refits,
+    perLegFits,
+  };
+  fs.writeFileSync(RESULT_PATH, JSON.stringify(result, null, 2));
+  process.stderr.write(`[combine-super-curve] wrote ${RESULT_PATH}\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`${err.stack ?? err}\n`);
+  process.exit(1);
+});

--- a/research/curve-redo-bundle/super-agent/dispatch-super-leg.sh
+++ b/research/curve-redo-bundle/super-agent/dispatch-super-leg.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# Super-agent random-trim dispatch — Phase C of
+# feature-plans/super-agent-curve-experiment-plan.md.
+#
+# For one leg (1..6) read from research/curve-redo-data/super-agent/legs.json,
+# spawns one cell per (trim agent × corpus issue × K=1). Each cell:
+#   * runs in --dry-run mode (intercepts push/PR side effects)
+#   * suppresses the live target-repo CLAUDE.md (--no-target-claude-md) so
+#     the effective context = trim agent's per-agent CLAUDE.md only
+#   * captures the post-run diff via --capture-diff-path so the scorer's
+#     run-tests can apply it
+#   * passes --skip-summary so the agent's CLAUDE.md doesn't drift across cells
+#   * passes --research-mode so registry side effects (counters, lastActiveAt,
+#     lesson appends) are suppressed across the experiment
+#   * uses claude-sonnet-4-6 to match the curve-redo trim baseline
+#   * (closed leg-2 issues only) rolls the worktree to baseSha via
+#     --replay-base-sha and forwards --allow-closed-issue + --issue-body-only
+#
+# Cells run serially within an agent (per-agent worktree race protection)
+# but sequentially across agents in this script. The leg structure already
+# bounds wall-time per leg; cross-agent parallelism would need a per-agent
+# scratch clone setup the operator may or may not have prepared.
+#
+# Usage:
+#   bash dispatch-super-leg.sh <leg-number 1..N> [--dry-print] [--issue <issueId>] [--trim <agentId>]
+#     <leg-number>   1..N where N = legs.json:legCount
+#     --dry-print    print the spawn commands without executing
+#     --issue <id>   only dispatch cells against this issue (smoke-test path)
+#     --trim <id>    only dispatch this trim agent's cells (smoke-test path)
+#
+# Required environment / file layout (relative to repo root):
+#   research/curve-redo-bundle/corpus.json               — 13-issue corpus
+#   research/curve-redo-data/super-agent/legs.json       — written by build-super-trims.cjs
+#   $OUT_DIR/leg<N>/logs/                                — created
+#   $OUT_DIR/leg<N>/diffs/                               — created
+#
+# Cost defense in depth:
+#   * VP_DEV_MAX_COST_USD per cell (caller-overridable, default 2.00)
+#   * MAX_TOTAL_COST_USD per leg (caller-overridable, default 130);
+#     dispatch aborts when the rolling sum (parsed from each cell's envelope
+#     JSON) exceeds the cap.
+
+set -euo pipefail
+
+LEG=""
+DRY_PRINT=false
+FILTER_ISSUE=""
+FILTER_TRIM=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-print) DRY_PRINT=true; shift;;
+    --issue)     FILTER_ISSUE="$2"; shift 2;;
+    --trim)      FILTER_TRIM="$2"; shift 2;;
+    -h|--help)
+      sed -n '2,30p' "$0" >&2
+      exit 0
+      ;;
+    *)
+      if [[ -z "$LEG" ]]; then LEG="$1"; shift
+      else echo "Unknown arg: $1" >&2; exit 2
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "$LEG" || ! "$LEG" =~ ^[0-9]+$ ]]; then
+  echo "Usage: $0 <leg-number> [--dry-print] [--issue <id>] [--trim <agentId>]" >&2
+  exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+LEGS_JSON="${LEGS_JSON:-$REPO_ROOT/research/curve-redo-data/super-agent/legs.json}"
+CORPUS="${CORPUS:-$REPO_ROOT/research/curve-redo-bundle/corpus.json}"
+OUT_DIR="${OUT_DIR:-$REPO_ROOT/research/curve-redo-data/super-agent}"
+LEG_DIR="$OUT_DIR/leg${LEG}"
+LOGS_DIR="$LEG_DIR/logs"
+DIFFS_DIR="$LEG_DIR/diffs"
+
+MODEL="${MODEL:-claude-sonnet-4-6}"
+LOG_PREFIX="${LOG_PREFIX:-curveStudy-}"
+MAX_TOTAL_COST_USD="${MAX_TOTAL_COST_USD:-130}"
+export VP_DEV_MAX_COST_USD="${VP_DEV_MAX_COST_USD:-2.00}"
+
+if [[ ! -f "$LEGS_JSON" ]]; then
+  echo "ERROR: legs.json missing at $LEGS_JSON — run build-super-trims.cjs first." >&2
+  exit 2
+fi
+if [[ ! -f "$CORPUS" ]]; then
+  echo "ERROR: corpus.json missing at $CORPUS." >&2
+  exit 2
+fi
+
+mkdir -p "$LOGS_DIR" "$DIFFS_DIR"
+
+echo "[$(date -Iseconds)] dispatch-super-leg: leg=$LEG model=$MODEL" >&2
+echo "  legs.json=$LEGS_JSON" >&2
+echo "  out_dir=$LEG_DIR" >&2
+echo "  per-cell cap=\$$VP_DEV_MAX_COST_USD; leg cap=\$$MAX_TOTAL_COST_USD" >&2
+
+# Resolve the trim agentIds for this leg (from legs.json).
+LEG_TRIM_LINES="$(node -e '
+  const fs = require("node:fs");
+  const j = JSON.parse(fs.readFileSync(process.argv[1], "utf-8"));
+  const target = Number(process.argv[2]);
+  const leg = j.legs.find((L) => L.legNumber === target);
+  if (!leg) { process.stderr.write(`ERROR: leg ${target} missing\n`); process.exit(3); }
+  for (const id of leg.trimAgentIds) {
+    const t = j.trims.find((T) => T.agentId === id);
+    const sizeBytes = t ? t.sizeBytes : 0;
+    const seed = t ? t.seed : 0;
+    const clones = t ? Object.entries(t.clones).map(([k,v]) => `${k}=${v}`).join(",") : "";
+    process.stdout.write([id, sizeBytes, seed, clones].join("\t") + "\n");
+  }
+' "$LEGS_JSON" "$LEG")"
+
+if [[ -z "$LEG_TRIM_LINES" ]]; then
+  echo "ERROR: no trim agents resolved for leg=$LEG." >&2
+  exit 2
+fi
+
+# Parse corpus once via node — bash JSON is a footgun.
+CORPUS_TSV="$(node -e '
+  const fs = require("node:fs");
+  const c = JSON.parse(fs.readFileSync(process.argv[1], "utf-8"));
+  for (const i of c.issues) {
+    const sha = i.baseSha || "";
+    const state = i.state || "open";
+    process.stdout.write([i.issueId, i.repo, state, sha].join("\t") + "\n");
+  }
+' "$CORPUS")"
+
+declare -A ISSUE_REPO ISSUE_STATE ISSUE_SHA
+ALL_ISSUE_IDS=()
+while IFS=$'\t' read -r issueId repo state sha; do
+  [[ -z "$issueId" ]] && continue
+  ISSUE_REPO["$issueId"]="$repo"
+  ISSUE_STATE["$issueId"]="$state"
+  ISSUE_SHA["$issueId"]="$sha"
+  ALL_ISSUE_IDS+=("$issueId")
+done <<<"$CORPUS_TSV"
+
+# Optionally filter to a single issue (smoke-test path).
+if [[ -n "$FILTER_ISSUE" ]]; then
+  if [[ -z "${ISSUE_REPO[$FILTER_ISSUE]:-}" ]]; then
+    echo "ERROR: --issue $FILTER_ISSUE not in corpus." >&2
+    exit 2
+  fi
+  ISSUE_IDS=("$FILTER_ISSUE")
+else
+  ISSUE_IDS=("${ALL_ISSUE_IDS[@]}")
+fi
+
+# Resolve a target-repo source clone the spawn can read from. Per-cell uses
+# this as --target-repo-path. Mirrors `resolveTargetRepoPath` (#254): default
+# to $HOME/dev/<name>, fall back to $HOME/dev/vaultpilot/<name>.
+resolve_clone_for_repo() {
+  local repo="$1" name agentId="${2:-}"
+  name="${repo##*/}"
+  # Prefer the per-agent scratch clone build-super-trims.cjs prepared.
+  if [[ -n "$agentId" ]]; then
+    local scratch="/tmp/study-clones/${agentId}-${name}"
+    if [[ -d "$scratch/.git" ]]; then echo "$scratch"; return 0; fi
+  fi
+  local candidate
+  for candidate in "${HOME:-/home}/dev/$name" "${HOME:-/home}/dev/vaultpilot/$name"; do
+    if [[ -d "$candidate/.git" ]]; then echo "$candidate"; return 0; fi
+  done
+  echo "ERROR: no clone for $repo at /tmp/study-clones/${agentId}-${name} nor under \$HOME/dev/. Run build-super-trims.cjs to pre-create scratch clones." >&2
+  return 1
+}
+
+# Cost extractor — same shape as dispatch-specialist-redo.sh.
+extract_cost() {
+  python3 -c '
+import json, sys, re
+text = open(sys.argv[1]).read()
+m = re.search(r"\"costUsd\"\s*:\s*([0-9.]+)", text)
+print(m.group(1) if m else "0")
+' "$1" 2>/dev/null || echo 0
+}
+
+# Build trim list (TSV: agentId\tsizeBytes\tseed). Filter to --trim if set.
+TRIMS=()
+while IFS=$'\t' read -r agentId sizeBytes seed clones; do
+  [[ -z "$agentId" ]] && continue
+  if [[ -n "$FILTER_TRIM" && "$agentId" != "$FILTER_TRIM" ]]; then continue; fi
+  TRIMS+=("$agentId")
+done <<<"$LEG_TRIM_LINES"
+
+if [[ ${#TRIMS[@]} -eq 0 ]]; then
+  echo "ERROR: no trims selected (filter --trim '$FILTER_TRIM' may not be in leg=$LEG)." >&2
+  exit 2
+fi
+
+cell_count=$((${#TRIMS[@]} * ${#ISSUE_IDS[@]}))
+echo "  trims: ${#TRIMS[@]}; issues: ${#ISSUE_IDS[@]}; cells: $cell_count" >&2
+
+total_cost=0
+cells_done=0
+
+for agentId in "${TRIMS[@]}"; do
+  for issueId in "${ISSUE_IDS[@]}"; do
+    repo="${ISSUE_REPO[$issueId]}"
+    state="${ISSUE_STATE[$issueId]}"
+    sha="${ISSUE_SHA[$issueId]}"
+
+    if ! clone="$(resolve_clone_for_repo "$repo" "$agentId")"; then
+      exit 5
+    fi
+
+    # The aggregator uses a regex of `^${prefix}(agent-[a-z0-9-]+)-(\d+)\.log$`,
+    # so the log filename must be exactly `<prefix><agentId>-<issueId>.log`.
+    cell_id="${LOG_PREFIX}${agentId}-${issueId}"
+    log_path="$LOGS_DIR/${cell_id}.log"
+    diff_path="$DIFFS_DIR/${cell_id}.diff"
+
+    cells_done=$((cells_done + 1))
+    if [[ -s "$log_path" ]]; then
+      echo "[$(date -Iseconds)] [$cells_done/$cell_count] skip (already exists): $cell_id" >&2
+      continue
+    fi
+
+    if (( $(echo "$total_cost >= $MAX_TOTAL_COST_USD" | bc -l) )); then
+      echo "[$(date -Iseconds)] BUDGET EXHAUSTED at \$$total_cost — aborting." >&2
+      exit 3
+    fi
+
+    cmd=(npm run vp-dev -- spawn
+      --agent "$agentId"
+      --issue "$issueId"
+      --target-repo "$repo"
+      --target-repo-path "$clone"
+      --dry-run
+      --no-target-claude-md
+      --skip-summary
+      --research-mode
+      --model "$MODEL"
+      --capture-diff-path "$diff_path")
+
+    if [[ "$state" == "closed" ]]; then
+      cmd+=(--allow-closed-issue --issue-body-only)
+      if [[ -n "$sha" ]]; then
+        cmd+=(--replay-base-sha "$sha")
+      fi
+    fi
+
+    echo "[$(date -Iseconds)] [$cells_done/$cell_count] $cell_id (clone=$clone)" >&2
+    if $DRY_PRINT; then
+      printf '  '; printf '%q ' "${cmd[@]}"; echo
+      continue
+    fi
+
+    if ! (cd "$REPO_ROOT" && "${cmd[@]}") >"$log_path" 2>&1; then
+      echo "  WARN: spawn exited non-zero — log preserved at $log_path" >&2
+    fi
+    delta="$(extract_cost "$log_path")"
+    total_cost="$(echo "$total_cost + $delta" | bc -l)"
+    echo "  cost: +\$$delta (running \$$total_cost)" >&2
+  done
+done
+
+echo "[$(date -Iseconds)] dispatch-super-leg: leg=$LEG complete. cells=$cells_done total_cost=\$$total_cost" >&2

--- a/research/curve-redo-bundle/super-agent/score-super-leg.sh
+++ b/research/curve-redo-bundle/super-agent/score-super-leg.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Super-agent random-trim scoring — Phase D of
+# feature-plans/super-agent-curve-experiment-plan.md.
+#
+# For every cell log under $OUT_DIR/leg<N>/logs/curveStudy-<agent>-<issue>.log:
+#   * parse the spawn log's envelope to get (decision, reason) and the diff
+#     path written by --capture-diff-path during dispatch
+#   * if decision == "implement" AND a non-empty diff exists: invoke
+#     `vp-dev research run-tests` to apply the diff into a fresh clone, run
+#     the issue's hidden-test suite, and write `<cellKey>-tests.json`
+#   * if decision in {implement, pushback}: invoke
+#     `vp-dev research grade-reasoning` for the K=3 Opus blind grade and
+#     write `<cellKey>-judge.json`
+#
+# Cells with envelope.decision == "error" / null produce no score files —
+# combine-super-curve.cjs scores them as 0 per `qualityFromAB`.
+#
+# Cells run independently per leg, so leg N's score step can pipeline with
+# leg N+1's dispatch.
+#
+# Usage:
+#   bash score-super-leg.sh <leg-number 1..N>
+
+set -euo pipefail
+
+LEG="${1:-}"
+if [[ -z "$LEG" || ! "$LEG" =~ ^[0-9]+$ ]]; then
+  echo "Usage: $0 <leg-number>" >&2
+  exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+OUT_DIR="${OUT_DIR:-$REPO_ROOT/research/curve-redo-data/super-agent}"
+CORPUS="${CORPUS:-$REPO_ROOT/research/curve-redo-bundle/corpus.json}"
+LEG_DIR="$OUT_DIR/leg${LEG}"
+LOGS_DIR="$LEG_DIR/logs"
+DIFFS_DIR="$LEG_DIR/diffs"
+SCORES_DIR="$LEG_DIR/scores"
+TESTS_BASE="${TESTS_BASE:-$REPO_ROOT/research/curve-redo-bundle/curve-redo-tests}"
+SCORE_CLONES_DIR="${SCORE_CLONES_DIR:-$LEG_DIR/score-clones}"
+LOG_PREFIX="${LOG_PREFIX:-curveStudy-}"
+
+JUDGE_K="${JUDGE_K:-3}"
+
+if [[ ! -d "$LOGS_DIR" ]]; then
+  echo "ERROR: logs dir not found at $LOGS_DIR — run dispatch-super-leg.sh first." >&2
+  exit 2
+fi
+if [[ ! -d "$TESTS_BASE" ]]; then
+  echo "ERROR: hidden-tests dir not found at $TESTS_BASE." >&2
+  exit 2
+fi
+
+mkdir -p "$SCORES_DIR" "$SCORE_CLONES_DIR"
+
+echo "[$(date -Iseconds)] score-super-leg: leg=$LEG K=$JUDGE_K" >&2
+echo "  logs=$LOGS_DIR" >&2
+echo "  scores=$SCORES_DIR" >&2
+
+# Per-issue metadata lookup (repo, framework, baseSha, testsDestRelDir).
+declare -A ISSUE_REPO ISSUE_FRAMEWORK ISSUE_SHA ISSUE_TESTS_DEST
+while IFS=$'\t' read -r issueId repo framework state cls sha testsDest; do
+  [[ -z "$issueId" ]] && continue
+  ISSUE_REPO["$issueId"]="$repo"
+  ISSUE_FRAMEWORK["$issueId"]="$framework"
+  ISSUE_SHA["$issueId"]="$sha"
+  ISSUE_TESTS_DEST["$issueId"]="$testsDest"
+done < <(node -e '
+  const fs = require("node:fs");
+  const c = JSON.parse(fs.readFileSync(process.argv[1], "utf-8"));
+  for (const i of c.issues) {
+    process.stdout.write([
+      i.issueId,
+      i.repo,
+      i.framework,
+      i.state || "open",
+      i.decisionClass || "",
+      i.baseSha || "",
+      i.testsDestRelDir || "",
+    ].join("\t") + "\n");
+  }
+' "$CORPUS")
+
+ensure_score_clone() {
+  local issueId="$1" repo="$2" sha="$3"
+  local name="${repo##*/}"
+  local cdir="$SCORE_CLONES_DIR/${name}-${issueId}"
+  if [[ ! -d "$cdir/.git" ]]; then
+    local src=""
+    local candidate
+    for candidate in "${HOME:-/home}/dev/$name" "${HOME:-/home}/dev/vaultpilot/$name"; do
+      if [[ -d "$candidate/.git" ]]; then
+        src="$candidate"
+        break
+      fi
+    done
+    if [[ -n "$src" ]]; then
+      git clone --quiet "$src" "$cdir" >&2
+    else
+      gh repo clone "$repo" "$cdir" -- --quiet >&2
+    fi
+  fi
+  if [[ -n "$sha" ]]; then
+    (cd "$cdir" && git fetch --quiet origin "$sha" 2>/dev/null || true)
+    (cd "$cdir" && git reset --hard "$sha" --quiet)
+  else
+    (cd "$cdir" && git fetch --quiet origin main && git reset --hard origin/main --quiet)
+  fi
+  echo "$cdir"
+}
+
+parse_log() {
+  local log="$1" cell_id="$2"
+  python3 -c '
+import json, re, sys, os, tempfile
+text = open(sys.argv[1]).read()
+obj = None
+for anchor in ("\n{\n", "{\n"):
+    idx = text.rfind(anchor)
+    while idx >= 0:
+        candidate = text[idx:].lstrip()
+        try:
+            obj = json.loads(candidate)
+            break
+        except json.JSONDecodeError:
+            idx = text.rfind(anchor, 0, idx)
+    if obj is not None:
+        break
+
+decision = ""
+reason_path = ""
+if obj is not None:
+    env = obj.get("envelope") or {}
+    decision = env.get("decision") or ""
+    reason = env.get("reason") or ""
+    if decision == "pushback" and reason:
+        cell_id = sys.argv[2]
+        out_dir = sys.argv[3]
+        os.makedirs(out_dir, exist_ok=True)
+        reason_path = os.path.join(out_dir, cell_id + ".pushback.txt")
+        open(reason_path, "w").write(reason)
+sys.stdout.write(decision + "\t" + reason_path + "\n")
+' "$log" "$cell_id" "$SCORES_DIR/.tmp"
+}
+
+shopt -s nullglob
+mapfile -t LOG_FILES < <(printf '%s\n' "$LOGS_DIR/${LOG_PREFIX}"agent-*-*.log | sort)
+if [[ ${#LOG_FILES[@]} -eq 0 ]]; then
+  echo "ERROR: no logs found at $LOGS_DIR/${LOG_PREFIX}*.log" >&2
+  exit 2
+fi
+
+# Strip the prefix and split base="<agent>-<issue>" via the same regex shape
+# the curve-study aggregator uses: agent-[a-z0-9-]+-(\d+)
+total=${#LOG_FILES[@]}
+done_count=0
+prefix_re="^${LOG_PREFIX}(agent-[a-z0-9-]+)-([0-9]+)$"
+
+for log in "${LOG_FILES[@]}"; do
+  done_count=$((done_count + 1))
+  base="$(basename "$log" .log)"
+  if [[ ! "$base" =~ $prefix_re ]]; then
+    echo "[$done_count/$total] skip (unrecognized name): $base" >&2
+    continue
+  fi
+  agent="${BASH_REMATCH[1]}"
+  issueId="${BASH_REMATCH[2]}"
+  repo="${ISSUE_REPO[$issueId]:-}"
+  framework="${ISSUE_FRAMEWORK[$issueId]:-}"
+  sha="${ISSUE_SHA[$issueId]:-}"
+  testsDest="${ISSUE_TESTS_DEST[$issueId]:-}"
+
+  if [[ -z "$repo" || -z "$framework" ]]; then
+    echo "[$done_count/$total] skip (no corpus entry for issue $issueId): $base" >&2
+    continue
+  fi
+
+  echo "[$(date -Iseconds)] [$done_count/$total] $base (decision=parsing)" >&2
+  parsed="$(parse_log "$log" "$base")"
+  decision="${parsed%%$'\t'*}"
+  reason_path="${parsed#*$'\t'}"
+
+  diff_path="$DIFFS_DIR/${base}.diff"
+  tests_dir="$TESTS_BASE/$issueId"
+
+  # Score files are KEYED ON `<agent>-<issue>` (no LOG_PREFIX) so the
+  # combine-super-curve.cjs glob doesn't have to know the dispatch prefix.
+  cell_key="${agent}-${issueId}"
+  tests_out="$SCORES_DIR/${cell_key}-tests.json"
+  judge_out="$SCORES_DIR/${cell_key}-judge.json"
+
+  if [[ "$decision" == "implement" && -s "$diff_path" && ! -s "$tests_out" ]]; then
+    if [[ ! -d "$tests_dir" ]]; then
+      echo "  WARN: no hidden tests at $tests_dir — skipping run-tests." >&2
+    else
+      clone="$(ensure_score_clone "$issueId" "$repo" "$sha")"
+      cmd=(npm run vp-dev -- research run-tests
+        --diff-path "$diff_path"
+        --tests-dir "$tests_dir"
+        --clone-dir "$clone"
+        --framework "$framework"
+        --out "$tests_out")
+      if [[ -n "$testsDest" ]]; then
+        cmd+=(--tests-dest-rel-dir "$testsDest")
+      fi
+      echo "  run-tests → $tests_out" >&2
+      (cd "$REPO_ROOT" && "${cmd[@]}" >/dev/null 2>&1) || \
+        echo "  WARN: run-tests exited non-zero (output preserved at $tests_out)" >&2
+    fi
+  fi
+
+  if [[ ( "$decision" == "implement" || "$decision" == "pushback" ) && ! -s "$judge_out" ]]; then
+    cmd=(npm run vp-dev -- research grade-reasoning
+      --issue "$issueId"
+      --target-repo "$repo"
+      --decision "$decision"
+      --k "$JUDGE_K"
+      --out "$judge_out")
+    if [[ "$decision" == "implement" && -s "$diff_path" ]]; then
+      cmd+=(--diff-path "$diff_path")
+    elif [[ "$decision" == "pushback" && -n "$reason_path" && -s "$reason_path" ]]; then
+      cmd+=(--pushback-path "$reason_path")
+    fi
+    echo "  grade-reasoning → $judge_out" >&2
+    (cd "$REPO_ROOT" && "${cmd[@]}" >/dev/null 2>&1) || \
+      echo "  WARN: grade-reasoning exited non-zero (output preserved at $judge_out)" >&2
+  fi
+
+  if [[ "$decision" != "implement" && "$decision" != "pushback" ]]; then
+    echo "  skip (decision=$decision)" >&2
+  fi
+done
+
+echo "[$(date -Iseconds)] score-super-leg: leg=$LEG complete." >&2

--- a/src/research/curveStudy/regression.test.ts
+++ b/src/research/curveStudy/regression.test.ts
@@ -96,6 +96,22 @@ test("fitPolynomialRegression: degree-2 raw fit recovers a known quadratic", () 
   assert.ok(reg.rSquared > 0.99999);
 });
 
+test("fitPolynomialRegression: degree-3 raw fit recovers a known cubic", () => {
+  // y = 0.1 x³ − 0.5 x² + 2 x + 7 sampled at eight points
+  const f = (x: number): number => 0.1 * x * x * x - 0.5 * x * x + 2 * x + 7;
+  const xs = [1, 3, 6, 10, 15, 21, 28, 36];
+  const samples: CurveSample[] = xs.map((x) => ({ xBytes: x, factor: f(x) }));
+  const reg = fitPolynomialRegression(samples, 3, "identity");
+  for (const s of samples) {
+    const yhat = evaluatePolynomial(reg, s.xBytes);
+    assert.ok(Math.abs(yhat - s.factor) < 1e-6, `at ${s.xBytes}: ${yhat} vs ${s.factor}`);
+  }
+  assert.ok(reg.rSquared > 0.99999);
+  assert.equal(reg.degree, 3);
+  assert.equal(reg.significance.fDfRegression, 3);
+  assert.equal(reg.significance.fDfResidual, samples.length - 4);
+});
+
 test("fitPolynomialRegression: noisy raw data still produces a usable fit", () => {
   // y = x² + small noise; expect monotone-increasing prediction
   const xs = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];


### PR DESCRIPTION
## Summary

Implements feature-plans/super-agent-curve-experiment-plan.md (merged via #273). Five scripts cover Phases A-E plus a degree=3 unit test for the regression machinery.

| Script | Phase | Role |
|---|---|---|
| `build-super-agent.cjs` | A | Pool eligible agents' CLAUDE.mds → `proposeCompaction()` → mint `agent-super` |
| `build-super-trims.cjs` | B | `planRandomTrims(12 sizes × 3 seeds)` → mint 36 trim agents → group into 6 legs |
| `dispatch-super-leg.sh` | C | Dispatch one leg × 13 corpus issues × K=1 (modeled on `dispatch-specialist-redo.sh`) |
| `score-super-leg.sh` | D | Per-cell `run-tests` + `grade-reasoning` into `leg<N>/scores/` |
| `combine-super-curve.cjs` | E | AIC sweep across degree {1,2,3} × xTransform {identity, log} + leave-out-N refit + per-leg sub-fit |

`fitPolynomialRegression()` is already degree-generic, so Phase E needs no source edit — added a degree=3 recovery test as a confirmation.

## Plan-vs-state delta

Plan estimated ~47 eligible agents totaling ~1.3 MB. Actual machine state: 47 eligible by registry, but only 27 have a materialized `agents/<id>/CLAUDE.md` (the other 20 are recently-minted agents that have never been dispatched and have no lessons). Pooled input is therefore ~0.68 MB. Phase A's retention gate ([25%, 50%]) and the plan's note that S can fall outside the [300 KB, 650 KB] window keep this within scope. The plan's acceptance criterion is the gate, not the input estimate.

## Smoke test

End-to-end smoke (1 trim × 1 issue × K=1) is the next step before committing leg dispatch. Will run on this branch and report; legs 1-6 do not dispatch until operator approval.

## Test plan
- [ ] `npm run typecheck && npm run build` — clean
- [ ] `node --test dist/src/research/curveStudy/regression.test.js` — degree=3 test passes
- [ ] `node --check` on each `.cjs`, `bash -n` on each `.sh` — syntax clean
- [ ] Phase A (Opus dedup) lands a non-empty agent-super CLAUDE.md, validator warnings == 0, retention printed
- [ ] Phase B trim plan reproducibility (rerun → byte-identical 36 trims)
- [ ] Phase C smoke: 1 cell against 1 corpus issue → log + diff captured + score files written
- [ ] Phase D scoring on the smoke cell → tests.json + judge.json present
- [ ] Phase E combiner on the single sample → JSON written, regression error is clean (n=1 ≤ degree+1 always under-determined)

🤖 Generated with [Claude Code](https://claude.com/claude-code)