### PR TITLE
study(super-agent): parallel-by-trim launcher + leg-1 results

### DIFF
--- a/research/curve-redo-bundle/super-agent/PARALLEL-LEGS.md
+++ b/research/curve-redo-bundle/super-agent/PARALLEL-LEGS.md
@@ -1,0 +1,74 @@
+# Super-agent curve study — parallel leg dispatch
+
+This document is the playbook for running legs of the super-agent curve experiment in parallel agents/worktrees. It complements [`super-agent-curve-experiment-plan.md`](../../../feature-plans/super-agent-curve-experiment-plan.md).
+
+## Why parallel-by-leg
+
+Phase C dispatches 6 legs of 6 trim agents × 13 issues each. Sequential wall time is ~3-4 hours; the experiment plan permits running multiple legs concurrently across worktrees on the same host as long as scratch clones and per-agent worktrees stay disjoint.
+
+The launcher introduced here (`launch-leg-parallel.sh`) handles the **within-leg** parallelism (6 trims at once via per-trim filtered dispatch). **Cross-leg parallelism** is just running multiple launchers, one per leg, in separate worktrees.
+
+## Bootstrap (per parallel agent)
+
+Each agent that will dispatch a leg must:
+
+1. **Branch off `origin/main`** in its own worktree.
+   ```bash
+   cd /Users/s/dev/vaultpilot/vaultpilot-dev-framework
+   git fetch origin main
+   git worktree add .claude/worktrees/super-agent-leg<N> -b super-agent/leg<N> origin/main
+   cd .claude/worktrees/super-agent-leg<N>
+   ```
+
+2. **Build dist/** (each worktree has its own `node_modules` + `dist/`).
+   ```bash
+   npm ci && npm run build
+   ```
+
+3. **Regenerate `legs.json`** (deterministic; rewrites the leg→trim mapping but does not re-mint trims if registry already has them, does not re-clone if `/tmp/study-clones/<agent>-<repo>/.git` exists).
+   ```bash
+   node research/curve-redo-bundle/super-agent/build-super-trims.cjs
+   ```
+
+   The `agents/` and `state/` directories are gitignored and shared across worktrees via symlink (each worktree symlinks `agents → /Users/s/dev/vaultpilot/vaultpilot-dev-framework/agents` and `state → /Users/s/dev/vaultpilot/vaultpilot-dev-framework/state`). The 36 trim CLAUDE.mds and registry entries minted by the leg-1 agent are visible from every parallel agent. Skip step 3's regeneration if `research/curve-redo-data/super-agent/legs.json` already exists in this worktree (the gitignored data dir may already be populated by a prior agent on the same host).
+
+4. **Launch the leg.**
+   ```bash
+   bash research/curve-redo-bundle/super-agent/launch-leg-parallel.sh <N>
+   ```
+
+   Outputs land under `research/curve-redo-data/super-agent/leg<N>/{logs,diffs,spawner-logs}/`. The launcher waits for all 6 child processes; spawner logs stream cell-by-cell progress.
+
+## Coordination rules
+
+- **One worktree per leg.** Two agents on the same leg would race on per-agent worktree branches.
+- **Different legs use disjoint trim agents** (the legs-json chunking guarantees this), so cross-leg dispatches do not collide on registry entries or scratch clones.
+- **Per-agent worktree races still apply within a leg.** `dispatch-super-leg.sh` serializes cells within a trim; the launcher's `--trim` filter ensures one bash process owns each trim's 13 cells.
+- **Cost caps stack independently.** Each parallel-leg invocation has its own `MAX_TOTAL_COST_USD=30` per process and `VP_DEV_MAX_COST_USD=2.00` per cell. Operator-side aggregate budget is the sum across all running legs.
+- **Don't clobber a sibling's leg dir.** Each `leg<N>/` directory is exclusively owned by one agent's launcher run. Re-running on the same leg is idempotent — completed cells skip via the `if [[ -s "$log_path" ]]; then continue; fi` check in `dispatch-super-leg.sh`, so a crash-resume picks up where it left off.
+
+## Leg state
+
+| Leg | Trim sizes (bytes) | Status | Notes |
+|-----|-------------------|--------|-------|
+| 1 | 0, 0, 0, 408, 408, 408 | **done** | $63.60, 78/78 cells, 3 cap-errors on #185 (small-trim seeds exhausted $2 cap) |
+| 2 | 817 × 3, 1633 × 3 | open | — |
+| 3 | 3266 × 3, 6533 × 3 | open | — |
+| 4 | 13065 × 3, 26130 × 3 | open | — |
+| 5 | 52261 × 3, 104521 × 3 | open | — |
+| 6 | 156782 × 3, 209042 × 3 | open | — |
+
+See [`leg1-results.md`](./leg1-results.md) for the leg-1 distributions and the smoke-check vs the curve-redo baseline.
+
+## Smoke-check gate (per Phase C)
+
+After each leg, verify:
+- **Mean cell cost < 1.5× curve-redo-baseline mean** ($0.70). Leg 1 = $0.817 (1.17×) → PASS.
+- **Per-issue cost stdev < ~1.5× baseline.** Leg 1 stdev across cells 0.85× baseline → PASS.
+- **Error rate < 5%.** Leg 1 was 3.8% (3/78), all per-cell-cap hits on the same issue (#185).
+
+If any threshold is exceeded, abort the leg and re-plan before the next one.
+
+## Per-leg cost reference
+
+Leg 1 actual: **$63.60** (mean $0.817/cell × 78). Use as a midpoint estimate for legs 2-6; expect modest growth as larger trims load more context per turn.

--- a/research/curve-redo-bundle/super-agent/launch-leg-parallel.sh
+++ b/research/curve-redo-bundle/super-agent/launch-leg-parallel.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Parallel launcher for one leg of the super-agent curve study. Spawns one
+# `dispatch-super-leg.sh --trim <id>` background process per trim agent in
+# the leg, so per-trim cells run sequentially within a process while trims
+# run concurrently across processes — exactly parallelism = (#trims).
+#
+# Per-process cost cap defaults to MAX_TOTAL_COST_USD=30; per-cell cap is
+# inherited from dispatch-super-leg.sh (VP_DEV_MAX_COST_USD=2.00). Worst
+# case for a 6-trim leg: 6 × 30 = $180; expected ~$110 at $1.40/cell mean.
+#
+# Usage:
+#   bash launch-leg-parallel.sh <leg-number 1..6> [--dry-print]
+
+set -euo pipefail
+
+LEG=""
+DRY_PRINT=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-print) DRY_PRINT=true;;
+    *)
+      if [[ -z "$LEG" ]]; then LEG="$arg"
+      else echo "Unknown arg: $arg" >&2; exit 2
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "$LEG" || ! "$LEG" =~ ^[0-9]+$ ]]; then
+  echo "Usage: $0 <leg-number> [--dry-print]" >&2
+  exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+LEGS_JSON="$REPO_ROOT/research/curve-redo-data/super-agent/legs.json"
+LEG_DIR="$REPO_ROOT/research/curve-redo-data/super-agent/leg${LEG}"
+SPAWN_LOG_DIR="$LEG_DIR/spawner-logs"
+mkdir -p "$SPAWN_LOG_DIR"
+
+TRIM_IDS="$(node -e '
+  const fs = require("node:fs");
+  const j = JSON.parse(fs.readFileSync(process.argv[1], "utf-8"));
+  const target = Number(process.argv[2]);
+  const leg = j.legs.find((L) => L.legNumber === target);
+  if (!leg) { process.stderr.write(`ERROR: leg ${target} missing\n`); process.exit(3); }
+  for (const id of leg.trimAgentIds) process.stdout.write(id + "\n");
+' "$LEGS_JSON" "$LEG")"
+
+if [[ -z "$TRIM_IDS" ]]; then
+  echo "ERROR: no trims for leg=$LEG" >&2
+  exit 2
+fi
+
+echo "[$(date -Iseconds)] launch-leg-parallel: leg=$LEG"
+echo "  trims:"
+while IFS= read -r tid; do
+  [[ -z "$tid" ]] && continue
+  echo "    - $tid"
+done <<<"$TRIM_IDS"
+
+DISPATCH="$REPO_ROOT/research/curve-redo-bundle/super-agent/dispatch-super-leg.sh"
+PIDS=()
+
+while IFS= read -r tid; do
+  [[ -z "$tid" ]] && continue
+  spawn_log="$SPAWN_LOG_DIR/${tid}.log"
+
+  if $DRY_PRINT; then
+    echo "  would spawn: bash $DISPATCH $LEG --trim $tid > $spawn_log 2>&1"
+    continue
+  fi
+
+  echo "[$(date -Iseconds)] launching $tid → $spawn_log"
+  MAX_TOTAL_COST_USD="${MAX_TOTAL_COST_USD:-30}" \
+  VP_DEV_MAX_COST_USD="${VP_DEV_MAX_COST_USD:-2.00}" \
+    bash "$DISPATCH" "$LEG" --trim "$tid" >"$spawn_log" 2>&1 &
+  PIDS+=($!)
+done <<<"$TRIM_IDS"
+
+if $DRY_PRINT; then
+  echo "[$(date -Iseconds)] dry-print only — no processes spawned."
+  exit 0
+fi
+
+echo "[$(date -Iseconds)] ${#PIDS[@]} dispatch processes started; waiting..."
+fail=0
+for pid in "${PIDS[@]}"; do
+  if ! wait "$pid"; then
+    echo "[$(date -Iseconds)] WARN: pid=$pid exited non-zero" >&2
+    fail=$((fail+1))
+  fi
+done
+
+echo "[$(date -Iseconds)] all dispatch processes finished. failed=$fail"
+
+# Aggregate cost summary across all spawner logs.
+total=$(awk '
+  /running \$/ {
+    n = split($0, parts, "running \\$")
+    if (n >= 2) {
+      gsub(/[^0-9.]/, "", parts[n])
+      val[FILENAME] = parts[n] + 0
+    }
+  }
+  END { sum = 0; for (k in val) sum += val[k]; printf "%.4f\n", sum }
+' "$SPAWN_LOG_DIR"/*.log 2>/dev/null || echo "0")
+
+echo "[$(date -Iseconds)] leg=$LEG aggregate cost \$$total"
+exit $fail

--- a/research/curve-redo-bundle/super-agent/leg1-results.md
+++ b/research/curve-redo-bundle/super-agent/leg1-results.md
@@ -1,0 +1,85 @@
+# Super-agent curve study — leg 1 results
+
+Leg 1 of the Phase C dispatch (see [`super-agent-curve-experiment-plan.md`](../../../feature-plans/super-agent-curve-experiment-plan.md)). 6 trim agents × 13 issues × K=1 = 78 cells, parallel-6 dispatch via [`launch-leg-parallel.sh`](./launch-leg-parallel.sh).
+
+## Run
+
+| | |
+|---|---|
+| Started | 2026-05-09T07:01:05+01:00 |
+| Finished | 2026-05-09T08:07:05+01:00 |
+| Wall | 66 min |
+| Aggregate cost | **$63.60** |
+| Cells | 78/78 |
+| Spawner failures | 0 |
+
+## Trims
+
+| Agent | Size (bytes) | Cells | Cost |
+|-------|-------------:|------:|-----:|
+| agent-super-trim-0-s19 | 0 | 13/13 | $10.46 |
+| agent-super-trim-0-s1000022 | 0 | 13/13 | $10.40 |
+| agent-super-trim-0-s2000025 | 0 | 13/13 | $10.57 |
+| agent-super-trim-408-s427 | 408 | 13/13 | $11.01 |
+| agent-super-trim-408-s1000430 | 408 | 13/13 | $11.02 |
+| agent-super-trim-408-s2000433 | 408 | 13/13 | $10.15 |
+
+All under the $30 per-process cap.
+
+## Cost distribution vs curve-redo baseline
+
+| Metric | Super leg 1 | Baseline leg 1 | Ratio |
+|---|--:|--:|--:|
+| n | 78 | 108 | — |
+| mean | $0.817 | $0.698 | **1.17×** (gate: <1.5×) |
+| median | $0.639 | $0.290 | 2.20× |
+| max | $2.04 (capped) | $2.93 | — |
+| stdev | — | — | 0.85× |
+| total | $63.69 | $75.33 | — |
+
+Median ratio is high because baseline includes many quick pushbacks (issues 156/162/665) at <$0.30, while super-leg-1 has more cells in the implement region (smaller trims still attempt to implement). Mean ratio is the gate-relevant metric.
+
+## Per-issue distribution
+
+| Issue | Super n | Super mean | Super stdev | Decisions |
+|---|--:|--:|--:|---|
+| 156 | 6 | $0.113 | $0.023 | 6 pushback |
+| 157 | 6 | $0.457 | $0.143 | 6 implement |
+| 162 | 6 | $0.170 | $0.141 | 6 pushback |
+| 168 | 6 | $0.550 | $0.176 | 6 implement |
+| 172 | 6 | $1.473 | $0.187 | 6 implement |
+| 178 | 6 | $1.068 | $0.262 | 6 implement |
+| 180 | 6 | $1.529 | $0.295 | 6 implement |
+| **185** | **6** | **$1.838** | **$0.238** | **3 implement / 2 None / 1 error** |
+| 186 | 6 | $0.655 | $0.127 | 6 implement |
+| 565 | 6 | $0.329 | $0.009 | 6 implement |
+| 574 | 6 | $0.755 | $0.284 | 6 implement |
+| 649 | 6 | $1.538 | $0.252 | 6 implement |
+| 665 | 6 | $0.140 | $0.038 | 6 pushback |
+
+## Issue #185 cap exhaustions
+
+3 of 6 trim seeds on issue #185 hit the per-cell $2 cap before completing the implement step:
+
+| Trim | Decision | isError | Cost | Duration |
+|---|---|---|--:|--:|
+| agent-super-trim-0-s19 | (none) | true | $2.04 | 593s |
+| agent-super-trim-0-s2000025 | error | true | $2.03 | 610s |
+| agent-super-trim-408-s427 | (none) | true | $2.04 | 585s |
+| agent-super-trim-0-s1000022 | implement | false | $1.61 | 495s |
+| agent-super-trim-408-s1000430 | implement | false | $1.50 | 486s |
+| agent-super-trim-408-s2000433 | implement | false | $1.81 | 392s |
+
+Issue #185 is a vaultpilot-dev-framework open issue not present in the curve-redo baseline corpus (baseline corpus was vaultpilot-mcp closed-only). Half of the small-trim seeds exhaust budget before producing a final envelope.
+
+**Operator decision recorded for the experiment:** accept the errors as part of the dataset and proceed to leg 2. The judge will score the 3 cap-hit cells per the standard pipeline (likely 0 quality / partial credit depending on the captured diff). Larger-trim legs (2-6) may have a lower error rate on #185 since more context per turn typically reduces total turn count.
+
+## Smoke-check gate verdict
+
+| Gate | Threshold | Actual | Result |
+|---|---|---|---|
+| Mean cost vs baseline | <1.5× | 1.17× | PASS |
+| Cost stdev vs baseline | <1.5× | 0.85× | PASS |
+| Error rate | <5% | 3.8% (3/78) | PASS |
+
+Phase C may proceed to leg 2.


### PR DESCRIPTION
## Summary

- Add `launch-leg-parallel.sh` — per-trim-filtered dispatch fan-out (6 trims → 6 background `dispatch-super-leg.sh --trim` processes, parallelism = 6 with strict per-trim serialization).
- Run leg 1 clean: 78/78 cells, $63.60, 66 min wall, smoke-check PASS on all three gates (mean cost 1.17× baseline, stdev 0.85×, error rate 3.8%).
- Add `PARALLEL-LEGS.md` playbook so a second agent can pick up legs 2-6 in a parallel worktree off this branch (or main once merged).

## Why parallel-by-trim, not parallel-by-cell

Each trim agent has one scratch clone at `/tmp/study-clones/<agentId>-<repo>` and one `vp-dev` per-agent worktree branch. Two cells for the same trim concurrently would race on the worktree branch. Per-trim filtered processes guarantee at most one cell per trim is in flight, matching the `dispatchCells` invariant in `src/research/curveStudy/dispatch.ts`.

The "phase-1 10-way racing" comment in `dispatch.ts:69-74` documents the failure mode this avoids.

## Leg 1 verdict

| Gate | Threshold | Actual | Result |
|---|---|---|---|
| Mean cost vs curve-redo baseline | <1.5× | 1.17× ($0.817 vs $0.698) | PASS |
| Cost stdev vs baseline | <1.5× | 0.85× | PASS |
| Error rate | <5% | 3.8% (3/78) | PASS |

All 3 errors were per-cell $2-cap hits on issue #185 (vaultpilot-dev-framework open) across small-trim seeds. Operator decision: accept and proceed.

Full distribution + per-issue breakdown in [`leg1-results.md`](research/curve-redo-bundle/super-agent/leg1-results.md).

## Parallel-leg coordination

`agents/` and `state/` symlink across worktrees on the same host, so trim CLAUDE.mds and registry entries minted by the leg-1 agent are visible to any sibling worktree without re-minting. A second agent's bootstrap is `npm ci && npm run build && node build-super-trims.cjs && bash launch-leg-parallel.sh <N>`.

Each leg's `research/curve-redo-data/super-agent/leg<N>/` directory is exclusively owned by one launcher invocation; cross-leg dispatches don't collide because legs use disjoint trim agents (the legs.json chunking guarantees this).

## Test plan

- [x] Typecheck passes (`npm run typecheck`).
- [x] Build passes (`npm run build`).
- [x] Leg-1 launcher exited 0 with `failed=0` and 78/78 logs.
- [x] Smoke-check Python script verified against curve-redo baseline distributions.
- [ ] Second agent bootstraps from this branch in a fresh worktree and dispatches a different leg without colliding (manual verification on demand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)