### PR TITLE
study(corpus): hidden tests for the +6 enrichment issues

### DIFF
--- a/research/curve-redo-bundle/curve-redo-tests/251/b1-claudeBinPath-still-exported.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/251/b1-claudeBinPath-still-exported.test.ts
@@ -1,0 +1,7 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+test("claudeBinPath is still exported from sdkBinary.js", async () => {
+  const mod: any = await import("./sdkBinary.js");
+  assert.equal(typeof mod.claudeBinPath, "function");
+});

--- a/research/curve-redo-bundle/curve-redo-tests/251/b1-env-override-preserved.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/251/b1-env-override-preserved.test.ts
@@ -1,0 +1,11 @@
+// The VP_DEV_CLAUDE_BIN env-var must still work as an escape hatch
+// (operator override wins).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("sdkBinary still honors VP_DEV_CLAUDE_BIN env-var override", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/sdkBinary.ts"), "utf8");
+  assert.match(src, /VP_DEV_CLAUDE_BIN/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/251/b1-env-takes-priority-over-detection.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/251/b1-env-takes-priority-over-detection.test.ts
@@ -1,0 +1,17 @@
+// Env-var override must be checked BEFORE auto-detection.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("VP_DEV_CLAUDE_BIN check appears before any libc-detect call", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/sdkBinary.ts"), "utf8");
+  const envIdx = src.indexOf("VP_DEV_CLAUDE_BIN");
+  assert.ok(envIdx > 0);
+  // Find the libc-detect signature index (glibcVersionRuntime / getReport)
+  const detectMatch = src.match(/glibcVersionRuntime|getReport|detectLibc/);
+  if (detectMatch) {
+    const detectIdx = src.indexOf(detectMatch[0]);
+    assert.ok(envIdx < detectIdx, `env check (${envIdx}) should precede libc detect (${detectIdx})`);
+  }
+});

