### PR TITLE
study(corpus): enrich to 19 issues — +3 mcp, +3 dev-framework

### DIFF
--- a/research/curve-redo-bundle/corpus.json
+++ b/research/curve-redo-bundle/corpus.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Curve-redo experiment corpus. 13 issues split across 2 legs (vp-mcp / vp-dev-agents). Each cell runs ISOLATED (no target-repo CLAUDE.md, no user-global CLAUDE.md \u2014 only per-agent CLAUDE.md per the size axis). Closed issues replay-rollback to baseSha (the codebase right before the fix landed). Open issues run against current main. Quality scoring: A (judge, 0-50) + B (test pass rate, 0-50) = 0-100; pushback uses 2A.",
+  "_comment": "Curve-redo experiment corpus. 19 issues split across 2 legs (vp-mcp / vp-dev-agents). Each cell runs ISOLATED (no target-repo CLAUDE.md, no user-global CLAUDE.md \u2014 only per-agent CLAUDE.md per the size axis). Closed issues replay-rollback to baseSha (the codebase right before the fix landed). Open issues run against current main. Quality scoring: A (judge, 0-50) + B (test pass rate, 0-50) = 0-100; pushback uses 2A. Original 13 issues from the 2026-04 trim study + 6 enrichment additions (2026-05-12) for n\u219219 power. The new 6 entries do NOT yet have hidden tests authored \u2014 implement-class cells will grade on judge-A only until tests land (a follow-up PR can author them by replaying the closed PRs' diffs for the closed entries and reading the spec for the open ones).",
   "model": "claude-sonnet-4-6",
   "trims": {
     "agentsSpec": "research/issue-179-leg2-bundle/agents-spec-phase3.json",
@@ -147,6 +147,70 @@
       "baseSha": "834d80f6ab80",
       "title": "feat: load user global `~/.claude/CLAUDE.md` into the agent prompt as a third layer",
       "testsDestRelDir": "src/agent"
+    },
+    {
+      "issueId": 626,
+      "repo": "szhygulin/vaultpilot-mcp",
+      "framework": "vitest",
+      "leg": 1,
+      "decisionClass": "implement",
+      "state": "closed",
+      "closedByPr": 628,
+      "baseSha": "074673f489b3",
+      "title": "[agent-request] prepare_curve_swap (steth_to_eth) — swap leg refused by destination-allowlist gate (companion to #618)",
+      "_comment": "Enrichment-batch (2026-05-12) — closed implement, destination-allowlist ack on swap leg. Hidden tests not yet authored."
+    },
+    {
+      "issueId": 667,
+      "repo": "szhygulin/vaultpilot-mcp",
+      "framework": "vitest",
+      "leg": 1,
+      "decisionClass": "implement",
+      "state": "open",
+      "title": "import_readonly_token bypasses preflight Step 0 binding",
+      "_comment": "Enrichment-batch (2026-05-12) — open security_finding. Implement-class: agent should design a fix that binds import to preflight Step 0."
+    },
+    {
+      "issueId": 669,
+      "repo": "szhygulin/vaultpilot-mcp",
+      "framework": "vitest",
+      "leg": 1,
+      "decisionClass": "implement",
+      "state": "open",
+      "title": "Rogue RPC corroborates presale scam — chain-data integrity gap",
+      "_comment": "Enrichment-batch (2026-05-12) — open security_finding. Implement-class: cross-RPC corroboration / chain-data integrity defense."
+    },
+    {
+      "issueId": 253,
+      "repo": "szhygulin/vaultpilot-dev-framework",
+      "framework": "node-test",
+      "leg": 2,
+      "decisionClass": "implement",
+      "state": "closed",
+      "closedByPr": 262,
+      "baseSha": "661ac08a7cbe",
+      "title": "applyReplayRollback strips origin from shared .git/config, breaking multi-cell --replay-base-sha dispatch",
+      "_comment": "Enrichment-batch (2026-05-12) — closed implement, replay-mode origin restore fix. Hidden tests not yet authored."
+    },
+    {
+      "issueId": 251,
+      "repo": "szhygulin/vaultpilot-dev-framework",
+      "framework": "node-test",
+      "leg": 2,
+      "decisionClass": "implement",
+      "state": "open",
+      "title": "claudeBinPath(): auto-detect glibc vs musl, eliminate VP_DEV_CLAUDE_BIN env-var requirement",
+      "_comment": "Enrichment-batch (2026-05-12) — open implement, libc auto-detect in SDK binary resolver."
+    },
+    {
+      "issueId": 173,
+      "repo": "szhygulin/vaultpilot-dev-framework",
+      "framework": "node-test",
+      "leg": 2,
+      "decisionClass": "pushback",
+      "state": "open",
+      "title": "feat: vp-dev agents tighten-claude-md — Phase B `--apply` / `--confirm <token>` (destructive)",
+      "_comment": "Enrichment-batch (2026-05-12) — open pushback. Body has explicit bake-window: 'do not dispatch until #172 has run for at least one month'. Agent should push back referencing the bake-window rule in CLAUDE.md, not implement."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Expands `research/curve-redo-bundle/corpus.json` from 13 → 19 issues. Per the chase strategy named at the end of [#289](https://github.com/szhygulin/vaultpilot-dev-framework/pull/289), doubling n is the highest-leverage path to crossing p<0.05 if v1's directional signal holds (cost-axis 95% CI excluded zero; Wilcoxon p=0.104 → projects to ~0.03 at n=26).

## What's added

**vaultpilot-mcp (+3):**
| Issue | State | Class | Source |
|---:|---|---|---|
| [#626](https://github.com/szhygulin/vaultpilot-mcp/issues/626) | closed | implement | PR #628 — destination-allowlist ack on swap leg |
| [#667](https://github.com/szhygulin/vaultpilot-mcp/issues/667) | open | implement | `security_finding` — import_readonly_token preflight bypass |
| [#669](https://github.com/szhygulin/vaultpilot-mcp/issues/669) | open | implement | `security_finding` — Rogue RPC chain-data integrity |

**vaultpilot-dev-framework (+3):**
| Issue | State | Class | Source |
|---:|---|---|---|
| [#253](https://github.com/szhygulin/vaultpilot-dev-framework/issues/253) | closed | implement | PR #262 — applyReplayRollback origin restore |
| [#251](https://github.com/szhygulin/vaultpilot-dev-framework/issues/251) | open | implement | claudeBinPath glibc/musl auto-detect |
| [#173](https://github.com/szhygulin/vaultpilot-dev-framework/issues/173) | open | pushback | tighten-claude-md Phase B (bake-window pushback — canonical case for testing whether tailored selector picks up the bake-window discipline rule) |

## Distribution shift

| | Before (n=13) | After (n=19) |
|---|---:|---:|
| Per repo | 6 / 7 | 9 / 10 |
| Open / closed | 6 / 7 | 10 / 9 |
| Implement / pushback | 9 / 4 | 14 / 5 |

More open + more implement = more data on the noisy axes. The new pushback (#173) is a canonical bake-window pushback — the kind of decision tailored prompting should make easier.

## What's deferred

Hidden tests for the 6 new entries are NOT in this PR. The existing 13 issues each carry ~100 hand-written test fixtures under `research/curve-redo-bundle/curve-redo-tests/<issueId>/`. Authoring 600+ tests is a separate task. Implement-class cells on the new 6 will grade on judge-A only (combined-Q formula returns 0 when tests are absent for implements).

A follow-up PR can author tests by:
1. **Closed entries (#626, #253)**: replay the PR diffs, derive `assert.match` patterns from the diff content (the existing test style — read `src/<file>` and grep for specific code patterns)
2. **Open entries (#667, #669, #251)**: read the issue spec, write aspirational tests for expected post-fix behavior
3. **Pushback entry (#173)**: no tests needed — judge-A handles pushback grading natively

## Test plan

- [x] `corpus.json` parses as valid JSON (verified locally).
- [x] All 6 new entries have required fields (issueId, repo, framework, leg, state, decisionClass, title).
- [x] Closed entries have `closedByPr` + `baseSha` (12-char prefix).
- [x] baseSha verified via `gh api repos/.../pulls/<n>` for each closed PR.
- [x] All 6 source issues/PRs exist + are in the expected state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)