### PR TITLE
plan(super-agent-tailored): per-issue rule selection arm setup

### DIFF
--- a/feature-plans/super-agent-tailored-experiment-plan.md
+++ b/feature-plans/super-agent-tailored-experiment-plan.md
@@ -1,0 +1,165 @@
+# Super-agent tailored-per-issue experiment
+
+## Context
+
+Three picker arms ([#255](https://github.com/szhygulin/vaultpilot-dev-framework/pull/255) Jaccard, [#269](https://github.com/szhygulin/vaultpilot-dev-framework/pull/269) naive, [#272](https://github.com/szhygulin/vaultpilot-dev-framework/pull/272) prose-LLM) all tied at −17 quality points vs. trim baseline. The most recent prose-baseline arm dispatched the full-prose LLM picker against the existing pool of pre-evolved specialists; quality matched the other two pickers, cost was ~$0.25/cell higher than naive.
+
+User hypothesis under test here: **build a fresh per-issue agent by subtracting irrelevant H2 rules from `agents/agent-super/CLAUDE.md` (the deduped union of every existing agent's CLAUDE.md, built in [#276](https://github.com/szhygulin/vaultpilot-dev-framework/pull/276)) — the per-issue tailored agent will outperform the prose-baseline picker arm on at least one of (accuracy, cost) at p<0.05.**
+
+The parent super-agent file (`research/curve-redo-bundle/super-agent/agent-super.CLAUDE.md`, 209 KB, 122 H2 sections) is held constant; only the per-issue selection step differs between this arm and the prose-baseline.
+
+## Hypothesis & success criteria
+
+Two one-sided paired Wilcoxon tests (n=13 issues, mean across K=3 replicates per cell), arm = `tailored`, comparator = `prose-baseline` (re-using existing data from [#272](https://github.com/szhygulin/vaultpilot-dev-framework/pull/272)):
+
+| Test | H1 | α | Win condition |
+|---|---|---|---|
+| Quality | tailored mean Q > prose mean Q (per issue) | 0.05 | p < 0.05 → "more accurate" |
+| Cost | tailored mean cost < prose mean cost (per issue) | 0.05 | p < 0.05 → "cheaper" |
+
+**Soft bar** (per user direction): winning on **either** dimension = significant. Both p-values reported unadjusted, with a one-line note that family-wise rate is ~0.0975 if Holm-Bonferroni is preferred when reading.
+
+Secondary descriptive comparisons (no p-test, narrative only): vs trim baseline, vs specialist-redo, vs naive. Re-uses existing leg-1/leg-2 score directories.
+
+## Design decisions (named explicitly)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Comparator | prose-baseline arm only | Same K=3, n=13, paired by issueId; super-agent-curve data is K=1 + varies by random byte-trim, not content-aware selection — answers a different question and the K mismatch makes paired Wilcoxon awkward. |
+| Selection mode | **subtractive** (start from full super-agent, drop irrelevant H2s) | Matches user's "dropping rules not needed" framing; subtractive prompts produce better-calibrated keep decisions than additive (lower false-negative rate on edge-case rules). |
+| Selection unit | H2 section (one `## ` heading = one rule) | Matches `parseClaudeMdSections()` and the `proposeCompaction` pipeline used to build the super-agent. |
+| Selector model | Opus 4.7 (`claude-opus-4-7[1m]`) | Identical to prose-baseline picker model — only the picking *target* differs. |
+| Selector caching | Super-agent prose pinned as cached system-prompt prefix; issue body in user message | 209 KB ≈ 52k tokens. Cached read ~10× cheaper than fresh; 13 calls share a single cache write. Selector cost ~$3-5 instead of ~$30 uncached. |
+| Per-issue agent identity | 13 fresh `agent-super-tailored-<issueId>` agents | Clean isolation per issue; mirrors the per-issue super-trim convention in the curve study. Snapshot+restore registry around the run. |
+| Replicates / corpus | K=3, n=13 (39 cells) | Identical to prose-baseline → direct paired comparison. |
+| Coding-cell flags | `--dry-run --no-target-claude-md --skip-summary --no-registry-mutation --capture-diff-path --max-cost-usd 2.00` | Identical to prose-baseline → only the per-issue agent's CLAUDE.md content differs. |
+| Coding model | Sonnet 4.6 | Identical to prose-baseline. |
+| Empty-selection edge case | Allow it: tailored agent's CLAUDE.md = empty → behaves like naive | Faithful to the selector's judgment; documented as expected outcome for issues where no rule applies. |
+
+## Phase A — Per-issue rule selection (~$3-5, ~13 Opus calls)
+
+**New file**: `research/curve-redo-bundle/super-agent-tailored/select-rules.cjs` (~250 lines).
+
+1. Load `research/curve-redo-bundle/super-agent/agent-super.CLAUDE.md`. Parse via `parseClaudeMdSections()` from `dist/src/agent/split.js`. Build a stable section index: `[{id, heading, body, byteOffset}]`. The `id` is the H2 heading slugified deterministically (e.g., `auto-escalate-secondllmrequired-when-humandecode-source-is-none-opaque-calldata`) — collisions disambiguated with `-2`, `-3` suffixes.
+2. Load `research/curve-redo-bundle/corpus.json`. For each of 13 issues, fetch the issue body via `getIssue()` (same path prose-baseline uses).
+3. **Selector prompt** (fixed across issues, cached):
+   - **System prompt** (cached): role description + super-agent prose, sections labeled `### Section <id>: <heading>` (replacing original `## ` so the prompt structure isn't ambiguous with the LLM's own output). Output schema: JSON array of `{sectionId, decision: "keep"|"drop", reason: string}`. Mandate: explain each `drop` in 1 sentence; explain each `keep` in 1 sentence (so the LLM thinks about both directions, not just defaults to keeping).
+   - **User message** (per issue, NOT cached): issue title + body + `decisionClass` from corpus + repo name. Instruction: "decide which sections from the super-agent help with this specific issue."
+4. **Anthropic SDK call** with `cache_control: {type: "ephemeral"}` on the system-prompt block. Track per-call cost via `response.usage` (input_tokens + cache_creation_input_tokens + cache_read_input_tokens + output_tokens × per-1M rates).
+5. **Validate output**:
+   - Parse JSON; reject if not a flat array of `{sectionId, decision, reason}` objects.
+   - Every section in the super-agent appears exactly once (no missing, no extra).
+   - `decision ∈ {"keep", "drop"}`.
+   - At least one `keep` OR explicit operator confirmation (the empty-selection case is allowed but flagged in the audit log).
+6. **Write outputs**:
+   - `research/curve-redo-data/super-agent-tailored/selections.json` — full audit trail: `{issueId, model, costUsd, selections: [{sectionId, decision, reason}]}` for each issue.
+   - `research/curve-redo-data/super-agent-tailored/picks-tailored.tsv` — one row per issue, columns: `issueId, agentId (= "agent-super-tailored-{issueId}"), rationale (= "tailored-keep-{N}-of-{122}"), score=0, leg, labels`. Mirrors the column shape of `picks-prose.tsv` so downstream tooling reuses unchanged.
+
+**Cost guardrail**: per-call hard cap `MAX_CALL_USD=2.00` (exits non-zero if any single call exceeds). Aggregate cap `MAX_TOTAL_USD=15.00` — well above expected $3-5 with margin for retry.
+
+**Idempotency**: re-running with the same super-agent file + same corpus skips issues whose `selections.json` entry already exists, unless `--force`. Selections are deterministic-ish (Opus is not seeded; same input ≈ same output but not byte-identical).
+
+## Phase B — Mint per-issue tailored agents (~$0)
+
+**New file**: `research/curve-redo-bundle/super-agent-tailored/build-tailored-agents.cjs` (~150 lines).
+
+1. Read `selections.json` from Phase A.
+2. For each issue:
+   - Render the per-issue CLAUDE.md = concatenation of super-agent H2 sections marked `keep`, in their original source order (preserves any inter-section dependencies the super-agent's section order encodes).
+   - Mint via `mutateRegistry(reg => createAgent(reg, { agentId: "agent-super-tailored-<issueId>", name: "Tailored-<issueId>", tags: ["super-agent-tailored", "issue-<issueId>"] }))`.
+   - Write to `agents/agent-super-tailored-<issueId>/CLAUDE.md`.
+   - Track sizes in `research/curve-redo-data/super-agent-tailored/sizes.json` for the writeup (Phase F): `{issueId, sectionsKept, bytesKept, percentOfSuperAgent}`.
+3. **Snapshot the registry first**: `cp state/agents-registry.json state/agents-registry.snapshot-pre-tailored.json` (per the prose-baseline §11 defense; mirrored here).
+4. Pre-create per-agent target-repo clones at `/tmp/tailored-scratch/<issueId>-<repo>` via `prepare-scratch-clones.sh` from the specialist-redo bundle.
+
+**Verification**: every minted agent has a non-empty `CLAUDE.md` (or empty-by-design with operator-acknowledged log entry); registry has 13 new entries with `agent-super-tailored-` prefix; tag `super-agent-tailored` resolves to exactly 13 agents.
+
+## Phase C — Dispatch K=3 against 13-issue corpus (~$45)
+
+**New file**: `research/curve-redo-bundle/super-agent-tailored/dispatch-tailored-parallel.sh` — **thin wrapper** over `research/curve-redo-bundle/specialist-redo/dispatch-specialist-redo-parallel.sh`. Differences:
+
+- `OUT_DIR` defaults to `$REPO_ROOT/research/curve-redo-data/super-agent-tailored`.
+- `PICKS` reads from `picks-tailored.tsv` (Phase A output).
+- All other behavior identical: 5 parallel slots, K=3, Sonnet 4.6, identical SDK flags, idempotent skip-if-log-exists, scratch-clone round-robin.
+
+**Per-issue agent ↔ issue binding**: `picks-tailored.tsv` maps issueId → `agent-super-tailored-<issueId>`, so each cell dispatches the correct per-issue agent. Cell key shape matches existing convention: `bench-r<replicate>-agent-super-tailored-<issueId>-<issueId>.log` (the `agentId-issueId` pairing in the log filename matches the existing `dispatchCells` regex).
+
+**Smoke leg before full sweep**: dispatch leg 1 only (6 issues × K=3 = 18 cells, ~$15, ~25 min wall). Inspect cell-cost distribution + per-issue Q variance against prose-baseline leg 1. Operator approval before leg 2.
+
+**Cost ceilings**:
+- Per-cell: `VP_DEV_MAX_COST_USD=2.00`.
+- Per-leg target: ~$15 leg 1 + ~$30 leg 2.
+- Aggregate: ~$50 dispatch budget; abort path at $60.
+
+## Phase D — Score (~$10)
+
+**New file**: `research/curve-redo-bundle/super-agent-tailored/score-tailored.sh` — **thin wrapper** over `research/curve-redo-bundle/specialist-redo/score-specialist-redo.sh` with `OUT_DIR=$REPO_ROOT/research/curve-redo-data/super-agent-tailored`. Identical scoring path: `vp-dev research run-tests` for implement+diff cells, `vp-dev research grade-reasoning` K=3 for implement+pushback. Same hidden-test fixtures.
+
+Each leg's score step runs in parallel with the next leg's dispatch.
+
+## Phase E — Combine + Wilcoxon (~$0)
+
+**New file**: `research/curve-redo-bundle/super-agent-tailored/combine-tailored.cjs` (~200 lines, modeled on `specialist-redo/combine-and-compare.cjs`). Deltas vs. the model:
+
+- `BASELINE_PREFIX = "bench-r"` — prose-baseline arm uses the same `bench-r<N>-<agent>-<issue>` log naming as specialist-redo, so we read both arms via the treatment-shaped reader.
+- Both arms supply leg-1/leg-2 logs + scores. Pair by `issueId` only (NOT by replicate; we compare mean Q per issue across K=3 → mean Q per issue across K=3 = paired sample of length 13).
+- Two one-sided Wilcoxon tests:
+  - `wilcoxonSignedRankPaired(dQs, "greater")` — H1: tailored Q > prose Q.
+  - `wilcoxonSignedRankPaired(dCosts, "less")` — H1: tailored cost < prose cost.
+- Output `comparison.json` with both p-values, Hedges' g for Q, mean dQ / dCost, per-issue table.
+- Family-wise rate note rendered in the writeup (not the JSON).
+- **Secondary descriptive cross-tab**: also load trim/specialist/naive existing score dirs → render the 5-arm matrix (tailored, prose, trim, specialist, naive). No p-test on those — just `mean(Q)` and `mean(Q) - mean(tailored Q)` per arm for context.
+
+## Phase F — Writeup + PR
+
+**File**: `research/curve-redo-bundle/super-agent-tailored-results.md` + `super-agent-tailored-results.tar.gz` (selections.json, sizes.json, comparison.json, picks-tailored.tsv).
+
+Headline:
+- Quality: tailored vs prose mean dQ + Wilcoxon p (one-sided greater).
+- Cost: tailored vs prose mean dCost + Wilcoxon p (one-sided less).
+- Soft-bar verdict: which dimension(s) crossed p<0.05.
+- Secondary 5-arm matrix (tailored vs prose / trim / specialist / naive).
+
+**Selector audit** (subsection): for each issue, which sections were kept (count + IDs), median size of tailored CLAUDE.md across 13 issues, distribution of "keep ratio" (kept_sections / 122).
+
+PR opens on the `study/super-agent-tailored` worktree branched from `origin/main`.
+
+## Critical files
+
+| Path | Role |
+|---|---|
+| `research/curve-redo-bundle/super-agent/agent-super.CLAUDE.md` | Phase A — input pool (committed, 209 KB) |
+| `research/curve-redo-bundle/super-agent/super-agent-build-manifest.json` | Phase A — provenance reference |
+| `src/agent/split.ts` (`parseClaudeMdSections`) | Phase A — section parsing (built dist) |
+| `src/state/registry.ts` (`mutateRegistry`, `createAgent`) | Phase B — minting |
+| `src/agent/specialization.ts` (`agentClaudeMdPath`) | Phase B — write path |
+| `research/curve-redo-bundle/corpus.json` | Phase A, C — 13-issue corpus |
+| `research/curve-redo-bundle/specialist-redo/{dispatch,score,combine-and-compare}*` | Phases C/D/E — wrappers / model code |
+| `research/curve-redo-data/prose-baseline/{logs-leg{1,2},scores-leg{1,2}}/` | Phase E — comparator data |
+| `dist/src/research/curveStudy/cellScores.js` (`loadCellScores`, `qualityFromAB`) | Phase E — score loader |
+| `dist/src/research/specialistBench/stats.js` (`wilcoxonSignedRankPaired`, `hedgesG`) | Phase E — Wilcoxon |
+
+## Risks
+
+- **Selector over-drops core sections.** Subtractive bias toward keeping is a known LLM tendency, but the explicit `keep` rationale requirement could backfire — if Opus reads the system prompt as "you must justify each kept section," it may drop borderline sections to avoid low-confidence justifications. Mitigation: per-issue keep-ratio printed at Phase A end; if median ratio < 5/122, abort and re-prompt with a softer mandate.
+- **Selector cost variance.** 209 KB cached = $0.04 cache write + $0.001 cache read per call. Total 13-call selector cost should land at $1-3, not $5+. If a single call exceeds $1.50 (12% of expected total), pause and inspect — likely indicates the cache isn't warming.
+- **Per-issue agent contamination via super-agent's inherited lessons.** The super-agent was built from `agent-916a` and 46 other contributors; `agent-916a` worked the leg-2 issues originally → some sections name those issues directly. The tailored arm inherits this contamination identically to the prose-baseline arm, so the paired comparison is still apples-to-apples. Documented in caveats.
+- **Empty-selection issues.** If Opus drops every section for some issue (e.g., #156 dependency-tracker pushback), that issue's tailored agent ≡ naive. This is the *correct* selector behavior, but means tailored Q for that issue ≈ naive Q for that issue. Documented as expected outcome; don't treat as a bug.
+- **Cell cost-cap exhaustion mirror.** Issue #185 burned 3/6 super-trim seeds at the per-cell $2 cap in leg-1 of the curve study. A small tailored CLAUDE.md (low keep-ratio) faces the same risk. Mitigation: same per-cell cap as prose-baseline; cap-hit cells score as 0 quality with non-zero cost — same dataset shape.
+- **Statistical power.** n=13 paired Wilcoxon at α=0.05 detects effects of ~0.7-0.8 SD reliably. The prose-baseline arm's per-issue dQ stdev was ~12 points; detecting tailored vs prose at p<0.05 needs |mean dQ| ≥ 8-10 points. Smaller effects fail the test even if real.
+
+## Verification
+
+- **Selector idempotency**: re-running `select-rules.cjs` without `--force` should print `skip (selections.json exists)` for each issue and exit $0 with $0 spent.
+- **Section count invariant**: each `selections.json` entry has exactly 122 entries (matching super-agent H2 count); `keep + drop = 122` for every issue.
+- **Mint reproducibility**: re-running `build-tailored-agents.cjs` should produce byte-identical CLAUDE.mds (deterministic source-order concatenation).
+- **Empty-selection smoke**: feed a synthetic `selections.json` with zero `keep`s for issue #156; Phase B should write an empty `agents/agent-super-tailored-156/CLAUDE.md` (not crash) and Phase C should still dispatch (the spawn doesn't require a non-empty per-agent file).
+- **Combine empty-set smoke**: feed `combine-tailored.cjs` an empty score directory → it should emit `comparison.json` with `pairedIssueCount: 0` and `wilcoxon: null` rather than `Infinity` / `NaN` (per local CLAUDE.md "smoke-test the empty-result path" rule).
+- **End-to-end smoke**: 1 tailored agent × 1 issue × K=1 cell → log + diff captured + score files written → combiner emits a single-sample regression (degenerate but errors clean).
+
+## Out of scope
+
+- **Modifying the super-agent CLAUDE.md** ("parent agent is not modified yet"). Phase 2 of this initiative if tailored wins.
+- **Production wiring of per-issue rule selection into the dispatcher.** This experiment is measurement-only; whether to deploy is a follow-up.
+- **Larger corpus.** 13 issues mirrors prose-baseline directly; bigger corpus is a separate scoping decision.
+- **K>3 replicates.** Identical to prose-baseline so the paired comparison stays clean.

--- a/research/curve-redo-bundle/super-agent-tailored/build-tailored-agents.cjs
+++ b/research/curve-redo-bundle/super-agent-tailored/build-tailored-agents.cjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+// Super-agent tailored arm — Phase B: mint per-issue tailored agents.
+//
+// Reads selections.json (from select-rules.cjs) + super-agent file. For
+// each issue, writes a per-issue CLAUDE.md = concatenation of `keep`
+// sections in their original source order, and registers
+// `agent-super-tailored-<issueId>` in state/agents-registry.json.
+//
+// Snapshots agents-registry.json before mutation (defense in depth, per
+// prose-baseline §11). Idempotent: re-running on the same selections
+// produces byte-identical CLAUDE.mds.
+//
+// Usage:
+//   node research/curve-redo-bundle/super-agent-tailored/build-tailored-agents.cjs \
+//     --super-agent  research/curve-redo-bundle/super-agent/agent-super.CLAUDE.md \
+//     --selections   research/curve-redo-data/super-agent-tailored/selections.json \
+//     --out-dir      research/curve-redo-data/super-agent-tailored
+//     [--no-mint]                # render CLAUDE.mds only, skip registry mutation
+//
+// Reads built dist/ — run `npm run build` first.
+
+const path = require("node:path");
+const fs = require("node:fs");
+
+function parseArgs() {
+  const args = {};
+  const argv = process.argv.slice(2);
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === "--no-mint") { args["no-mint"] = true; continue; }
+    if (k.startsWith("--") && i + 1 < argv.length) {
+      args[k.slice(2)] = argv[i + 1];
+      i++;
+    }
+  }
+  return args;
+}
+
+function slugify(heading) {
+  const base = heading.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  return base.length > 0 ? base.slice(0, 80) : "section";
+}
+
+const SECTION_BOUNDARY =
+  /(<!--\s*run:[^\n]*-->)\s*\n##\s+([^\n]+)\n/g;
+
+function parseSuperAgentSections(md) {
+  const matches = [];
+  for (const m of md.matchAll(SECTION_BOUNDARY)) {
+    matches.push({ start: m.index, sentinel: m[1], heading: m[2].trim() });
+  }
+  if (matches.length === 0) {
+    throw new Error("No sentinel-tagged H2 sections found in super-agent file.");
+  }
+  const sections = [];
+  const taken = new Map();
+  for (let i = 0; i < matches.length; i++) {
+    const start = matches[i].start;
+    const end = i + 1 < matches.length ? matches[i + 1].start : md.length;
+    const fullBlock = md.slice(start, end).replace(/\s+$/, "");
+    let id = slugify(matches[i].heading);
+    const seen = taken.get(id) ?? 0;
+    if (seen > 0) id = `${id}-${seen + 1}`;
+    taken.set(slugify(matches[i].heading), seen + 1);
+    sections.push({ id, heading: matches[i].heading, fullBlock });
+  }
+  return sections;
+}
+
+async function main() {
+  const args = parseArgs();
+  const required = ["super-agent", "selections", "out-dir"];
+  for (const r of required) {
+    if (!args[r]) {
+      process.stderr.write(`Missing --${r}\n`);
+      process.exit(1);
+    }
+  }
+
+  const repoRoot = path.resolve(__dirname, "..", "..", "..");
+  const distRoot = path.join(repoRoot, "dist", "src");
+  const { mutateRegistry, ensureAgent } = require(path.join(distRoot, "state", "registry.js"));
+  const { agentClaudeMdPath, agentDir } = require(path.join(distRoot, "agent", "specialization.js"));
+
+  const superMd = fs.readFileSync(path.resolve(args["super-agent"]), "utf-8");
+  const sections = parseSuperAgentSections(superMd);
+  const sectionsById = new Map(sections.map((s) => [s.id, s]));
+  process.stderr.write(`Parsed ${sections.length} sections from super-agent file.\n`);
+
+  const selectionsRaw = JSON.parse(fs.readFileSync(path.resolve(args.selections), "utf-8"));
+  const byIssueId = selectionsRaw.byIssueId ?? {};
+  const issueIds = Object.keys(byIssueId).map(Number).sort((a, b) => a - b);
+  if (issueIds.length === 0) {
+    process.stderr.write("No issues in selections.json — nothing to mint.\n");
+    process.exit(0);
+  }
+  process.stderr.write(`Selections cover ${issueIds.length} issue(s): ${issueIds.join(", ")}\n`);
+
+  const outDir = path.resolve(args["out-dir"]);
+  fs.mkdirSync(outDir, { recursive: true });
+  const sizesPath = path.join(outDir, "sizes.json");
+
+  // Snapshot the registry before any mutation. Mirrors the prose-baseline
+  // §11 defense — recoverable if the run goes sideways.
+  const registryPath = path.join(repoRoot, "state", "agents-registry.json");
+  const snapshotPath = path.join(repoRoot, "state", "agents-registry.snapshot-pre-tailored.json");
+  if (fs.existsSync(registryPath) && !fs.existsSync(snapshotPath)) {
+    fs.copyFileSync(registryPath, snapshotPath);
+    process.stderr.write(`Registry snapshotted to ${snapshotPath}\n`);
+  } else if (fs.existsSync(snapshotPath)) {
+    process.stderr.write(`Snapshot already exists at ${snapshotPath} (idempotent skip).\n`);
+  } else {
+    process.stderr.write(`No registry at ${registryPath} yet — minting will create it.\n`);
+  }
+
+  const sizes = [];
+  const renderedByIssueId = new Map();
+
+  for (const issueId of issueIds) {
+    const sel = byIssueId[String(issueId)];
+    const keepIds = sel.selections.filter((s) => s.decision === "keep").map((s) => s.sectionId);
+    const keepIdSet = new Set(keepIds);
+    const keptInOrder = sections.filter((s) => keepIdSet.has(s.id));
+    const missingIds = keepIds.filter((id) => !sectionsById.has(id));
+    if (missingIds.length > 0) {
+      throw new Error(
+        `Issue #${issueId}: selections reference unknown sectionIds: ${missingIds.join(", ")}`,
+      );
+    }
+
+    const header = [
+      `# Tailored CLAUDE.md for issue #${issueId} (${sel.repo})`,
+      ``,
+      `Built by \`research/curve-redo-bundle/super-agent-tailored/build-tailored-agents.cjs\`.`,
+      `Source: \`research/curve-redo-bundle/super-agent/agent-super.CLAUDE.md\` (${sections.length} sections).`,
+      `Selector: ${sel.model}; kept ${keptInOrder.length}/${sections.length} sections.`,
+      ``,
+    ].join("\n");
+
+    const body = keptInOrder.map((s) => s.fullBlock).join("\n\n");
+    const claudeMd = keptInOrder.length === 0 ? header + "\n_(All sections dropped by the selector for this issue.)_\n" : `${header}\n${body}\n`;
+
+    renderedByIssueId.set(issueId, { agentId: `agent-super-tailored-${issueId}`, claudeMd, keptInOrder });
+
+    sizes.push({
+      issueId,
+      sectionsKept: keptInOrder.length,
+      sectionsTotal: sections.length,
+      bytesKept: claudeMd.length,
+      keepRatio: keptInOrder.length / sections.length,
+    });
+  }
+
+  // Mint registry entries first so `agentDir()` is consistent with state.
+  if (!args["no-mint"]) {
+    await mutateRegistry((reg) => {
+      for (const issueId of issueIds) {
+        const agentId = `agent-super-tailored-${issueId}`;
+        const rec = ensureAgent(reg, agentId);
+        rec.tags = ["super-agent-tailored", `issue-${issueId}`];
+        rec.lastActiveAt = new Date().toISOString();
+      }
+    });
+    process.stderr.write(`Minted ${issueIds.length} agent record(s) in registry.\n`);
+  } else {
+    process.stderr.write(`--no-mint: skipping registry mutation.\n`);
+  }
+
+  // Write per-issue CLAUDE.mds.
+  for (const issueId of issueIds) {
+    const { agentId, claudeMd } = renderedByIssueId.get(issueId);
+    const dir = agentDir(agentId);
+    fs.mkdirSync(dir, { recursive: true });
+    const claudePath = agentClaudeMdPath(agentId);
+    fs.writeFileSync(claudePath, claudeMd);
+  }
+
+  fs.writeFileSync(sizesPath, JSON.stringify({ generatedAt: new Date().toISOString(), sectionsTotal: sections.length, sizes }, null, 2));
+
+  process.stderr.write(`\nSize distribution (sorted by bytes asc):\n`);
+  const sorted = [...sizes].sort((a, b) => a.bytesKept - b.bytesKept);
+  for (const s of sorted) {
+    process.stderr.write(
+      `  #${s.issueId}: ${s.sectionsKept}/${s.sectionsTotal} sections, ${s.bytesKept} bytes (${(s.keepRatio * 100).toFixed(1)}%)\n`,
+    );
+  }
+  process.stderr.write(`\nSizes written to ${sizesPath}\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`${err.stack ?? err}\n`);
+  process.exit(1);
+});

--- a/research/curve-redo-bundle/super-agent-tailored/combine-tailored.cjs
+++ b/research/curve-redo-bundle/super-agent-tailored/combine-tailored.cjs
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+// Super-agent tailored arm — Phase E: paired Wilcoxon vs prose-baseline.
+//
+// Both arms (tailored and prose) write logs as
+// `bench-r<replicate>-<agentId>-<issueId>.log` and scores as
+// `<cellKey>-tests.json` / `<cellKey>-judge.json`. We pair by issueId
+// and run two one-sided Wilcoxon tests (quality H1: tailored > prose;
+// cost H1: tailored < prose). Soft-bar verdict: pass on either dimension
+// at unadjusted p<0.05 = significant.
+//
+// Optional descriptive 5-arm cross-tab (tailored, prose, trim, specialist,
+// naive) — no p-tests on the secondary arms; their existence is
+// narrative-only context.
+//
+// Usage:
+//   node combine-tailored.cjs \
+//     --tailored-leg1-logs <dir> --tailored-leg1-scores <dir> \
+//     --tailored-leg2-logs <dir> --tailored-leg2-scores <dir> \
+//     --prose-leg1-logs <dir>    --prose-leg1-scores <dir> \
+//     --prose-leg2-logs <dir>    --prose-leg2-scores <dir> \
+//     --picks <picks-tailored.tsv> \
+//     --output <comparison.json> \
+//     [--trim-leg1-logs <dir>      --trim-leg1-scores <dir> \
+//      --trim-leg2-logs <dir>      --trim-leg2-scores <dir>] \
+//     [--specialist-leg1-logs <dir> ... --specialist-leg2-scores <dir>] \
+//     [--naive-leg1-logs <dir>     ...  --naive-leg2-scores <dir>]
+//
+// Reads built dist/ — run `npm run build` first.
+
+const path = require("node:path");
+const fs = require("node:fs");
+
+function parseArgs() {
+  const args = {};
+  const argv = process.argv.slice(2);
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    if (k.startsWith("--") && i + 1 < argv.length) {
+      args[k.slice(2)] = argv[i + 1];
+      i++;
+    }
+  }
+  return args;
+}
+
+const REQUIRED = [
+  "tailored-leg1-logs", "tailored-leg1-scores",
+  "tailored-leg2-logs", "tailored-leg2-scores",
+  "prose-leg1-logs",    "prose-leg1-scores",
+  "prose-leg2-logs",    "prose-leg2-scores",
+  "picks", "output",
+];
+
+// `bench-r<replicate>-<agentId>-<issueId>.log` — used by both prose-baseline
+// and tailored arms. The trim baseline uses `curveStudy-<agent>-<issue>`.
+const BENCH_LOG_RE = /^bench-r(\d+)-(agent-[a-z0-9-]+)-(\d+)\.log$/;
+const CURVE_LOG_RE = /^curveStudy-(agent-[a-z0-9-]+)-(\d+)\.log$/;
+
+function dirExists(p) {
+  try { return fs.statSync(p).isDirectory(); } catch { return false; }
+}
+
+let distRoot;
+
+async function readBenchCells(armName, logsDir, qualityFromAB, scores) {
+  if (!logsDir || !dirExists(logsDir)) return [];
+  const { aggregateLog } = require(path.join(distRoot, "research", "curveStudy", "aggregate.js"));
+  const out = [];
+  for (const f of fs.readdirSync(logsDir).sort()) {
+    const m = BENCH_LOG_RE.exec(f);
+    if (!m) continue;
+    const replicate = Number(m[1]);
+    const agentId = m[2];
+    const issueId = Number(m[3]);
+    const cell = await aggregateLog({
+      logPath: path.join(logsDir, f),
+      agentId,
+      agentSizeBytes: 0,
+      issueId,
+    });
+    if (!cell) continue;
+    const cellKey = `bench-r${replicate}-${agentId}-${issueId}`;
+    const sc = scores.get(cellKey);
+    const quality = qualityFromAB({ decision: cell.decision, judge: sc?.judge, test: sc?.test });
+    out.push({
+      arm: armName, agentId, issueId, replicate,
+      decision: cell.decision, costUsd: cell.costUsd, quality,
+    });
+  }
+  return out;
+}
+
+async function readCurveCells(armName, logsDir, qualityFromAB, scores) {
+  if (!logsDir || !dirExists(logsDir)) return [];
+  const { aggregateLog } = require(path.join(distRoot, "research", "curveStudy", "aggregate.js"));
+  const out = [];
+  for (const f of fs.readdirSync(logsDir).sort()) {
+    const m = CURVE_LOG_RE.exec(f);
+    if (!m) continue;
+    const agentId = m[1];
+    const issueId = Number(m[2]);
+    const cell = await aggregateLog({
+      logPath: path.join(logsDir, f),
+      agentId,
+      agentSizeBytes: 0,
+      issueId,
+    });
+    if (!cell) continue;
+    const cellKey = `${agentId}-${issueId}`;
+    const sc = scores.get(cellKey);
+    const quality = qualityFromAB({ decision: cell.decision, judge: sc?.judge, test: sc?.test });
+    out.push({
+      arm: armName, agentId, issueId,
+      decision: cell.decision, costUsd: cell.costUsd, quality,
+    });
+  }
+  return out;
+}
+
+function groupByIssue(cells) {
+  const m = new Map();
+  for (const c of cells) {
+    let b = m.get(c.issueId);
+    if (!b) { b = []; m.set(c.issueId, b); }
+    b.push(c);
+  }
+  return m;
+}
+
+async function main() {
+  const args = parseArgs();
+  for (const r of REQUIRED) {
+    if (!args[r]) {
+      process.stderr.write(`Missing --${r}\n`);
+      process.stderr.write(`Required: ${REQUIRED.map((x) => "--" + x).join(" ")}\n`);
+      process.exit(1);
+    }
+  }
+
+  const repoRoot = path.resolve(__dirname, "..", "..", "..");
+  distRoot = path.join(repoRoot, "dist", "src");
+  const { qualityFromAB, loadCellScores } = require(path.join(distRoot, "research", "curveStudy", "cellScores.js"));
+  const { wilcoxonSignedRankPaired, hedgesG, mean, median } =
+    require(path.join(distRoot, "research", "specialistBench", "stats.js"));
+
+  // Load every score directory we were given.
+  const scoreDirs = {
+    tailored: [args["tailored-leg1-scores"], args["tailored-leg2-scores"]],
+    prose:    [args["prose-leg1-scores"],    args["prose-leg2-scores"]],
+    trim:       [args["trim-leg1-scores"],       args["trim-leg2-scores"]],
+    specialist: [args["specialist-leg1-scores"], args["specialist-leg2-scores"]],
+    naive:      [args["naive-leg1-scores"],      args["naive-leg2-scores"]],
+  };
+  const scoreMaps = {};
+  for (const [arm, dirs] of Object.entries(scoreDirs)) {
+    const merged = new Map();
+    for (const d of dirs) {
+      if (!d) continue;
+      const m = await loadCellScores(d);
+      for (const [k, v] of m) merged.set(k, v);
+    }
+    scoreMaps[arm] = merged;
+  }
+
+  // Load every log directory we were given. Bench-shaped vs curve-shaped
+  // is a function of the arm.
+  const logDirs = {
+    tailored:   { logs: [args["tailored-leg1-logs"],   args["tailored-leg2-logs"]],   shape: "bench" },
+    prose:      { logs: [args["prose-leg1-logs"],      args["prose-leg2-logs"]],      shape: "bench" },
+    trim:       { logs: [args["trim-leg1-logs"],       args["trim-leg2-logs"]],       shape: "curve" },
+    specialist: { logs: [args["specialist-leg1-logs"], args["specialist-leg2-logs"]], shape: "bench" },
+    naive:      { logs: [args["naive-leg1-logs"],      args["naive-leg2-logs"]],      shape: "bench" },
+  };
+  const cellsByArm = {};
+  for (const [arm, { logs, shape }] of Object.entries(logDirs)) {
+    const reader = shape === "bench" ? readBenchCells : readCurveCells;
+    const all = [];
+    for (const d of logs) {
+      if (!d) continue;
+      all.push(...(await reader(arm, d, qualityFromAB, scoreMaps[arm])));
+    }
+    cellsByArm[arm] = all;
+  }
+
+  // Pair per-issue: mean Q across replicates per arm.
+  const tailoredByIssue = groupByIssue(cellsByArm.tailored);
+  const proseByIssue = groupByIssue(cellsByArm.prose);
+  const pairedIssueIds = [...tailoredByIssue.keys()]
+    .filter((id) => proseByIssue.has(id))
+    .sort((a, b) => a - b);
+
+  // Picks → rationale lookup for stratification.
+  const picks = new Map();
+  if (fs.existsSync(args.picks)) {
+    const raw = fs.readFileSync(args.picks, "utf-8");
+    for (const line of raw.split(/\r?\n/)) {
+      if (!line || line.startsWith("issueId\t")) continue;
+      const parts = line.split("\t");
+      const issueId = Number(parts[0]);
+      if (Number.isFinite(issueId)) {
+        picks.set(issueId, { agentId: parts[1], rationale: parts[2] });
+      }
+    }
+  }
+
+  const perIssue = [];
+  for (const issueId of pairedIssueIds) {
+    const tCells = tailoredByIssue.get(issueId);
+    const pCells = proseByIssue.get(issueId);
+    const tQ = tCells.map((c) => c.quality);
+    const pQ = pCells.map((c) => c.quality);
+    const tCost = tCells.map((c) => c.costUsd);
+    const pCost = pCells.map((c) => c.costUsd);
+    const pick = picks.get(issueId);
+    perIssue.push({
+      issueId,
+      tailoredMeanQuality: mean(tQ),
+      proseMeanQuality: mean(pQ),
+      dQuality: mean(tQ) - mean(pQ),
+      tailoredMeanCostUsd: mean(tCost),
+      proseMeanCostUsd: mean(pCost),
+      dCost: mean(tCost) - mean(pCost),
+      tailoredReplicateCount: tCells.length,
+      proseReplicateCount: pCells.length,
+      pickedAgentId: pick?.agentId ?? null,
+      pickRationale: pick?.rationale ?? null,
+    });
+  }
+
+  // Two one-sided Wilcoxon tests.
+  const dQs = perIssue.map((p) => p.dQuality);
+  const dCosts = perIssue.map((p) => p.dCost);
+  const wilcoxonQuality = perIssue.length >= 1
+    ? wilcoxonSignedRankPaired(dQs, "greater")
+    : null;
+  const wilcoxonCost = perIssue.length >= 1
+    ? wilcoxonSignedRankPaired(dCosts, "less")
+    : null;
+  const hedgesQuality = perIssue.length >= 2 ? hedgesG(dQs) : Number.NaN;
+
+  // Secondary descriptive cross-tab. mean Q and mean cost per arm,
+  // restricted to issues that appear in BOTH tailored and that arm.
+  // No p-tests — narrative-only context for the writeup.
+  const secondary = {};
+  for (const arm of ["trim", "specialist", "naive"]) {
+    const armByIssue = groupByIssue(cellsByArm[arm]);
+    const overlap = pairedIssueIds.filter((id) => armByIssue.has(id));
+    if (overlap.length === 0) continue;
+    let dQSum = 0, dCostSum = 0, n = 0;
+    const perIssueOverlay = [];
+    for (const issueId of overlap) {
+      const tQ = mean(tailoredByIssue.get(issueId).map((c) => c.quality));
+      const tCost = mean(tailoredByIssue.get(issueId).map((c) => c.costUsd));
+      const aQ = mean(armByIssue.get(issueId).map((c) => c.quality));
+      const aCost = mean(armByIssue.get(issueId).map((c) => c.costUsd));
+      dQSum += (tQ - aQ);
+      dCostSum += (tCost - aCost);
+      n++;
+      perIssueOverlay.push({ issueId, tailoredQ: tQ, [`${arm}Q`]: aQ, dQ: tQ - aQ });
+    }
+    secondary[arm] = {
+      pairedIssueCount: n,
+      meanDQuality: n > 0 ? dQSum / n : null,
+      meanDCost: n > 0 ? dCostSum / n : null,
+      perIssue: perIssueOverlay,
+    };
+  }
+
+  // Soft-bar verdict.
+  const qPass = wilcoxonQuality && Number.isFinite(wilcoxonQuality.pValue) && wilcoxonQuality.pValue < 0.05;
+  const cPass = wilcoxonCost    && Number.isFinite(wilcoxonCost.pValue)    && wilcoxonCost.pValue    < 0.05;
+  const verdict =
+    qPass && cPass ? "win-on-both"
+    : qPass ? "win-on-quality"
+    : cPass ? "win-on-cost"
+    : "no-significant-difference";
+
+  const output = {
+    generatedAt: new Date().toISOString(),
+    armCounts: Object.fromEntries(Object.entries(cellsByArm).map(([k, v]) => [k, v.length])),
+    pairedIssueCount: pairedIssueIds.length,
+    perIssue,
+    test: {
+      hypothesis: {
+        quality: "median(dQuality = tailored - prose) > 0",
+        cost: "median(dCost = tailored - prose) < 0",
+        softBar: "win on either dimension at unadjusted p < 0.05",
+        familyWiseRateNote: "Holm-Bonferroni: smaller p must be < 0.025 if family-wise correction applied (~0.0975 uncorrected family rate)",
+      },
+      wilcoxonQuality,
+      wilcoxonCost,
+      hedgesGQuality: hedgesQuality,
+      verdict,
+    },
+    secondaryDescriptive: secondary,
+  };
+
+  fs.mkdirSync(path.dirname(path.resolve(args.output)), { recursive: true });
+  fs.writeFileSync(args.output, JSON.stringify(output, null, 2) + "\n");
+
+  // Empty-result-aware formatter — never emit raw NaN / Infinity.
+  const fmt = (x, digits = 3) => (Number.isFinite(x) ? x.toFixed(digits) : "n/a");
+
+  process.stdout.write(`\n=== super-agent-tailored vs prose-baseline ===\n`);
+  process.stdout.write(`tailored cells: ${cellsByArm.tailored.length} (${tailoredByIssue.size} issues)\n`);
+  process.stdout.write(`prose    cells: ${cellsByArm.prose.length} (${proseByIssue.size} issues)\n`);
+  process.stdout.write(`paired issues:  ${pairedIssueIds.length}\n\n`);
+
+  if (perIssue.length === 0) {
+    process.stdout.write(`No paired issues — nothing to test.\n`);
+    process.stdout.write(`Output written to ${args.output}.\n`);
+    return;
+  }
+
+  process.stdout.write(`issueId\ttailQ\tproseQ\tdQ\ttailCost\tproseCost\tdCost\trationale\n`);
+  for (const p of perIssue) {
+    process.stdout.write(
+      `${p.issueId}\t${fmt(p.tailoredMeanQuality, 1)}\t${fmt(p.proseMeanQuality, 1)}\t` +
+        `${fmt(p.dQuality, 1)}\t$${fmt(p.tailoredMeanCostUsd, 2)}\t$${fmt(p.proseMeanCostUsd, 2)}\t` +
+        `$${fmt(p.dCost, 2)}\t${p.pickRationale ?? "?"}\n`,
+    );
+  }
+  process.stdout.write(`\n`);
+  if (wilcoxonQuality) {
+    process.stdout.write(
+      `Wilcoxon (quality, H1: dQ > 0):    n=${wilcoxonQuality.n}, w+=${fmt(wilcoxonQuality.wPlus, 1)}, ` +
+        `z=${fmt(wilcoxonQuality.z, 3)}, p=${fmt(wilcoxonQuality.pValue, 4)}\n`,
+    );
+  }
+  if (wilcoxonCost) {
+    process.stdout.write(
+      `Wilcoxon (cost,    H1: dCost < 0): n=${wilcoxonCost.n}, w+=${fmt(wilcoxonCost.wPlus, 1)}, ` +
+        `z=${fmt(wilcoxonCost.z, 3)}, p=${fmt(wilcoxonCost.pValue, 4)}\n`,
+    );
+  }
+  process.stdout.write(`Hedges' g (quality): ${fmt(hedgesQuality, 3)}\n`);
+  process.stdout.write(`\nVerdict: ${verdict}\n`);
+
+  if (Object.keys(secondary).length > 0) {
+    process.stdout.write(`\nSecondary descriptive cross-tab (no p-test):\n`);
+    for (const [arm, s] of Object.entries(secondary)) {
+      process.stdout.write(
+        `  vs ${arm}: n=${s.pairedIssueCount}, mean dQ=${fmt(s.meanDQuality, 1)}, mean dCost=$${fmt(s.meanDCost, 2)}\n`,
+      );
+    }
+  }
+
+  process.stdout.write(`\nOutput written to ${args.output}.\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`${err.stack ?? err}\n`);
+  process.exit(1);
+});

--- a/research/curve-redo-bundle/super-agent-tailored/dispatch-tailored-parallel.sh
+++ b/research/curve-redo-bundle/super-agent-tailored/dispatch-tailored-parallel.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Super-agent tailored arm — Phase C: dispatch K=3 cells per issue.
+#
+# Thin wrapper over `dispatch-specialist-redo-parallel.sh`. The specialist
+# dispatcher is generic over picks.tsv → only the picks file path and
+# OUT_DIR change for the tailored arm. Per-issue agent IDs follow the
+# pattern `agent-super-tailored-<issueId>`, written by select-rules.cjs.
+#
+# Usage:
+#   SCRATCH_CLONES_DIR=<path> \
+#     bash dispatch-tailored-parallel.sh <leg> --parallel <N> [--dry-print]
+#
+# Example: SCRATCH_CLONES_DIR=/tmp/tailored-scratch \
+#            bash dispatch-tailored-parallel.sh 1 --parallel 4
+#
+# Required env / flags identical to the specialist wrapper. Differences:
+#   * OUT_DIR defaults to research/curve-redo-data/super-agent-tailored
+#   * picks.tsv read from $OUT_DIR/picks-tailored.tsv (rendered by Phase A)
+#
+# All other behavior — K=3, Sonnet 4.6, --dry-run / --no-target-claude-md
+# / --skip-summary / --no-registry-mutation, scratch-clone round-robin,
+# idempotent skip-if-log-exists, per-cell $2 cap — is identical.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+DEFAULT_OUT_DIR="$REPO_ROOT/research/curve-redo-data/super-agent-tailored"
+export OUT_DIR="${OUT_DIR:-$DEFAULT_OUT_DIR}"
+
+mkdir -p "$OUT_DIR"
+PICKS_SRC="$OUT_DIR/picks-tailored.tsv"
+PICKS_DST="$OUT_DIR/picks.tsv"
+if [[ ! -f "$PICKS_SRC" ]]; then
+  echo "ERROR: picks-tailored.tsv not found at $PICKS_SRC — run select-rules.cjs first." >&2
+  exit 2
+fi
+# specialist-redo-parallel.sh reads $OUT_DIR/picks.tsv. Symlink (idempotent).
+if [[ -L "$PICKS_DST" ]] && [[ "$(readlink "$PICKS_DST")" == "picks-tailored.tsv" ]]; then
+  : # already correct
+else
+  rm -f "$PICKS_DST"
+  ln -s "picks-tailored.tsv" "$PICKS_DST"
+fi
+
+exec bash "$REPO_ROOT/research/curve-redo-bundle/specialist-redo/dispatch-specialist-redo-parallel.sh" "$@"

--- a/research/curve-redo-bundle/super-agent-tailored/score-tailored.sh
+++ b/research/curve-redo-bundle/super-agent-tailored/score-tailored.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Super-agent tailored arm — Phase D: score logs.
+#
+# Thin wrapper over `score-specialist-redo.sh`. Differs only in OUT_DIR.
+# Same hidden-test fixtures, same K=3 Opus blind-grade pipeline.
+#
+# Usage:
+#   bash score-tailored.sh <leg>
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+DEFAULT_OUT_DIR="$REPO_ROOT/research/curve-redo-data/super-agent-tailored"
+export OUT_DIR="${OUT_DIR:-$DEFAULT_OUT_DIR}"
+
+exec bash "$REPO_ROOT/research/curve-redo-bundle/specialist-redo/score-specialist-redo.sh" "$@"

--- a/research/curve-redo-bundle/super-agent-tailored/select-rules.cjs
+++ b/research/curve-redo-bundle/super-agent-tailored/select-rules.cjs
@@ -1,0 +1,394 @@
+#!/usr/bin/env node
+// Super-agent tailored arm — Phase A: per-issue rule selector.
+//
+// For each of the 13 corpus issues, ask Opus to decide which H2 sections
+// from `agent-super.CLAUDE.md` (the deduped union of every existing
+// agent's CLAUDE.md, 122 sections, ~209 KB) help with THIS issue. The
+// super-agent prose is sent once as a cached system-prompt prefix; only
+// the issue body changes between calls. Output: per-issue keep/drop
+// audit + a picks.tsv compatible with the existing dispatcher wrapper.
+//
+// Usage:
+//   node research/curve-redo-bundle/super-agent-tailored/select-rules.cjs \
+//     --super-agent research/curve-redo-bundle/super-agent/agent-super.CLAUDE.md \
+//     --corpus      research/curve-redo-bundle/corpus.json \
+//     --out-dir     research/curve-redo-data/super-agent-tailored \
+//     [--force]                  # re-run even if selections.json exists for an issue
+//     [--max-call-usd 2.00]      # per-call hard cap (exit non-zero if exceeded)
+//     [--max-total-usd 15.00]    # aggregate hard cap
+//     [--model claude-opus-4-7[1m]]
+//
+// Reads built dist/ — run `npm run build` first.
+
+const path = require("node:path");
+const fs = require("node:fs");
+
+function parseArgs() {
+  const args = {};
+  const argv = process.argv.slice(2);
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === "--force") { args.force = true; continue; }
+    if (k.startsWith("--") && i + 1 < argv.length) {
+      args[k.slice(2)] = argv[i + 1];
+      i++;
+    }
+  }
+  return args;
+}
+
+// Slugify an H2 heading deterministically. Lowercase ASCII, runs of
+// non-alphanumerics → "-", trim leading/trailing "-". Identical input →
+// identical id. Collisions disambiguated downstream with -2, -3 suffixes.
+function slugify(heading) {
+  const base = heading
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return base.length > 0 ? base.slice(0, 80) : "section";
+}
+
+// Parse the super-agent into ordered H2 sections, each carrying its
+// preceding `<!-- run:... -->` sentinel + `## heading` line + body up to
+// the next sentinel. Mirrors `parseClaudeMdSections` in src/agent/split.ts
+// but skips the sentinel coupling — the super-agent file's preamble +
+// section-header structure is what we tokenize against.
+//
+// Returns: [{id, heading, sentinel, fullBlock, byteOffset}].
+const SECTION_BOUNDARY =
+  /(<!--\s*run:[^\n]*-->)\s*\n##\s+([^\n]+)\n/g;
+
+function parseSuperAgentSections(md) {
+  const matches = [];
+  for (const m of md.matchAll(SECTION_BOUNDARY)) {
+    matches.push({ start: m.index, sentinel: m[1], heading: m[2].trim() });
+  }
+  if (matches.length === 0) {
+    throw new Error(
+      "No sections found in super-agent file (expected `<!-- run:... -->` + `## heading` blocks).",
+    );
+  }
+  const sections = [];
+  const taken = new Map(); // slug -> count
+  for (let i = 0; i < matches.length; i++) {
+    const start = matches[i].start;
+    const end = i + 1 < matches.length ? matches[i + 1].start : md.length;
+    const fullBlock = md.slice(start, end).trimEnd();
+    let id = slugify(matches[i].heading);
+    const seen = taken.get(id) ?? 0;
+    if (seen > 0) id = `${id}-${seen + 1}`;
+    taken.set(slugify(matches[i].heading), seen + 1);
+    sections.push({
+      id,
+      heading: matches[i].heading,
+      sentinel: matches[i].sentinel,
+      fullBlock,
+      byteOffset: start,
+    });
+  }
+  return sections;
+}
+
+// Build the cache-stable system prompt. Sections are labeled `### Section
+// <id>: <heading>` (replacing the original `## ` so the LLM's section
+// tokens don't collide with its own JSON output structure).
+function buildSystemPrompt(sections) {
+  const header = `You are evaluating which lessons from a pooled-knowledge "super-agent" file should be kept for a coding agent assigned to ONE specific GitHub issue. Your job: for each numbered Section below, decide whether keeping that lesson would help the assigned coding agent on THIS specific issue, or whether dropping it makes the per-issue agent's prompt cleaner.
+
+The coding agent reads its CLAUDE.md once at dispatch time. Sections that don't apply to this issue's domain, mechanism, or decision class waste prompt context and may bias the agent toward irrelevant patterns. Sections that DO apply are valuable even when the connection is non-obvious — apply judgment, lean toward "drop" only when the section is clearly off-topic.
+
+YOUR OUTPUT — strict JSON, no prose around it, no code fences:
+
+{"selections": [{"sectionId": "<id>", "decision": "keep" | "drop", "reason": "<1 short sentence>"} ... ]}
+
+Rules:
+1. Output one entry per Section in the list below, in the same order. Total entries MUST equal the number of sections in the list.
+2. "decision" is exactly "keep" or "drop". No other strings.
+3. "reason" is one short sentence (≤25 words). For "keep", state why it applies to this issue. For "drop", state why it's off-topic.
+
+The Sections (each block is one rule):
+
+`;
+  const blocks = sections.map((s, i) => {
+    return `### Section ${s.id}: ${s.heading}\n\n${s.fullBlock.replace(/^## /m, "## ")}`;
+  });
+  return header + blocks.join("\n\n") + "\n";
+}
+
+function loadCorpus(corpusPath) {
+  const raw = fs.readFileSync(corpusPath, "utf-8");
+  return JSON.parse(raw).issues;
+}
+
+async function callOpus({ systemPrompt, userPrompt, model, claudeBinPath, query, BOUNDARY }) {
+  const stream = query({
+    prompt: userPrompt,
+    options: {
+      model,
+      systemPrompt: [systemPrompt, BOUNDARY],
+      tools: [],
+      permissionMode: "default",
+      env: process.env,
+      maxTurns: 1,
+      settingSources: [],
+      persistSession: false,
+      pathToClaudeCodeExecutable: claudeBinPath(),
+    },
+  });
+  let raw = "";
+  let costUsd = 0;
+  let usage = null;
+  let isError = false;
+  let errorReason = "";
+  for await (const msg of stream) {
+    if (msg.type === "result") {
+      costUsd = msg.total_cost_usd ?? 0;
+      usage = msg.usage ?? null;
+      if (msg.subtype === "success") raw = msg.result;
+      else { isError = true; errorReason = msg.subtype; }
+    }
+  }
+  return { raw, costUsd, usage, isError, errorReason };
+}
+
+function parseSelectorOutput(raw, sectionIds) {
+  // Tolerant JSON extraction: take the largest balanced {...} substring.
+  const start = raw.indexOf("{");
+  if (start < 0) throw new Error("No JSON object in selector output");
+  const candidate = raw.slice(start);
+  let parsed;
+  try { parsed = JSON.parse(candidate); }
+  catch {
+    // Try trailing fence stripping.
+    const lastBrace = candidate.lastIndexOf("}");
+    if (lastBrace < 0) throw new Error("Unbalanced JSON in selector output");
+    parsed = JSON.parse(candidate.slice(0, lastBrace + 1));
+  }
+  if (!parsed || !Array.isArray(parsed.selections)) {
+    throw new Error("Selector output missing `selections` array");
+  }
+  const expected = new Set(sectionIds);
+  const seen = new Set();
+  const validated = [];
+  for (const entry of parsed.selections) {
+    if (!entry || typeof entry !== "object") {
+      throw new Error("Selection entry is not an object");
+    }
+    const { sectionId, decision, reason } = entry;
+    if (typeof sectionId !== "string" || !expected.has(sectionId)) {
+      throw new Error(`Unknown sectionId in selector output: ${sectionId}`);
+    }
+    if (seen.has(sectionId)) {
+      throw new Error(`Duplicate sectionId in selector output: ${sectionId}`);
+    }
+    if (decision !== "keep" && decision !== "drop") {
+      throw new Error(`Invalid decision for ${sectionId}: ${decision}`);
+    }
+    seen.add(sectionId);
+    validated.push({
+      sectionId,
+      decision,
+      reason: typeof reason === "string" ? reason.slice(0, 240) : "",
+    });
+  }
+  // Allow partial coverage if every entry is valid — but warn loudly.
+  // Any missing section is filled in as `keep` by default (conservative).
+  for (const id of sectionIds) {
+    if (!seen.has(id)) {
+      validated.push({
+        sectionId: id,
+        decision: "keep",
+        reason: "(missing from selector output; defaulted to keep)",
+      });
+    }
+  }
+  return validated;
+}
+
+async function main() {
+  const args = parseArgs();
+  const required = ["super-agent", "corpus", "out-dir"];
+  for (const r of required) {
+    if (!args[r]) {
+      process.stderr.write(`Missing --${r}\n`);
+      process.exit(1);
+    }
+  }
+
+  const repoRoot = path.resolve(__dirname, "..", "..", "..");
+  const distRoot = path.join(repoRoot, "dist", "src");
+  const sdk = require("@anthropic-ai/claude-agent-sdk");
+  const { query, SYSTEM_PROMPT_DYNAMIC_BOUNDARY } = sdk;
+  if (typeof query !== "function") {
+    throw new Error("Anthropic Agent SDK `query` not available — run `npm ci && npm run build`.");
+  }
+  const { claudeBinPath } = require(path.join(distRoot, "agent", "sdkBinary.js"));
+  const { getIssue } = require(path.join(distRoot, "github", "gh.js"));
+
+  const model = args.model ?? "claude-opus-4-7[1m]";
+  const maxCallUsd = Number(args["max-call-usd"] ?? 2.0);
+  const maxTotalUsd = Number(args["max-total-usd"] ?? 15.0);
+
+  const superMd = fs.readFileSync(path.resolve(args["super-agent"]), "utf-8");
+  const sections = parseSuperAgentSections(superMd);
+  process.stderr.write(`Parsed ${sections.length} sections from super-agent file (${superMd.length} bytes).\n`);
+
+  const issues = loadCorpus(path.resolve(args.corpus));
+  process.stderr.write(`Corpus: ${issues.length} issues across legs ${[...new Set(issues.map(i => i.leg))].sort().join(",")}.\n`);
+
+  const outDir = path.resolve(args["out-dir"]);
+  fs.mkdirSync(outDir, { recursive: true });
+  const selectionsPath = path.join(outDir, "selections.json");
+  const picksPath = path.join(outDir, "picks-tailored.tsv");
+
+  // Resume support: load existing selections (per-issue keyed).
+  let allSelections = {};
+  if (fs.existsSync(selectionsPath) && !args.force) {
+    try {
+      allSelections = JSON.parse(fs.readFileSync(selectionsPath, "utf-8")).byIssueId ?? {};
+      const completed = Object.keys(allSelections).length;
+      if (completed > 0) {
+        process.stderr.write(`Resuming: ${completed} issues already have selections (use --force to redo).\n`);
+      }
+    } catch (err) {
+      process.stderr.write(`WARN: failed to parse existing selections.json (${err.message}); starting fresh.\n`);
+      allSelections = {};
+    }
+  }
+
+  // Stable system prompt — build once, send 13 times (cache-stable prefix).
+  const systemPrompt = buildSystemPrompt(sections);
+  process.stderr.write(`System prompt: ${systemPrompt.length} bytes (~${Math.round(systemPrompt.length / 4)} tokens).\n`);
+
+  const sectionIds = sections.map((s) => s.id);
+  let totalUsd = 0;
+  const newlyProcessed = [];
+
+  for (const issue of issues) {
+    const issueKey = String(issue.issueId);
+    if (allSelections[issueKey] && !args.force) {
+      process.stderr.write(`#${issue.issueId}: skip (selections exist)\n`);
+      continue;
+    }
+
+    process.stderr.write(`#${issue.issueId}: fetching body via gh ${issue.repo}#${issue.issueId}\n`);
+    const summary = await getIssue(issue.repo, issue.issueId);
+    if (!summary) {
+      throw new Error(`gh issue view failed for ${issue.repo}#${issue.issueId}`);
+    }
+
+    const userPrompt = [
+      `# Target issue`,
+      `Repository: ${issue.repo}`,
+      `Issue ID: #${issue.issueId}`,
+      `Decision class (operator-labeled): ${issue.decisionClass ?? "(unspecified)"}`,
+      `State: ${issue.state ?? "open"}`,
+      ``,
+      `## Title`,
+      summary.title,
+      ``,
+      `## Body`,
+      summary.body || "(empty)",
+      ``,
+      `Apply your selection decisions per the system prompt's rules. Output ONLY the JSON object.`,
+    ].join("\n");
+
+    const t0 = Date.now();
+    const { raw, costUsd, usage, isError, errorReason } = await callOpus({
+      systemPrompt,
+      userPrompt,
+      model,
+      claudeBinPath,
+      query,
+      BOUNDARY: SYSTEM_PROMPT_DYNAMIC_BOUNDARY,
+    });
+    const wallMs = Date.now() - t0;
+
+    if (isError) {
+      throw new Error(`Selector LLM call failed for #${issue.issueId}: ${errorReason}`);
+    }
+    if (costUsd > maxCallUsd) {
+      throw new Error(
+        `Selector call for #${issue.issueId} exceeded per-call cap: $${costUsd.toFixed(4)} > $${maxCallUsd.toFixed(2)}`,
+      );
+    }
+
+    let selections;
+    try {
+      selections = parseSelectorOutput(raw, sectionIds);
+    } catch (err) {
+      throw new Error(`Selector output for #${issue.issueId} did not parse: ${err.message}\nRaw output (first 500 bytes): ${raw.slice(0, 500)}`);
+    }
+
+    const keepCount = selections.filter((s) => s.decision === "keep").length;
+    const dropCount = selections.length - keepCount;
+
+    allSelections[issueKey] = {
+      issueId: issue.issueId,
+      repo: issue.repo,
+      leg: issue.leg,
+      labels: summary.labels ?? [],
+      model,
+      costUsd,
+      wallMs,
+      usage,
+      keepCount,
+      dropCount,
+      sectionTotal: sections.length,
+      selections,
+    };
+
+    totalUsd += costUsd;
+    newlyProcessed.push(issue.issueId);
+    process.stderr.write(
+      `#${issue.issueId}: keep=${keepCount}/${sections.length} drop=${dropCount} cost=$${costUsd.toFixed(4)} wall=${wallMs}ms total=$${totalUsd.toFixed(4)}\n`,
+    );
+
+    // Incremental save after every issue so a crash doesn't lose work.
+    fs.writeFileSync(
+      selectionsPath,
+      JSON.stringify({ generatedAt: new Date().toISOString(), model, sectionTotal: sections.length, byIssueId: allSelections }, null, 2),
+    );
+
+    if (totalUsd > maxTotalUsd) {
+      throw new Error(`Aggregate selector cost exceeded cap: $${totalUsd.toFixed(4)} > $${maxTotalUsd.toFixed(2)}`);
+    }
+  }
+
+  // Render picks-tailored.tsv with the same column shape as picks-prose.tsv.
+  const picksLines = ["issueId\tagentId\trationale\tscore\tleg\tlabels"];
+  for (const issue of issues) {
+    const sel = allSelections[String(issue.issueId)];
+    if (!sel) continue;
+    const agentId = `agent-super-tailored-${issue.issueId}`;
+    const rationale = `tailored-keep-${sel.keepCount}-of-${sel.sectionTotal}`;
+    const labels = (sel.labels ?? []).join(",");
+    picksLines.push(
+      `${issue.issueId}\t${agentId}\t${rationale}\t0.0000\t${issue.leg}\t${labels}`,
+    );
+  }
+  fs.writeFileSync(picksPath, picksLines.join("\n") + "\n");
+
+  // Summary distribution.
+  const keepRatios = [];
+  for (const issue of issues) {
+    const sel = allSelections[String(issue.issueId)];
+    if (!sel) continue;
+    keepRatios.push({ issueId: issue.issueId, keep: sel.keepCount, ratio: sel.keepCount / sel.sectionTotal });
+  }
+  keepRatios.sort((a, b) => a.keep - b.keep);
+  process.stderr.write(`\nSelections written to ${selectionsPath}\nPicks written to ${picksPath}\n`);
+  process.stderr.write(`\nKeep-count distribution (sorted asc):\n`);
+  for (const r of keepRatios) {
+    process.stderr.write(`  #${r.issueId}: ${r.keep} kept (${(r.ratio * 100).toFixed(1)}%)\n`);
+  }
+  process.stderr.write(`\nNewly processed: ${newlyProcessed.length} issue(s); total selector cost: $${totalUsd.toFixed(4)}\n`);
+  if (newlyProcessed.length === 0) {
+    process.stderr.write(`Re-run with --force to redo all issues.\n`);
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`${err.stack ?? err}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Phase A-E scripts + experiment plan for the super-agent tailored arm: build a fresh per-issue agent by subtracting irrelevant H2 rules from `agents/agent-super/CLAUDE.md` (the deduped union of every existing agent's CLAUDE.md, 209 KB / 122 H2 sections). Hypothesis: tailored arm wins on Q OR cost vs the prose-baseline picker arm at unadjusted p<0.05.

**Soft-bar verdict** (per user direction): win on either dimension = significant. Both unadjusted Wilcoxon p-values reported with a Holm-Bonferroni note (smaller p < 0.025 if family-wise correction is preferred).

**Comparator**: prose-baseline arm only ([#272](https://github.com/szhygulin/vaultpilot-dev-framework/pull/272)). Same K=3, n=13, paired by issueId; super-agent-curve data was rejected as comparator because K=1 + random byte-trimming answers a different question.

**Scope**: setup only — no API budget consumed. Operator runs Phase A separately to review selections before committing to Phase C dispatch.

## Pipeline

| Phase | Script | Cost | What |
|---|---|---:|---|
| A | `select-rules.cjs` | ~$3-5 | Opus 4.7, 209 KB super-agent prose cached as system prompt; per-issue keep/drop JSON. Per-call cap $2, aggregate $15. |
| B | `build-tailored-agents.cjs` | $0 | Mint `agent-super-tailored-<issueId>` × 13; per-issue CLAUDE.md = kept sections in source order. Snapshot+restore registry. |
| C | `dispatch-tailored-parallel.sh` | ~$45 | Symlinks `picks.tsv → picks-tailored.tsv`, execs `dispatch-specialist-redo-parallel.sh`. K=3, Sonnet 4.6, identical flags. |
| D | `score-tailored.sh` | ~$10 | Thin shim over `score-specialist-redo.sh`. |
| E | `combine-tailored.cjs` | $0 | Two one-sided paired Wilcoxon tests; soft-bar verdict; optional 5-arm descriptive cross-tab. |

Total budget envelope: ~$60. Smoke leg 1 first (~$15), checkpoint, then leg 2.

## Design decisions (named explicitly)

- **Selection mode**: subtractive (start full, drop irrelevant) — matches the user's "dropping rules not needed" framing.
- **Selection unit**: H2 section (`## ` heading), matching `parseClaudeMdSections` and the super-agent's build pipeline.
- **Selector model**: Opus 4.7, identical to prose-baseline picker.
- **Caching**: super-agent prose pinned as cache-stable prefix → ~$3-5 selector cost vs ~$30 uncached.
- **Per-issue agent**: 13 fresh `agent-super-tailored-<issueId>` agents, snapshot+restore registry.
- **Empty-selection edge case**: allowed; tailored CLAUDE.md = empty header → behaves like naive. Documented as expected outcome.
- **Parent super-agent file held constant** — modification is deferred to a follow-up phase.

## Smoke verified

- Section parser: 122/122 hits on real super-agent file.
- `npm ci && npm run build && npm run typecheck` clean.
- All-drop fixture → 344-byte header-only CLAUDE.md, no crash.
- 3-keep mixed fixture → sentinel-prefixed sections preserved verbatim, source order intact.
- Dispatch wrapper dry-print → K=3 cells synthesized, log naming matches `bench-r<N>-<agent>-<issue>` regex used by combiner.
- Combine empty-result → `wilcoxonQuality: null`, `verdict: "no-significant-difference"`, no NaN/Infinity (per local CLAUDE.md "smoke-test the empty-result path" rule).

## Test plan

- [ ] Phase A: `node select-rules.cjs ...` — review keep/drop ratios + per-issue rationales in `selections.json` before proceeding.
- [ ] Phase B: `node build-tailored-agents.cjs ...` — verify 13 minted agents, inspect a few CLAUDE.mds.
- [ ] Phase C smoke leg 1 (~$15) — checkpoint cell-cost distribution against prose-baseline leg 1 before launching leg 2.
- [ ] Phase C leg 2.
- [ ] Phase D scoring (~$10).
- [ ] Phase E combine — two Wilcoxon p-values, soft-bar verdict, 5-arm cross-tab; writeup PR follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)