--- a/research/curve-redo-bundle/curve-redo-tests/251/b1-falls-back-to-musl-on-musl.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/251/b1-falls-back-to-musl-on-musl.test.ts
@@ -1,0 +1,11 @@
+// Both artifact paths must be referenced by the auto-detect logic.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("sdkBinary references both glibc and musl artifact paths", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/sdkBinary.ts"), "utf8");
+  assert.match(src, /claude-agent-sdk-linux-x64\b/);
+  assert.match(src, /claude-agent-sdk-linux-x64-musl/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/251/b1-returns-string-no-throw.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/251/b1-returns-string-no-throw.test.ts
@@ -1,0 +1,11 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+test("claudeBinPath returns a string and does not throw on default invocation", async () => {
+  const mod: any = await import("./sdkBinary.js");
+  // No env override set in test process (or whatever is set by harness).
+  // We just verify the call doesn't throw and yields a string.
+  const result = mod.claudeBinPath();
+  assert.equal(typeof result, "string");
+  assert.ok(result.length > 0);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/251/b1-sdk-binary-module-exists.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/251/b1-sdk-binary-module-exists.test.ts
@@ -1,0 +1,12 @@
+// Issue #251 — claudeBinPath() auto-detect glibc vs musl. The fix
+// modifies src/agent/sdkBinary.ts to detect libc at runtime and select
+// the correct sibling artifact under node_modules/@anthropic-ai/.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("sdkBinary source exists at src/agent/sdkBinary.ts", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/sdkBinary.ts"), "utf8");
+  assert.ok(src.length > 0);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/251/b1-uses-glibc-version-runtime-probe.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/251/b1-uses-glibc-version-runtime-probe.test.ts
@@ -1,0 +1,12 @@
+// The proposed primary mechanism (from the issue body) is
+// process.report.getReport().header.glibcVersionRuntime — defined string
+// on glibc, undefined on musl.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("sdkBinary references glibcVersionRuntime or an equivalent libc probe", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/sdkBinary.ts"), "utf8");
+  assert.match(src, /glibcVersionRuntime|getReport|ldd|isGlibc|isMusl|detectLibc/i);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/251/b2-no-shell-out-required.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/251/b2-no-shell-out-required.test.ts
@@ -1,0 +1,15 @@
+// Primary detection should use process.report (zero-cost, built-in).
+// `ldd` shell-out is an acceptable fallback but shouldn't dominate.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("sdkBinary uses process.report or equivalent built-in detection (not pure ldd)", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/sdkBinary.ts"), "utf8");
+  // Either glibcVersionRuntime / getReport (built-in) OR an explicit
+  // detect-libc dependency import.
+  const hasBuiltIn = /glibcVersionRuntime|getReport/.test(src);
+  const hasLib = /detect-libc/.test(src);
+  assert.ok(hasBuiltIn || hasLib, "auto-detect needs a libc probe (process.report or detect-libc)");
+});

--- a/research/curve-redo-bundle/curve-redo-tests/251/b2-rationale-comment-references-issue-251.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/251/b2-rationale-comment-references-issue-251.test.ts
@@ -1,0 +1,9 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("sdkBinary cites issue #251 in a comment", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/sdkBinary.ts"), "utf8");
+  assert.match(src, /#251/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/251/b3-no-removal-of-error-message.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/251/b3-no-removal-of-error-message.test.ts
@@ -1,0 +1,13 @@
+// The original error path (binary not found) must still produce an
+// actionable error if neither libc artifact resolves. The fix removes the
+// burden of remembering VP_DEV_CLAUDE_BIN, but the error message should
+// still be useful if both artifacts are missing.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("sdkBinary still surfaces an error / throws when no artifact resolves", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/sdkBinary.ts"), "utf8");
+  assert.match(src, /throw\s+new\s+Error|throw\s+Error/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/253/b1-apply-replay-returns-object.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/253/b1-apply-replay-returns-object.test.ts
@@ -1,0 +1,11 @@
+// PR #262 changed applyReplayRollback's return type from Promise<void> to
+// Promise<ApplyReplayRollbackResult> (so the caller can capture originUrl).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("applyReplayRollback signature returns ApplyReplayRollbackResult, not void", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/replay.ts"), "utf8");
+  assert.match(src, /applyReplayRollback[\s\S]*?:\s*Promise<\s*ApplyReplayRollbackResult\s*>/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/253/b1-issue-253-cited-in-source.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/253/b1-issue-253-cited-in-source.test.ts
@@ -1,0 +1,10 @@
+// Code comment cites issue #253 (the canonical pattern for surface fixes).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("replay.ts cites issue #253 in a comment", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/replay.ts"), "utf8");
+  assert.match(src, /#253/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/253/b1-no-throw-on-existing-remote.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/253/b1-no-throw-on-existing-remote.test.ts
@@ -1,0 +1,17 @@
+// `git remote add origin <url>` errors if origin already exists. The
+// restore function must either try-catch or use set-url to avoid throwing.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("restoreOriginRemote does not throw on already-existing origin", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/replay.ts"), "utf8");
+  const fnIdx = src.indexOf("function restoreOriginRemote");
+  assert.ok(fnIdx > 0);
+  const body = src.slice(fnIdx, fnIdx + 2000);
+  // Either try/catch or `set-url` (which is unconditional).
+  const hasTryCatch = /try\s*\{[\s\S]*?\}\s*catch/.test(body);
+  const hasSetUrl = /set-url|setUrl/.test(body);
+  assert.ok(hasTryCatch || hasSetUrl, "must guard against duplicate-add (try/catch or set-url)");
+});

--- a/research/curve-redo-bundle/curve-redo-tests/253/b1-rationale-comment-cites-shared-config.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/253/b1-rationale-comment-cites-shared-config.test.ts
@@ -1,0 +1,11 @@
+// The doc comment near the fix should explain WHY the strip needed a
+// counterpart restore — because .git/config is shared across worktrees.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("replay.ts cites the shared .git/config mutation as the bug's mechanism", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/replay.ts"), "utf8");
+  assert.match(src, /shared.*\.git\/config|\.git\/config.*shared|cross-cell|sibling cell|subsequent cell/i);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/253/b1-replay-module-exists.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/253/b1-replay-module-exists.test.ts
@@ -1,0 +1,12 @@
+// Issue #253 — applyReplayRollback strips origin from shared .git/config,
+// breaking subsequent cells. PR #262 fix: return originUrl from
+// applyReplayRollback + add restoreOriginRemote() helper.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("src/agent/replay.ts source exists post-fix", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/replay.ts"), "utf8");
+  assert.ok(src.length > 0);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/253/b1-restore-idempotent-set-url-fallback.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/253/b1-restore-idempotent-set-url-fallback.test.ts
@@ -1,0 +1,15 @@
+// restoreOriginRemote must be idempotent: if origin already exists (a
+// sibling cell re-added first), it falls through to `git remote set-url`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("restoreOriginRemote uses set-url fallback for idempotent re-add", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/replay.ts"), "utf8");
+  const fnIdx = src.indexOf("restoreOriginRemote");
+  assert.ok(fnIdx > 0);
+  // Search the function body region (next ~2KB) for the set-url fallback.
+  const body = src.slice(fnIdx, fnIdx + 2000);
+  assert.match(body, /set-url|setUrl/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/253/b1-restore-no-op-when-undefined.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/253/b1-restore-no-op-when-undefined.test.ts
@@ -1,0 +1,15 @@
+// When originUrl is undefined (the capture window closed empty),
+// restoreOriginRemote must no-op.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("restoreOriginRemote no-ops when originUrl is undefined", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/replay.ts"), "utf8");
+  const fnIdx = src.indexOf("function restoreOriginRemote");
+  assert.ok(fnIdx > 0, "restoreOriginRemote function not found");
+  const body = src.slice(fnIdx, fnIdx + 2000);
+  // Either an explicit return guard or an early conditional on originUrl.
+  assert.match(body, /if\s*\(\s*!?\s*[\w.]*originUrl\b|originUrl\s*===\s*undefined|\?\?|return\s*;/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/253/b1-restore-origin-remote-exported.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/253/b1-restore-origin-remote-exported.test.ts
@@ -1,0 +1,10 @@
+// PR #262 added restoreOriginRemote as a new exported function.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("replay.ts exports restoreOriginRemote", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/replay.ts"), "utf8");
+  assert.match(src, /export\s+(async\s+)?function\s+restoreOriginRemote/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/253/b1-restore-origin-remote-importable.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/253/b1-restore-origin-remote-importable.test.ts
@@ -1,0 +1,7 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+test("restoreOriginRemote is importable from replay.js", async () => {
+  const mod: any = await import("./replay.js");
+  assert.equal(typeof mod.restoreOriginRemote, "function");
+});

--- a/research/curve-redo-bundle/curve-redo-tests/253/b1-result-has-origin-url-field.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/253/b1-result-has-origin-url-field.test.ts
@@ -1,0 +1,13 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("ApplyReplayRollbackResult has originUrl field (optional string)", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/replay.ts"), "utf8");
+  // Inside the interface declaration, originUrl is declared.
+  const ifaceIdx = src.indexOf("ApplyReplayRollbackResult");
+  assert.ok(ifaceIdx >= 0);
+  const window = src.slice(ifaceIdx, ifaceIdx + 600);
+  assert.match(window, /originUrl\??\s*:\s*string/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/253/b1-result-interface-exists.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/253/b1-result-interface-exists.test.ts
@@ -1,0 +1,10 @@
+// The new result type must be declared/exported.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("ApplyReplayRollbackResult interface is declared in replay.ts", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/replay.ts"), "utf8");
+  assert.match(src, /interface\s+ApplyReplayRollbackResult/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/253/b1-rollback-captures-url-before-strip.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/253/b1-rollback-captures-url-before-strip.test.ts
@@ -1,0 +1,16 @@
+// The fix order must be: capture URL FIRST, then strip. If strip runs
+// before capture, the saved URL is empty.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("applyReplayRollback captures origin URL before stripping it", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/replay.ts"), "utf8");
+  const captureIdx = src.search(/remote.*get-url.*origin|originUrl\s*=/i);
+  const stripIdx = src.search(/remote.*remove.*origin|remote",\s*"remove",\s*"origin/i);
+  assert.ok(captureIdx > 0, "capture pattern missing");
+  assert.ok(stripIdx > 0, "strip pattern missing");
+  // capture comes before strip in source order
+  assert.ok(captureIdx < stripIdx, `capture at ${captureIdx} should precede strip at ${stripIdx}`);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/253/b2-test-asserts-origin-url-captured.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/253/b2-test-asserts-origin-url-captured.test.ts
@@ -1,0 +1,9 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("replay.test.ts asserts result.originUrl matches the pre-strip URL", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/replay.test.ts"), "utf8");
+  assert.match(src, /result\.originUrl|\.originUrl/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/253/b2-test-asserts-restore-after-strip.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/253/b2-test-asserts-restore-after-strip.test.ts
@@ -1,0 +1,12 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("replay.test.ts asserts origin is restored to the saved URL after restoreOriginRemote", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/replay.test.ts"), "utf8");
+  // The test reads remote get-url origin and checks the value equals the
+  // pre-strip URL.
+  assert.match(src, /restoreOriginRemote/);
+  assert.match(src, /remote.*get-url.*origin/i);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/253/b2-test-covers-sibling-strip-race.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/253/b2-test-covers-sibling-strip-race.test.ts
@@ -1,0 +1,11 @@
+// One test path covers the case where a sibling already stripped origin
+// (the originUrl=undefined branch).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("replay.test.ts covers originUrl=undefined when origin was absent", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/replay.test.ts"), "utf8");
+  assert.match(src, /originUrl[\s\S]*?undefined/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/253/b2-test-file-imports-restore.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/253/b2-test-file-imports-restore.test.ts
@@ -1,0 +1,9 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("replay.test.ts imports restoreOriginRemote", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/replay.test.ts"), "utf8");
+  assert.match(src, /restoreOriginRemote/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/253/b3-apply-replay-still-callable-with-positional-args.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/253/b3-apply-replay-still-callable-with-positional-args.test.ts
@@ -1,0 +1,9 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+test("applyReplayRollback retains its options-object signature", async () => {
+  const mod: any = await import("./replay.js");
+  assert.equal(typeof mod.applyReplayRollback, "function");
+  // It takes options object — function arity will be 1.
+  assert.equal(mod.applyReplayRollback.length, 1);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/253/b3-other-exports-preserved.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/253/b3-other-exports-preserved.test.ts
@@ -1,0 +1,10 @@
+// Other exports from the module (captureWorktreeDiff, readWorktreeHead)
+// must remain.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+test("replay.js still exports captureWorktreeDiff and readWorktreeHead", async () => {
+  const mod: any = await import("./replay.js");
+  assert.equal(typeof mod.captureWorktreeDiff, "function");
+  assert.equal(typeof mod.readWorktreeHead, "function");
+});

--- a/research/curve-redo-bundle/curve-redo-tests/253/b3-rollback-still-resets-to-base-sha.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/253/b3-rollback-still-resets-to-base-sha.test.ts
@@ -1,0 +1,11 @@
+// Regression: the reset --hard baseSha is the load-bearing behavior of
+// applyReplayRollback — the fix must not remove it.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("applyReplayRollback still resets --hard to baseSha", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/replay.ts"), "utf8");
+  assert.match(src, /reset.*--hard|"reset",\s*"--hard"/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/253/b3-rollback-still-strips-origin.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/253/b3-rollback-still-strips-origin.test.ts
@@ -1,0 +1,12 @@
+// Regression: applyReplayRollback must still strip origin so the agent
+// can't fetch from it during replay. The fix adds a return value but
+// doesn't remove the strip.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("applyReplayRollback retains the origin-strip behavior", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/agent/replay.ts"), "utf8");
+  assert.match(src, /remote.*remove.*origin|remote",\s*"remove",\s*"origin/i);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/626/b1-no-conditional-gate-on-ack.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/626/b1-no-conditional-gate-on-ack.test.ts
@@ -1,0 +1,18 @@
+// The ack must be set UNCONDITIONALLY (not gated on a flag the user
+// has to pass). Issue #626's framing originally proposed gating on
+// `acknowledgeNonAllowlistedSpender` (which the native→ERC-20 direction
+// never passes); the chosen fix stamps the flag from server-side
+// validation, so it lands on every code path that reaches buildCurveSwap.
+import { test, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("ack assignment is not wrapped in a user-flag conditional", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/modules/curve/actions.ts"), "utf8");
+  const ackIdx = src.indexOf("acknowledgedNonProtocolTarget");
+  expect(ackIdx).toBeGreaterThan(-1);
+  // The 200 chars before the ack should be inside an object literal
+  // (no `if (...)` block opening between).
+  const window = src.slice(Math.max(0, ackIdx - 200), ackIdx);
+  expect(window).not.toMatch(/if\s*\([^)]*acknowledge/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/626/b1-non-zero-loc-change.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/626/b1-non-zero-loc-change.test.ts
@@ -1,0 +1,11 @@
+// Smoke: the implementation file must have grown (at minimum +1 line for
+// the new field; #628 added +9 LOC including the explanatory comment).
+import { test, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("actions.ts non-trivially contains the new field assignment", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/modules/curve/actions.ts"), "utf8");
+  // Multiple occurrences (1 in code, optionally more in comments)
+  expect(src).toMatch(/acknowledgedNonProtocolTarget/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/626/b1-not-on-approve-leg.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/626/b1-not-on-approve-leg.test.ts
@@ -1,0 +1,14 @@
+// The ack added by #628 sits on the swap leg, NOT on the approve leg
+// (the approve leg's gate uses acknowledgedNonAllowlistedSpender, #618).
+// Verify the swap-target ack is distinct from spender-allowlist ack.
+import { test, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("acknowledgedNonProtocolTarget is distinct from acknowledgedNonAllowlistedSpender (spender ack)", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/modules/curve/actions.ts"), "utf8");
+  expect(src).toMatch(/acknowledgedNonProtocolTarget/);
+  // Both flags can coexist (approve leg + swap leg), but each is its own
+  // identifier — this test just asserts the new flag exists with the
+  // post-#628 spelling.
+});

--- a/research/curve-redo-bundle/curve-redo-tests/626/b1-rationale-comment-mentions-issue.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/626/b1-rationale-comment-mentions-issue.test.ts
@@ -1,0 +1,13 @@
+// Self-documenting fix — the code comment near the ack should reference
+// the issue / its mechanism (classifyDestination / non-protocol target).
+import { test, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("rationale comment near the ack references classifyDestination or non-protocol concept", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/modules/curve/actions.ts"), "utf8");
+  const ackIdx = src.indexOf("acknowledgedNonProtocolTarget");
+  expect(ackIdx).toBeGreaterThan(-1);
+  const window = src.slice(Math.max(0, ackIdx - 800), ackIdx);
+  expect(window).toMatch(/classifyDestination|non-protocol|allowlist|catch-all|unknown destination|destination gate/i);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/626/b1-rationale-explains-server-side-trust.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/626/b1-rationale-explains-server-side-trust.test.ts
@@ -1,0 +1,14 @@
+// The fix's trust source is server-side pool validation
+// (ensureSupportedCurvePool already restricted `pool` to curated entries).
+// The code comment should hint at this rather than just stamp the flag.
+import { test, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("comment near the ack references pool-validation trust source", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/modules/curve/actions.ts"), "utf8");
+  const ackIdx = src.indexOf("acknowledgedNonProtocolTarget");
+  expect(ackIdx).toBeGreaterThan(-1);
+  const window = src.slice(Math.max(0, ackIdx - 1200), ackIdx);
+  expect(window).toMatch(/ensureSupportedCurvePool|pool validation|server-side|curated/i);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/626/b1-source-has-actions-ts.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/626/b1-source-has-actions-ts.test.ts
@@ -1,0 +1,12 @@
+// Issue #626 — destination-allowlist ack on curve-swap leg. PR #628 added
+// `acknowledgedNonProtocolTarget: true` to the swap leg's UnsignedTx in
+// `src/modules/curve/actions.ts::buildCurveSwap` so `assertTransactionSafe`
+// doesn't catch-all-refuse the unrecognized Curve pool destination.
+import { test, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("curve actions module exists at src/modules/curve/actions.ts", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/modules/curve/actions.ts"), "utf8");
+  expect(src.length).toBeGreaterThan(0);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/626/b1-swap-leg-has-ack.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/626/b1-swap-leg-has-ack.test.ts
@@ -1,0 +1,11 @@
+// Issue #626 — Curve pools sit outside classifyDestination's recognized
+// set, so the swap leg needs `acknowledgedNonProtocolTarget` to bypass
+// `assertTransactionSafe`'s catch-all unknown-destination refusal.
+import { test, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("buildCurveSwap stamps acknowledgedNonProtocolTarget on the swap UnsignedTx", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/modules/curve/actions.ts"), "utf8");
+  expect(src).toMatch(/acknowledgedNonProtocolTarget\s*:\s*true/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/626/b1-swap-leg-in-build-curve-swap.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/626/b1-swap-leg-in-build-curve-swap.test.ts
@@ -1,0 +1,13 @@
+// The ack must be inside buildCurveSwap (not some unrelated helper).
+import { test, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("acknowledgedNonProtocolTarget appears within buildCurveSwap's scope", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/modules/curve/actions.ts"), "utf8");
+  const start = src.indexOf("buildCurveSwap");
+  expect(start).toBeGreaterThan(-1);
+  // window: from buildCurveSwap declaration to end of file
+  const window = src.slice(start);
+  expect(window).toMatch(/acknowledgedNonProtocolTarget/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/626/b1-swap-leg-stamped-not-just-approve.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/626/b1-swap-leg-stamped-not-just-approve.test.ts
@@ -1,0 +1,15 @@
+// The ack belongs on the swap tx (the leg with `to=pool`), not on an
+// approval tx. Verify the ack appears near the swap tx fields.
+import { test, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("ack flag is sited near the swap UnsignedTx fields (chain/to/value)", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/modules/curve/actions.ts"), "utf8");
+  const ackIdx = src.indexOf("acknowledgedNonProtocolTarget");
+  expect(ackIdx).toBeGreaterThan(-1);
+  // The ack should sit within the same object literal as `to: pool` /
+  // chain field. Look for `to` and `chain` within a 600-char window.
+  const window = src.slice(Math.max(0, ackIdx - 600), ackIdx + 300);
+  expect(window).toMatch(/\bto\s*:/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/626/b2-claude-md-references-issue-626.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/626/b2-claude-md-references-issue-626.test.ts
@@ -1,0 +1,9 @@
+// The CLAUDE.md rule's past-incident citation names issue #626.
+import { test, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("CLAUDE.md past-incident citation references issue #626", () => {
+  const src = readFileSync(resolve(process.cwd(), "CLAUDE.md"), "utf8");
+  expect(src).toMatch(/#626/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/626/b2-claude-md-rule-added.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/626/b2-claude-md-rule-added.test.ts
@@ -1,0 +1,10 @@
+// PR #628 also added a "Pre-Sign Gate Surface Sweeps" rule to CLAUDE.md
+// covering the lesson learned. Verify the rule landed in CLAUDE.md.
+import { test, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("CLAUDE.md gained the Pre-Sign Gate Surface Sweeps rule", () => {
+  const src = readFileSync(resolve(process.cwd(), "CLAUDE.md"), "utf8");
+  expect(src).toMatch(/Pre-Sign Gate Surface Sweeps/i);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/626/b2-curve-v1-asserts-stable-ng.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/626/b2-curve-v1-asserts-stable-ng.test.ts
@@ -1,0 +1,12 @@
+// stable_ng plain pools take the same code path; the test should assert
+// the ack on the stable_ng path too.
+import { test, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("curve-v1.test.ts covers stable_ng pool path with the new ack assertion", () => {
+  const src = readFileSync(resolve(process.cwd(), "test/curve-v1.test.ts"), "utf8");
+  const ackCount = (src.match(/acknowledgedNonProtocolTarget/g) || []).length;
+  // PR #628 added at least 3 separate assertions across legacy/stable_ng/multi-leg cases.
+  expect(ackCount).toBeGreaterThanOrEqual(2);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/626/b2-curve-v1-test-suite-asserts-flag.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/626/b2-curve-v1-test-suite-asserts-flag.test.ts
@@ -1,0 +1,11 @@
+// PR #628 added expect(...acknowledgedNonProtocolTarget).toBe(true)
+// assertions in test/curve-v1.test.ts. Verify the test file has the
+// updated assertions.
+import { test, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("test/curve-v1.test.ts asserts swap leg carries acknowledgedNonProtocolTarget", () => {
+  const src = readFileSync(resolve(process.cwd(), "test/curve-v1.test.ts"), "utf8");
+  expect(src).toMatch(/acknowledgedNonProtocolTarget/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/626/b2-test-asserts-eth-to-steth-direction.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/626/b2-test-asserts-eth-to-steth-direction.test.ts
@@ -1,0 +1,12 @@
+// Both directions (steth_to_eth and eth_to_steth) hit the same pool `to`
+// and need the ack. PR #628's test suite covers both.
+import { test, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("curve-v1 test suite covers eth↔steth (or both directions) with the ack", () => {
+  const src = readFileSync(resolve(process.cwd(), "test/curve-v1.test.ts"), "utf8");
+  // The ack assertion appears multiple times — across different test cases.
+  const ackCount = (src.match(/acknowledgedNonProtocolTarget/g) || []).length;
+  expect(ackCount).toBeGreaterThanOrEqual(2);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/626/b3-ack-value-is-true-not-false.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/626/b3-ack-value-is-true-not-false.test.ts
@@ -1,0 +1,12 @@
+// The ack must be `true` (not `false`); a `false` value would still fail
+// the gate.
+import { test, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("acknowledgedNonProtocolTarget value is set to true, not false", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/modules/curve/actions.ts"), "utf8");
+  expect(src).toMatch(/acknowledgedNonProtocolTarget\s*:\s*true/);
+  // Negative check: there should NOT be a `acknowledgedNonProtocolTarget: false` in actions.ts.
+  expect(src).not.toMatch(/acknowledgedNonProtocolTarget\s*:\s*false/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/626/b3-build-curve-swap-exported.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/626/b3-build-curve-swap-exported.test.ts
@@ -1,0 +1,8 @@
+// Regression: buildCurveSwap must remain exported (the rest of the code
+// imports it).
+import { test, expect } from "vitest";
+
+test("buildCurveSwap remains exported from src/modules/curve/actions.ts", async () => {
+  const mod: any = await import("../src/modules/curve/actions.js");
+  expect(typeof mod.buildCurveSwap).toBe("function");
+});

--- a/research/curve-redo-bundle/curve-redo-tests/626/b3-curve-test-suite-still-runs.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/626/b3-curve-test-suite-still-runs.test.ts
@@ -1,0 +1,10 @@
+// Regression: curve-v1.test.ts must still parse as valid TS / vitest.
+// Check for the describe/it structure rather than re-executing.
+import { test, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("curve-v1.test.ts retains describe block for buildCurveSwap", () => {
+  const src = readFileSync(resolve(process.cwd(), "test/curve-v1.test.ts"), "utf8");
+  expect(src).toMatch(/describe\s*\(\s*"buildCurveSwap/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/626/b3-no-orphan-imports.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/626/b3-no-orphan-imports.test.ts
@@ -1,0 +1,8 @@
+// Ensure the file remains a valid TS module — no obvious syntax breakage
+// from the small edit. Vitest will refuse to load it if syntax errors.
+import { test, expect } from "vitest";
+
+test("curve/actions module loads without import-time error", async () => {
+  const mod: any = await import("../src/modules/curve/actions.js");
+  expect(mod).toBeDefined();
+});

--- a/research/curve-redo-bundle/curve-redo-tests/626/b3-no-regression-existing-spender-ack.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/626/b3-no-regression-existing-spender-ack.test.ts
@@ -1,0 +1,10 @@
+// The fix must NOT remove the existing spender-allowlist ack (#618);
+// both flags coexist on different transaction legs.
+import { test, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("existing acknowledgedNonAllowlistedSpender on approve leg is preserved", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/modules/curve/actions.ts"), "utf8");
+  expect(src).toMatch(/acknowledgedNonAllowlistedSpender/);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/667/b1-import-readonly-token-source-references-preflight.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/667/b1-import-readonly-token-source-references-preflight.test.ts
@@ -1,0 +1,20 @@
+// Issue #667 — import_readonly_token bypasses preflight Step 0 binding.
+// Aspirational: the fix must add some form of preflight/Step 0 / sentinel
+// binding for import_readonly_token. Test looks for the link in any file
+// in src/ since the exact file location isn't pre-specified.
+import { test, expect } from "vitest";
+import { execSync } from "node:child_process";
+
+test("some src/ file links import_readonly_token to preflight Step 0 / sentinel binding", () => {
+  const out = execSync(
+    "grep -rIE 'import_readonly_token|importReadonlyToken' src/ || true",
+    { encoding: "utf8" },
+  );
+  // The fix should reference preflight or sentinel binding NEAR
+  // import_readonly_token in some source file.
+  const lines = out.split("\n");
+  const candidatesNearImport = lines.filter((l) =>
+    /import.readonly.token/i.test(l),
+  );
+  expect(candidatesNearImport.length).toBeGreaterThan(0);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/667/b1-issue-667-cited-in-source.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/667/b1-issue-667-cited-in-source.test.ts
@@ -1,0 +1,7 @@
+import { test, expect } from "vitest";
+import { execSync } from "node:child_process";
+
+test("issue #667 is cited somewhere in src/", () => {
+  const out = execSync(`grep -rlE '#667' src/ 2>/dev/null || true`, { encoding: "utf8" });
+  expect(out.trim().length).toBeGreaterThan(0);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/667/b1-rejects-recovery-framing.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/667/b1-rejects-recovery-framing.test.ts
@@ -1,0 +1,21 @@
+// Issue's suggested fix: "Reject installs whose name/description fields
+// claim 'recovery' framing without explicit user confirmation."
+import { test, expect } from "vitest";
+import { execSync } from "node:child_process";
+
+test("import_readonly_token source has recovery-framing guard or warning", () => {
+  const out = execSync(
+    `grep -rlE 'import.readonly.token|importReadonlyToken' src/ 2>/dev/null || true`,
+    { encoding: "utf8" },
+  );
+  const files = out.trim().split("\n").filter(Boolean);
+  let guardFound = false;
+  for (const f of files) {
+    const src = require("node:fs").readFileSync(f, "utf8");
+    if (/recovery|onboarding|wallet.import.*confirm|acknowledged.*recovery/i.test(src)) {
+      guardFound = true;
+      break;
+    }
+  }
+  expect(guardFound).toBe(true);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/667/b1-step0-or-sentinel-in-import-flow.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/667/b1-step0-or-sentinel-in-import-flow.test.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "vitest";
+import { execSync } from "node:child_process";
+
+test("import_readonly_token's source area mentions preflight, Step 0, or sentinel", () => {
+  // Look for files in src/ that mention BOTH import_readonly_token AND a
+  // preflight binding indicator.
+  const out = execSync(
+    `grep -rlE 'import.readonly.token|importReadonlyToken' src/ 2>/dev/null || true`,
+    { encoding: "utf8" },
+  );
+  const files = out.trim().split("\n").filter(Boolean);
+  let bindingFound = false;
+  for (const f of files) {
+    const src = require("node:fs").readFileSync(f, "utf8");
+    if (/preflight|Step 0|sentinel|step-0|Inv #4|Inv #7|presence.check|contact.decoration/i.test(src)) {
+      bindingFound = true;
+      break;
+    }
+  }
+  expect(bindingFound).toBe(true);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/667/b2-test-asserts-preflight-bypass-rejected.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/667/b2-test-asserts-preflight-bypass-rejected.test.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "vitest";
+import { execSync } from "node:child_process";
+
+test("test suite has an assertion that bypass-of-preflight is rejected", () => {
+  const out = execSync(
+    `grep -rlE 'import.readonly.token|importReadonlyToken' test/ 2>/dev/null || true`,
+    { encoding: "utf8" },
+  );
+  const files = out.trim().split("\n").filter(Boolean);
+  let rejectAssertion = false;
+  for (const f of files) {
+    const src = require("node:fs").readFileSync(f, "utf8");
+    if (/reject|refus|throw|expect.*toThrow|toBe.*false|step.0|preflight|sentinel/i.test(src)) {
+      rejectAssertion = true;
+      break;
+    }
+  }
+  expect(rejectAssertion).toBe(true);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/667/b2-test-coverage-for-import-binding.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/667/b2-test-coverage-for-import-binding.test.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "vitest";
+import { execSync } from "node:child_process";
+
+test("a test file under test/ exercises the import_readonly_token preflight binding", () => {
+  const out = execSync(
+    `grep -rlE 'import.readonly.token|importReadonlyToken' test/ src/ 2>/dev/null | grep -E 'test\\.ts$|spec\\.ts$|test/' || true`,
+    { encoding: "utf8" },
+  );
+  expect(out.trim().length).toBeGreaterThan(0);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/667/b3-no-regression-import-still-callable.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/667/b3-no-regression-import-still-callable.test.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "vitest";
+import { execSync } from "node:child_process";
+
+test("import_readonly_token tool symbol is still defined (no accidental delete)", () => {
+  const out = execSync(
+    `grep -rlE 'import.readonly.token|importReadonlyToken' src/ 2>/dev/null || true`,
+    { encoding: "utf8" },
+  );
+  expect(out.trim().length).toBeGreaterThan(0);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/667/b3-tool-still-handles-presence-check.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/667/b3-tool-still-handles-presence-check.test.ts
@@ -1,0 +1,25 @@
+// Inv #4 specifically — presence check on token metadata.
+import { test, expect } from "vitest";
+import { execSync } from "node:child_process";
+
+test("import_readonly_token area references presence-check or Inv #4 by name", () => {
+  const out = execSync(
+    `grep -rlE 'import.readonly.token|importReadonlyToken' src/ 2>/dev/null || true`,
+    { encoding: "utf8" },
+  );
+  const files = out.trim().split("\n").filter(Boolean);
+  let hasPresence = false;
+  for (const f of files) {
+    const src = require("node:fs").readFileSync(f, "utf8");
+    if (/presence.check|Inv\s*#?4|presence:|onChain.*present|presence:\s*true|presenceCheck/i.test(src)) {
+      hasPresence = true;
+      break;
+    }
+  }
+  // This is a soft signal — pass if found OR if alternative defense layer used.
+  expect(true).toBe(true);
+  // Annotate the result for run-tests visibility.
+  if (!hasPresence) {
+    console.log("[hint] presence-check / Inv #4 not yet wired through import_readonly_token");
+  }
+});

--- a/research/curve-redo-bundle/curve-redo-tests/669/b1-batch-cross-reference.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/669/b1-batch-cross-reference.test.ts
@@ -1,0 +1,15 @@
+// Issue notes: STRENGTHENED — same shape as batch-03 F-class chain-data
+// integrity gap. Source comment / docstring should reference this.
+import { test, expect } from "vitest";
+import { execSync } from "node:child_process";
+
+test("source references batch-03 or F-class chain-data finding (cross-batch link)", () => {
+  const out = execSync(
+    `grep -rIE 'batch-03|F-class|chain.data.integrity' src/ 2>/dev/null || true`,
+    { encoding: "utf8" },
+  );
+  if (out.trim().length === 0) {
+    console.log("[hint] batch-03 / F-class cross-reference not in source — may be in docs only");
+  }
+  expect(true).toBe(true);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/669/b1-chain-data-integrity-defense-exists.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/669/b1-chain-data-integrity-defense-exists.test.ts
@@ -1,0 +1,15 @@
+// Issue #669 — Rogue RPC chain-data integrity gap. Aspirational: the fix
+// adds SOME form of chain-data corroboration / sanity check / out-of-band
+// validation. Options listed in the issue: secondary RPC oracle, rate-of-
+// change sanity, OOB confirmation, known-scam-pattern matcher. Tests look
+// for indicators of any of these.
+import { test, expect } from "vitest";
+import { execSync } from "node:child_process";
+
+test("source has a chain-data integrity / RPC corroboration mechanism", () => {
+  const out = execSync(
+    `grep -rlE 'secondary.RPC|RPC.corroborat|cross-RPC|chain.data.integrity|scam.pattern|rogue.RPC|rate.of.change|OOB.*confirm|out.of.band' src/ 2>/dev/null || true`,
+    { encoding: "utf8" },
+  );
+  expect(out.trim().length).toBeGreaterThan(0);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/669/b1-issue-669-cited.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/669/b1-issue-669-cited.test.ts
@@ -1,0 +1,7 @@
+import { test, expect } from "vitest";
+import { execSync } from "node:child_process";
+
+test("issue #669 is cited somewhere in src/", () => {
+  const out = execSync(`grep -rlE '#669' src/ 2>/dev/null || true`, { encoding: "utf8" });
+  expect(out.trim().length).toBeGreaterThan(0);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/669/b1-scam-pattern-matcher-or-rate-sanity.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/669/b1-scam-pattern-matcher-or-rate-sanity.test.ts
@@ -1,0 +1,12 @@
+import { test, expect } from "vitest";
+import { execSync } from "node:child_process";
+
+test("source mentions scam-pattern matching or rate-of-change sanity", () => {
+  const out = execSync(
+    `grep -rIE 'scam.pattern|rate.of.change|sanity.check|presale.scam|risk.score.*spoof' src/ 2>/dev/null || true`,
+    { encoding: "utf8" },
+  );
+  // Soft pass: any indicator that one of the listed mechanisms exists.
+  // The mechanism doesn't have to be all four — any one is sufficient.
+  expect(out.trim().length).toBeGreaterThan(0);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/669/b1-second-llm-flag-on-chain-data.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/669/b1-second-llm-flag-on-chain-data.test.ts
@@ -1,0 +1,14 @@
+// Existing pattern: secondLlmRequired flag stamped on opaque calldata
+// (per s001 in the super-agent). The same pattern could apply for
+// chain-data fraud — stamp secondLlmRequired when chain-data has
+// rogue-RPC indicators.
+import { test, expect } from "vitest";
+import { execSync } from "node:child_process";
+
+test("chain-data flow stamps secondLlmRequired or similar verification flag", () => {
+  const out = execSync(
+    `grep -rIE 'secondLlmRequired|cross.RPC|verifyChain|chainDataIntegrity' src/ 2>/dev/null || true`,
+    { encoding: "utf8" },
+  );
+  expect(out.trim().length).toBeGreaterThan(0);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/669/b2-test-coverage-for-integrity.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/669/b2-test-coverage-for-integrity.test.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "vitest";
+import { execSync } from "node:child_process";
+
+test("a test file under test/ asserts the chain-data integrity behavior", () => {
+  const out = execSync(
+    `grep -rlE 'chain.data.integrity|secondary.RPC|RPC.corroborat|rogue.RPC|scam.pattern|rate.of.change' test/ 2>/dev/null || true`,
+    { encoding: "utf8" },
+  );
+  expect(out.trim().length).toBeGreaterThan(0);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/669/b3-affects-risk-or-history-tools.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/669/b3-affects-risk-or-history-tools.test.ts
@@ -1,0 +1,19 @@
+// Likely-affected tools: get_protocol_risk_score, get_transaction_history,
+// or similar surface that returns chain-derived data the user can act on.
+import { test, expect } from "vitest";
+import { execSync } from "node:child_process";
+
+test("risk-score / history / portfolio surface has integrity defense addition", () => {
+  const out = execSync(
+    `grep -rIE 'risk.score|transaction.history|portfolio' src/ 2>/dev/null | grep -IE 'rpc|corroborat|cross|sanity|secondary' || true`,
+    { encoding: "utf8" },
+  );
+  // Soft — pass if any indicator. The architectural decision is open per
+  // the issue body, so we accept multiple shapes of fix.
+  if (out.trim().length === 0) {
+    console.log("[hint] integrity defense may not yet be wired through risk/history tools");
+  }
+  // Always pass; this is informational. A stricter assertion would
+  // over-prescribe the solution.
+  expect(true).toBe(true);
+});

--- a/research/curve-redo-bundle/curve-redo-tests/669/b3-warning-blocks-or-elevates-not-just-soft.test.ts
+++ b/research/curve-redo-bundle/curve-redo-tests/669/b3-warning-blocks-or-elevates-not-just-soft.test.ts
@@ -1,0 +1,18 @@
+// Per the issue: intent-layer issued only a SOFT warning. The fix should
+// either escalate to a hard block or trigger second-LLM verification, not
+// remain advisory-only.
+import { test, expect } from "vitest";
+import { execSync } from "node:child_process";
+
+test("integrity defense escalates beyond soft-warning (hard block or 2LLM)", () => {
+  const out = execSync(
+    `grep -rIE 'secondLlmRequired|hardBlock|hard.block|refuse|reject.*scam' src/ 2>/dev/null || true`,
+    { encoding: "utf8" },
+  );
+  // Soft pass for now: open issue with multiple valid solution paths.
+  // The presence of ANY escalation mechanism is positive signal.
+  if (out.trim().length === 0) {
+    console.log("[hint] no obvious escalation mechanism found; fix may rely on advisory layer only");
+  }
+  expect(true).toBe(true);
+});


### PR DESCRIPTION
## Summary

[#292](https://github.com/szhygulin/vaultpilot-dev-framework/pull/292) added 6 new corpus entries but deferred hidden-test fixtures. Without tests, implement-class cells grade to 0 (qualityFromAB returns 0 for implements when test data is absent). This PR authors fixtures for the 5 implement-class entries — #173 is pushback and doesn't need tests.

## Test counts

| Issue | Repo | State | Class | Source | Tests |
|---:|---|---|---|---|---:|
| #626 | mcp | closed | implement | PR #628 diff | 19 |
| #253 | dev-framework | closed | implement | PR #262 diff | 20 |
| #251 | dev-framework | open | implement | aspirational | 10 |
| #667 | mcp | open | implement | aspirational | 8 |
| #669 | mcp | open | implement | aspirational | 8 |
| #173 | dev-framework | open | **pushback** | — | 0 (judge-A only) |
| | | | | **Total** | **65** |

The existing 13 issues carry ~100 tests each; the new entries are 8-20. Fewer but functional. Authoring tests for OPEN issues is inherently aspirational — over-prescribing the solution shape would penalize valid alternatives, so those tests use looser `grep`-based patterns and a few are soft-pass with hint-prints.

## Test strategies

**Closed-PR derivation (#626, #253)** — diff-based: I read each PR's actual diff and wrote `assert.match`/`expect().toMatch` checks on the post-fix source code patterns. Verifies the canonical fix landed in the canonical place. Mirrors the existing test style for closed entries.

**Open-issue aspirational (#251, #667, #669)** — spec-based: I read each issue body and wrote tests for the observable indicators of the suggested fix:
- #251: env-var override preserved, libc-probe mechanism used (glibcVersionRuntime or detect-libc), both artifact paths referenced
- #667: `import_readonly_token` linked to preflight/Step 0/sentinel binding somewhere in src/
- #669: chain-data integrity defense exists (secondary RPC / rate-of-change / OOB / scam-pattern matcher — any of the issue's 4 listed shapes counts)

A few #667/#669 tests soft-pass (always green) but emit `[hint]` log lines when the expected indicator is absent — they document the expectation without penalizing alternative valid solutions.

## Verification

- [x] 65 test files committed across 5 dirs.
- [x] mcp tests use vitest (matches existing #565/#574/#649/#665 convention).
- [x] dev-framework tests use node:test (matches existing #157/#168 convention).
- [x] Closed-entry tests verify patterns derived from actual merged PR diffs (#628, #262).
- [x] Open-entry tests don't over-prescribe — multiple valid solution shapes pass.

After this lands, the 19-issue corpus from [#292](https://github.com/szhygulin/vaultpilot-dev-framework/pull/292) is fully gradable on both judge-A and tests-B axes. Next experiment runs at n=19 can drop the "tests deferred" caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)